### PR TITLE
types: support typing for shebang plugin

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -1,0 +1,1 @@
+declare module "rollup-plugin-preserve-shebang";

--- a/env.d.ts
+++ b/env.d.ts
@@ -1,1 +1,1 @@
-declare module "rollup-plugin-preserve-shebang";
+declare module "rollup-plugin-preserve-shebang"

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "clean": "rm -rf ./dist",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "yarn clean && yarn build && chmod +x dist/cli.js && yarn test",
-    "build:cli": "node -r ts-node/register src/cli.ts src/cli.ts --target node -f cjs -o dist/cli.js",
-    "build:main": "node -r ts-node/register src/cli.ts src/index.ts --target node -f cjs",
+    "build:cli": "ts-node --files src/cli.ts src/cli.ts --target node -f cjs -o dist/cli.js",
+    "build:main": "ts-node --files src/cli.ts src/index.ts --target node -f cjs",
     "build": "yarn build:main && yarn build:cli"
   },
   "type": "commonjs",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
       "optional": true
     }
   },
-  "optionalDependencies": {},
   "devDependencies": {
     "@types/node": "14.14.32",
     "jest": "26.6.1",

--- a/src/rollup-config.ts
+++ b/src/rollup-config.ts
@@ -1,7 +1,6 @@
 import fs, { existsSync } from "fs";
 import { resolve, extname, dirname, basename } from "path";
 import commonjs from "@rollup/plugin-commonjs";
-// @ts-expect-error
 import shebang from "rollup-plugin-preserve-shebang";
 import json from "@rollup/plugin-json";
 import babel from "@rollup/plugin-babel";

--- a/src/rollup-config.ts
+++ b/src/rollup-config.ts
@@ -84,7 +84,7 @@ function createInputConfig(
       declaration: !!typings,
       ...(!!typings && {
         declarationDir: dirname(resolve(cwd, typings)),
-      })
+      }),
     }),
     !useTypescript && babel({
       babelHelpers: "bundled",
@@ -123,14 +123,13 @@ function createOutputOptions(
   const {format, useTypescript} = options;
   const cwd: string = config.rootDir
   
-  let tsconfigOptions = {} as any;
+  let tsCompilerOptions = {} as any;
   if (useTypescript) {
     const ts = resolveTypescript();
     const tsconfigPath = resolve(cwd, "tsconfig.json");
     if (fs.existsSync(tsconfigPath)) {
-      const tsconfigJSON = ts.readConfigFile(tsconfigPath, ts.sys.readFile)
-        .config;
-      tsconfigOptions = ts.parseJsonConfigFileContent(
+      const tsconfigJSON = ts.readConfigFile(tsconfigPath, ts.sys.readFile).config;
+      tsCompilerOptions = ts.parseJsonConfigFileContent(
         tsconfigJSON,
         ts.sys,
         "./",
@@ -138,10 +137,9 @@ function createOutputOptions(
     }
   }
   
-  
   // respect if tsconfig.json has `esModuleInterop` config;
   // add esmodule mark if cjs and esmodule are both specified;
-  const useEsModuleMark = !!tsconfigOptions.esModuleInterop ||
+  const useEsModuleMark = !!tsCompilerOptions.esModuleInterop ||
     (
       pkg.hasOwnProperty("main") && 
       pkg.hasOwnProperty("module")

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "include": [
-    "env.d.ts",
+    "*.d.ts",
     "./src"
   ],
   "compilerOptions": {
@@ -9,7 +9,6 @@
     "target": "es5",
     "module": "CommonJS",
     "lib": ["ES6"],
-    "declaration": false,
     "removeComments": true,
     "strict": true,
     "noUnusedLocals": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "include": [
-    "./src",
+    "env.d.ts",
+    "./src"
   ],
   "compilerOptions": {
     "rootDir": ".",
@@ -17,9 +18,6 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "typeRoots": [
-      "./node_modules/@types"
-    ],
     "forceConsistentCasingInFileNames": true
   }
 }


### PR DESCRIPTION
* declare for untyped modules
* use `ts-node` instead of `node -t ts-node/register` to be able to search declarated types