### PR TITLE
feature: support jsx

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -18,6 +18,7 @@ program
   .version(pkg.version, '-v, --version')
   .option('-w, --watch', 'watch src files changes')
   .option('-d, --dest <dir>', 'specify output dest file')
+  .option('--jsx <jsx>', 'jsx function for creating element')
   .action(run);
 
 program.parse(process.argv);
@@ -26,6 +27,7 @@ function run(entryFilePath) {
   const options = {
     dest: program.dest,
     watch: !!program.watch,
+    jsx: program.jsx,
   };
   if (typeof entryFilePath !== 'string') {
     return help();

--- a/package.json
+++ b/package.json
@@ -25,7 +25,5 @@
     "rollup-plugin-json": "^3.1.0",
     "rollup-plugin-node-resolve": "^4.0.0"
   },
-  "devDependencies": {
-    "@rollup/plugin-buble": "^0.20.0"
-  }
+  "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -24,5 +24,11 @@
     "rollup-plugin-commonjs": "^9.2.0",
     "rollup-plugin-json": "^3.1.0",
     "rollup-plugin-node-resolve": "^4.0.0"
+  },
+  "resolutions": {
+    "acorn": "^6.0.0"
+  },
+  "devDependencies": {
+    "@rollup/plugin-buble": "^0.20.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   "author": "huozhi (github.com/huozhi)",
   "license": "MIT",
   "dependencies": {
+    "@rollup/plugin-buble": "^0.20.0",
     "commander": "^2.19.0",
     "rollup": "~1.19.4",
-    "rollup-plugin-buble": "^0.19.6",
     "rollup-plugin-commonjs": "^9.2.0",
     "rollup-plugin-json": "^3.1.0",
     "rollup-plugin-node-resolve": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -19,14 +19,11 @@
   "license": "MIT",
   "dependencies": {
     "commander": "^2.19.0",
-    "rollup": "^1.2.2",
+    "rollup": "~1.19.4",
     "rollup-plugin-buble": "^0.19.6",
     "rollup-plugin-commonjs": "^9.2.0",
     "rollup-plugin-json": "^3.1.0",
     "rollup-plugin-node-resolve": "^4.0.0"
-  },
-  "resolutions": {
-    "acorn": "^6.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-buble": "^0.20.0"

--- a/src/bundle.js
+++ b/src/bundle.js
@@ -31,10 +31,8 @@ function bundle({input, outputs}) {
         return Promise.all(wirteJobs)
       },
       error => {
-        console.log(error.code)
-        if (error.snippet) {
-          console.error(error.snippet);
-        }
+        console.log(error)
+        console.error(error.snippet); // logging source code in format
       }
     );
 }

--- a/src/bundle.js
+++ b/src/bundle.js
@@ -31,7 +31,10 @@ function bundle({input, outputs}) {
         return Promise.all(wirteJobs)
       },
       error => {
-        console.error(error);
+        console.log(error.code)
+        if (error.snippet) {
+          console.error(error.snippet);
+        }
       }
     );
 }

--- a/src/rollup-config.js
+++ b/src/rollup-config.js
@@ -1,6 +1,6 @@
 const commonjs = require('rollup-plugin-commonjs');
 const json = require('rollup-plugin-json');
-const buble = require('rollup-plugin-buble');
+const buble = require('@rollup/plugin-buble');
 const nodeResolve = require('rollup-plugin-node-resolve');
 
 const mainFieldsConfig = [
@@ -13,7 +13,7 @@ function createInputConfig(entry, package, options) {
     package.peerDependencies,
     package.dependencies,
   ].filter(Boolean).map(Object.keys).reduce((a, b) => a.concat(b), []);
-
+  
   return {
     input: entry,
     external: externals,
@@ -27,7 +27,7 @@ function createInputConfig(entry, package, options) {
       json(),
       buble({
         exclude: 'node_modules/**',
-        jsx: options.jsx,
+        // jsx: options.jsx,
         objectAssign: 'Object.assign',
         transforms: {
           dangerousForOf: true,

--- a/src/rollup-config.js
+++ b/src/rollup-config.js
@@ -27,7 +27,7 @@ function createInputConfig(entry, package, options) {
       json(),
       buble({
         exclude: 'node_modules/**',
-        // jsx: options.jsx,
+        jsx: options.jsx,
         objectAssign: 'Object.assign',
         transforms: {
           dangerousForOf: true,

--- a/test/jsx/package.json
+++ b/test/jsx/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "react": "*"
+  }
+}

--- a/test/jsx/test.jsx
+++ b/test/jsx/test.jsx
@@ -1,5 +1,3 @@
-//import React from 'react'
-
 function Dumb() {
   return (
     <React.Fragment>
@@ -9,4 +7,3 @@ function Dumb() {
   )
 }
 
-//export default Dumb

--- a/test/jsx/test.jsx
+++ b/test/jsx/test.jsx
@@ -1,0 +1,12 @@
+//import React from 'react'
+
+function Dumb() {
+  return (
+    <React.Fragment>
+      <div>hello</div>
+      <h1>yep</h1>
+    </React.Fragment>
+  )
+}
+
+//export default Dumb


### PR DESCRIPTION
* support jsx option
* parsing jsx with buble
* downgrade rollup to 1.19 to fix acorn version conflicts

reference: https://github.com/acornjs/acorn-jsx/issues/103