### PR TITLE
feature: preserve shebang

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Options:
   -w, --watch            watch src files changes
   -o, --output <file>    specify output filename
   -f, --format <format>  specify bundle type. esm, cjs, umd. default is esm
-  -b, --bin              output with shebang banner at top of file
   -h, --help             output usage information
 
 Usage:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "jest",
     "clean": "rm -rf ./dist",
     "prerelease": "yarn clean && yarn build && chmod +x dist/cli.js",
-    "build:cli": "ts-node src/cli.ts src/cli.ts -f cjs -b -o dist/cli.js",
+    "build:cli": "ts-node src/cli.ts src/cli.ts -f cjs -o dist/cli.js",
     "build:main": "ts-node src/cli.ts src/index.ts -f cjs",
     "build": "yarn build:main && yarn build:cli"
   },
@@ -38,6 +38,7 @@
     "commander": "2.20.3",
     "rollup": "1.32.0",
     "rollup-plugin-commonjs": "10.1.0",
+    "rollup-plugin-preserve-shebang": "1.0.1",
     "tslib": "2.0.0",
     "typescript": "^3.9.6"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import fs from "fs";
 import path from "path";
 import program from "commander";
@@ -9,7 +11,6 @@ program
   .option("-w, --watch", "watch src files changes")
   .option("-o, --output <file>", "specify output filename")
   .option("-f, --format <format>", "specify output file format")
-  .option("-b, --bin", "output with shebang as banner at top")
   .action(run);
 
 program.parse(process.argv);

--- a/src/rollup-config.ts
+++ b/src/rollup-config.ts
@@ -91,7 +91,7 @@ function createOutputOptions(
   options: BundleOptions,
   npmPackage: PackageMetadata
 ): OutputOptions {
-  const {file, format, shebang, useTypescript} = options;
+  const {file, format, useTypescript} = options;
   
   let tsconfigOptions = {} as any;
   const ts = resolveTypescript();
@@ -119,7 +119,6 @@ function createOutputOptions(
     
   return {
     name: npmPackage.name,
-    banner: shebang ? "#!/usr/bin/env node" : undefined,
     file,
     format,
     esModule: !useEsModuleMark && format !== "umd",
@@ -149,7 +148,6 @@ function createRollupConfig(
         {
           file: filename, 
           format: config.format,
-          shebang: options.shebang,
           useTypescript,
         },
         npmPackage
@@ -163,7 +161,6 @@ function createRollupConfig(
         {
           file, 
           format, 
-          shebang: options.shebang,
           useTypescript,
         }, 
         npmPackage

--- a/src/rollup-config.ts
+++ b/src/rollup-config.ts
@@ -1,6 +1,8 @@
 import fs from "fs";
 import { resolve, extname } from "path";
 import commonjs from "rollup-plugin-commonjs";
+// @ts-ignore rollup-plugin-preserve-shebang is untyped module
+import shebang from "rollup-plugin-preserve-shebang"; 
 import json from "@rollup/plugin-json";
 import babel from "@rollup/plugin-babel";
 import nodeResolve from "@rollup/plugin-node-resolve";
@@ -60,6 +62,7 @@ function createInputConfig(
       include: /node_modules\//,
     }),
     json(),
+    shebang(),
     useTypescript && typescript({
       tsconfig: resolve(config.rootDir, "tsconfig.json"),
       typescript: require("typescript"),

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -14,17 +14,6 @@ const testCases = [
       ]
     }
   },
-  {
-    name: 'shebang',
-    args: [resolve('fixtures/shebang.js'), '-b', '-o', resolve('dist/shebang.bundle.js')],
-    expected(distFile) {
-      const shebang = `#!/usr/bin/env node`;
-      return [
-        [fs.existsSync(distFile), true],
-        [fs.readFileSync(distFile, {encoding: 'utf-8'}).slice(0, shebang.length), shebang],
-      ]
-    }
-  },
 ]
 
 for (const testCase of testCases) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,10 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "typeRoots": [
+      "./types",
+      "./node_modules/@types"
+    ],
     "forceConsistentCasingInFileNames": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3192,7 +3192,7 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-magic-string@^0.25.2:
+magic-string@^0.25.2, magic-string@^0.25.7:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
   integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
@@ -3816,6 +3816,13 @@ rollup-plugin-commonjs@10.1.0:
     magic-string "^0.25.2"
     resolve "^1.11.0"
     rollup-pluginutils "^2.8.1"
+
+rollup-plugin-preserve-shebang@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/rollup-plugin-preserve-shebang/-/rollup-plugin-preserve-shebang-1.0.1.tgz#17109cdb4ed12c3cac9379b802182427cdbee5a1"
+  integrity sha512-gk7ExGBqvUinhgrvldKHkAKXXwRkWMXMZymNkrtn50uBgHITlhRjhnKmbNGwAIc4Bzgl3yLv7/8Fhi/XeHhFKg==
+  dependencies:
+    magic-string "^0.25.7"
 
 rollup-pluginutils@^2.8.1:
   version "2.8.2"


### PR DESCRIPTION
Resolves #24 

* drop `-b` arg, user need to manually add shebang header
* use preseve-shebang plugin