### PR TITLE
BREAKING: Rename target to runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Options:
   -f, --format <format>  specify bundle type: "esm", "cjs", "umd". "esm" by default
   -e, --external <mod>   specify an external dependency
   -h, --help             output usage information
-  --target <target>      build environment, use "node" for nodejs runtime
+  --runtime <target>     target build environment, use "node" for nodejs runtime, default runtime is "browser"
   --sourcemap            enable sourcemap generation, sourcemap generation is disabled by default
   --cwd <cwd>            specify current working directory
 

--- a/cli.ts
+++ b/cli.ts
@@ -16,7 +16,7 @@ Options:
   -o, --output <file>    specify output filename
   -f, --format <format>  specify bundle type: "esm", "cjs", "umd". "esm" by default
   -e, --external <mod>   specify an external dependency
-  --target <target>      build environment, use "node" for nodejs runtime
+  --runtime              target build environment, use "node" for nodejs runtime, default runtime is "browser"
   --sourcemap            enable sourcemap generation, sourcemap generation is disabled by default
   --cwd <cwd>            specify current working directory
   -h, --help             output usage information
@@ -32,14 +32,14 @@ function exit(err: Error) {
 }
 
 async function run(args: any) {
-  const { source, format, watch, minify, sourcemap, target } = args
+  const { source, format, watch, minify, sourcemap, runtime } = args
   const cwd = args.cwd || process.cwd()
   const file = args.file ? path.resolve(cwd, args.file) : args.file
   const outputConfig: CliArgs = {
     file,
     format,
     cwd,
-    target,
+    runtime,
     external: args.external || [],
     watch: !!watch,
     minify: !!minify,

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "clean": "rm -rf ./dist",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "yarn clean && yarn build && chmod +x ./dist/cli.js && yarn test",
-    "build:cli": "tsx ./cli.ts ./cli.ts --target node -f cjs -o ./dist/cli.js",
-    "build:main": "tsx ./cli.ts ./lib.ts --target node -f cjs",
+    "build:cli": "tsx ./cli.ts ./cli.ts --runtime node -f cjs -o ./dist/cli.js",
+    "build:main": "tsx ./cli.ts ./lib.ts --runtime node -f cjs",
     "build": "yarn build:main && yarn build:cli"
   },
   "type": "commonjs",

--- a/src/rollup-config.ts
+++ b/src/rollup-config.ts
@@ -55,7 +55,7 @@ function createInputConfig(
     .reduce((a: string[], b: string[]) => a.concat(b), [] as string[])
     .concat((options.external ?? []).concat(pkg.name ? [pkg.name] : []))
 
-  const { useTypescript, target, minify = false, exportCondition } = options
+  const { useTypescript, runtime, minify = false, exportCondition } = options
   const typings: string | undefined = pkg.types || pkg.typings
   const cwd: string = config.rootDir
 
@@ -88,7 +88,7 @@ function createInputConfig(
 
   const plugins: Plugin[] = [
     nodeResolve({
-      preferBuiltins: target === 'node',
+      preferBuiltins: runtime === 'node',
       extensions: ['.mjs', '.js', '.json', '.node', '.jsx'],
     }),
     commonjs({

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ type CommonConfig = {
   minify?: boolean
   sourcemap?: boolean
   external?: string[]
-  target?: string
+  runtime?: string
 }
 
 type PackageMetadata = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,7 +29,7 @@ export function parseCliArgs(argv: string[]) {
       '--minify': Boolean,
       '--help': Boolean,
       '--version': Boolean,
-      '--target': String,
+      '--runtime': String,
       '--sourcemap': Boolean,
       '--external': [String],
 
@@ -57,7 +57,7 @@ export function parseCliArgs(argv: string[]) {
     cwd: args['--cwd'],
     help: args['--help'],
     version: args['--version'],
-    target: args['--target'],
+    runtime: args['--runtime'],
     external: args['--external'],
   }
   return parsedArgs


### PR DESCRIPTION
`target` will be used as the compilation target (such as es5 / es2020) in the future, and we rename it to `runtime`, but still represent the similar thing like "target environment" in webpack