### PR TITLE
Fix: only apply terser for ts

### DIFF
--- a/src/rollup-config.ts
+++ b/src/rollup-config.ts
@@ -86,16 +86,6 @@ function createInputConfig(
         declarationDir: dirname(resolve(cwd, typings)),
       }),
     }),
-    minify && terser({
-      compress: {
-        "keep_infinity": true,
-      },
-      format: {
-        "comments": /^\s*([@#]__[A-Z]__\s*$|@[a-zA-Z]\s*$)/,
-        "wrap_func_args": false,
-        "preserve_annotations": true,
-      }
-    }),
     useTypescript && minify && terser({
       compress: {
         "keep_infinity": true,


### PR DESCRIPTION
js files will be minified by swc when it's enabled, so we don't apply the terser onto them but only for typescript for now.