### PR TITLE
fix(deps): fix unmet peer dependency issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,10 @@
   "author": "huozhi (github.com/huozhi)",
   "license": "MIT",
   "dependencies": {
+    "@babel/core": "^7.0.0",
     "@rollup/plugin-babel": "5.2.1",
     "@rollup/plugin-commonjs": "21.1.0",
-    "@rollup/plugin-json": "4.0.2",
+    "@rollup/plugin-json": "4.1.0",
     "@rollup/plugin-node-resolve": "13.3.0",
     "@rollup/plugin-typescript": "8.2.3",
     "arg": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   "author": "huozhi (github.com/huozhi)",
   "license": "MIT",
   "dependencies": {
-    "@babel/core": "^7.0.0",
     "@rollup/plugin-babel": "5.2.1",
     "@rollup/plugin-commonjs": "21.1.0",
     "@rollup/plugin-json": "4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1415,12 +1415,12 @@
     magic-string "^0.25.7"
     resolve "^1.17.0"
 
-"@rollup/plugin-json@4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-json/-/plugin-json-4.0.2.tgz#482185ee36ac7dd21c346e2dbcc22ffed0c6f2d6"
-  integrity sha512-t4zJMc98BdH42mBuzjhQA7dKh0t4vMJlUka6Fz0c+iO5IVnWaEMiYBy1uBj9ruHZzXBW23IPDGL9oCzBkQ9Udg==
+"@rollup/plugin-json@4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-json/-/plugin-json-4.1.0.tgz#54e09867ae6963c593844d8bd7a9c718294496f3"
+  integrity sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==
   dependencies:
-    "@rollup/pluginutils" "^3.0.4"
+    "@rollup/pluginutils" "^3.0.8"
 
 "@rollup/plugin-node-resolve@13.3.0":
   version "13.3.0"
@@ -1442,7 +1442,7 @@
     "@rollup/pluginutils" "^3.1.0"
     resolve "^1.17.0"
 
-"@rollup/pluginutils@^3.0.4", "@rollup/pluginutils@^3.1.0":
+"@rollup/pluginutils@^3.0.8", "@rollup/pluginutils@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
   integrity sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==


### PR DESCRIPTION
I was running into this...

```
 ERR_PNPM_PEER_DEP_ISSUES  Unmet peer dependencies

.
└─┬ bunchee
  └─┬ @rollup/plugin-json
    └── ✕ unmet peer rollup@^1.20.0: found 2.74.1 in bunchee
```

...when installing dependencies and, upon inspection, saw that `@babel/core` was encountering similar issues.

This PR adds `@babel/core` and bumps `@rollup/plugin-json`.

I can see that you're working on integrating SWC, so the `@babel/core` addition is likely somewhat moot, but I changed both to ensure that everything's working in the meantime.

Thanks!