### PR TITLE
enhance: ignore this undefined and circular dep warnings

### DIFF
--- a/src/rollup-config.ts
+++ b/src/rollup-config.ts
@@ -120,11 +120,15 @@ function createInputConfig(
     treeshake: {
       propertyReadSideEffects: false,
     },
-    onwarn (warning, warn) {
+    onwarn(warning, warn) {
+      const code = warning.code || '';
       if (
-        warning.code &&
-        ['MIXED_EXPORTS', 'PREFER_NAMED_EXPORTS'].includes(warning.code)
+        ['MIXED_EXPORTS', 'PREFER_NAMED_EXPORTS', 'THIS_IS_UNDEFINED'].includes(code)
       ) return;
+      // If the circular dependency warning is from node_modules, ignore it
+      if (code === 'CIRCULAR_DEPENDENCY' && /Circular dependency: node_modules/.test(warning.message)) {
+        return;
+      }
       warn(warning);
     },
   };

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -26,8 +26,20 @@ const testCases = [
     }
   },
   {
-    name: 'with-sourcemap',
-    args: [resolve('fixtures/hello.js'), '--sourcemap', '-o', resolve('dist/hello.nomap.js')],
+    name: 'with sourcemap',
+    args: [resolve('fixtures/hello.js'), '--sourcemap', '-o', resolve('dist/hello.js')],
+    expected(distFile) {
+      return [
+        [fs.existsSync(distFile), true],
+        //# sourceMappingURL is set
+        [fs.readFileSync(distFile, { encoding: 'utf-8' }).includes('sourceMappingURL'), true],
+        [fs.existsSync(distFile + '.map'), true],
+      ]
+    }
+  },
+  {
+    name: 'minified with sourcemap',
+    args: [resolve('fixtures/hello.js'), '-m', '--sourcemap', '-o', resolve('dist/hello.min.js')],
     expected(distFile) {
       return [
         [fs.existsSync(distFile), true],


### PR DESCRIPTION
Ignore the warnings are from bundled assets or from external dependencies

* Ignore `THIS_IS_UNDEFINED` warning: `The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten`, the structure of `THIS_IS_UNDEFINED` warning is not tracible to the original file. Or it can be pretty unrelated.

* Ignore `CIRCULAR_DEPENDENCY` warning if it's from 3rd party package in node_modules