### PR TITLE
Ensure sourcemap is generated by SWC minify

### DIFF
--- a/src/rollup-config.ts
+++ b/src/rollup-config.ts
@@ -104,7 +104,7 @@ function createInputConfig(
           classPrivateProperty: true,
           exportDefaultFrom: true,
         },
-        ...(minify && { minify: minifyOptions })
+        ...(minify && { minify: {...minifyOptions, sourceMap: options.sourcemap } })
       },
       sourceMaps: options.sourcemap,
       inlineSourcesContent: false,


### PR DESCRIPTION
When specifying the `minify` and `sourcemap` options simultaneously via the CLI, the following message appears in the terminal:

```sh
Sourcemap is likely to be incorrect: a plugin (swc) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help
Sourcemap is likely to be incorrect: a plugin (swc) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help
```

The Rollup documentation details [why this warning appears](https://rollupjs.org/guide/en/#warning-sourcemap-is-likely-to-be-incorrect):

> You'll see this warning if you generate a sourcemap with your bundle (sourcemap: true or sourcemap: 'inline') but you're using one or more plugins that transformed code without generating a sourcemap for the transformation.
> 
> Usually, a plugin will only omit the sourcemap if it (the plugin, not the bundle) was configured with sourcemap: false – so all you need to do is change that. If the plugin doesn't generate a sourcemap, consider raising an issue with the plugin author.

This PR removes this warning by ensuring `rollup-plugin-swc3` receives the correct minification options to also generate a sourcemap for the minify transform when a user passes in the `sourcemap` option to bunchee via the CLI.