### PR TITLE
enhance: rename shebang arg to bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Options:
   -w, --watch            watch src files changes
   -o, --output <file>    specify output filename
   -f, --format <format>  specify bundle type. esm, cjs, umd. default is esm
+  -b, --bin              output with shebang banner at top of file
   -h, --help             output usage information
 
 Usage:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,18 +14,18 @@ program
   .option("-w, --watch", "watch src files changes")
   .option("-o, --output <file>", "specify output filename")
   .option("-f, --format <format>", "specify output file format")
-  .option("--shebang", "output with shebang as banner")
+  .option("-b, --bin", "output with shebang as banner at top")
   .action(run);
 
 program.parse(process.argv);
 
 async function run(entryFilePath: string) {
-  const { format, output: file, shebang, watch } = program;
+  const { format, output: file, bin, watch } = program;
   const outputConfig: CliArgs = {
     file,
     format,
     watch: !!watch,
-    shebang: !!shebang,
+    shebang: !!bin,
   };
   if (typeof entryFilePath !== "string") {
     return help();

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -16,7 +16,7 @@ const testCases = [
   },
   {
     name: 'shebang',
-    args: [resolve('fixtures/shebang.js'), '--shebang', '-o', resolve('dist/shebang.bundle.js')],
+    args: [resolve('fixtures/shebang.js'), '-b', '-o', resolve('dist/shebang.bundle.js')],
     expected(distFile) {
       const shebang = `#!/usr/bin/env node`;
       return [


### PR DESCRIPTION
* `--shebang` to `-b, --bin` for shorter typing