### PR TITLE
Improve error logging

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -28,7 +28,7 @@ function help() {
 
 function exit(err: Error) {
   logger.error(err)
-  process.exit(2)
+  process.exit(1)
 }
 
 async function run(args: any) {

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -115,12 +115,12 @@ function onError(error: any) {
   if (!error) return
   // logging source code in format
   if (error.frame) {
-    process.stdout.write(error.frame + '\n')
+    process.stderr.write(error.frame + '\n')
   }
-  if (error.stack) {
-    process.stdout.write(error.stack + '\n')
-  }
-  throw error
+  // filter out the rollup plugin error information such as loc/frame/code...
+  const err = new Error(error.message)
+  err.stack = error.stack
+  throw err
 }
 
 export default bundle


### PR DESCRIPTION
Resolves #104

Filter out the rollup plugin object error, only log the formatted frame and throw the error to top-level with existing trace