### PR TITLE
feat: exports field

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -4,8 +4,9 @@ type PackageMetadata = {
   name?: string;
   main?: string;
   module?: string;
-  dependencies?: { [key: string]: string };
-  peerDependencies?: { [key: string]: string };
+  dependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  exports?: string | Record<string, string>
   types?: string,
   typings?: string,
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,31 +6,12 @@ import { PackageMetadata } from "./types";
 
 export function getPackageMeta(): PackageMetadata {
   const pkgFilePath = path.resolve(config.rootDir, "package.json");
-  let targetPackageJson;
+  let targetPackageJson = {};
   try {
     targetPackageJson = JSON.parse(fs.readFileSync(pkgFilePath, { encoding: "utf-8" }));
-  } catch (e) {
-    targetPackageJson = {}
-  }
-  const {
-    name,
-    main,
-    module,
-    dependencies,
-    peerDependencies,
-    types,
-    typings,
-  } = targetPackageJson;
+  } catch (_) {}
 
-  return {
-    name,
-    main,
-    module,
-    dependencies,
-    peerDependencies,
-    types,
-    typings,
-  };
+  return targetPackageJson;
 }
 
 export function resolvePackagePath(pathname: string): string {

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -23,6 +23,18 @@ const testCases = [
       const distFile = join(dir, './dist/index.js')
       expect(fs.existsSync(distFile)).toBe(true)
     }
+  },
+  {
+    name: 'pkg-exports',
+    args: ['index.js'],
+    expected(dir) {
+      const distFiles = [
+        join(dir, './dist/index.cjs'),
+        join(dir, './dist/index.mjs'),
+        join(dir, './dist/index.esm.js'),
+      ]
+      expect(distFiles.every(f => fs.existsSync(f))).toBe(true)
+    }
   }
 ]
 

--- a/test/integration/pkg-exports/index.js
+++ b/test/integration/pkg-exports/index.js
@@ -1,0 +1,1 @@
+export default 'exports-sugar'

--- a/test/integration/pkg-exports/package.json
+++ b/test/integration/pkg-exports/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "pkg-export",
+  "exports": {
+    "import": "./dist/index.mjs",
+    "require": "./dist/index.cjs",
+    "module": "./dist/index.esm.js"
+  }
+}

--- a/test/unit/ts-interop/tsconfig.json
+++ b/test/unit/ts-interop/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "compilerOptions": {
-    "esModuleInterop": false
+    "esModuleInterop": true
   }
 }


### PR DESCRIPTION
Support `exports` field in package.json

* string: `"exports:" "./dist/index.js"`
* object: `"exports": { "require": "./dist/index.cjs", "import": "./dist/index.mjs" }`