### PR TITLE
Support ES features compile target

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,12 @@ Options:
   -w, --watch            watch src files changes
   -m, --minify           compress output. false by default
   -o, --output <file>    specify output filename
-  -f, --format <format>  specify bundle type: "esm", "cjs", "umd". default is "esm"
+  -f, --format <format>  specify bundle type: "esm", "cjs", "umd". "esm" by default
   -e, --external <mod>   specify an external dependency
   -h, --help             output usage information
-  --runtime <runtime>    build runtime: "nodejs", "browser". default is "browser"
-  --sourcemap            enable sourcemap generation, sourcemap generation is disabled by default
+  --target <target>      js features target: swc target es versions. "es5" by default
+  --runtime <runtime>    build runtime: "nodejs", "browser". "browser" by default
+  --sourcemap            enable sourcemap generation, false by default
   --cwd <cwd>            specify current working directory
 
 Usage:

--- a/cli.ts
+++ b/cli.ts
@@ -14,10 +14,11 @@ Options:
   -w, --watch            watch src files changes
   -m, --minify           compress output. false by default
   -o, --output <file>    specify output filename
-  -f, --format <format>  specify bundle type: "esm", "cjs", "umd". default is "esm"
+  -f, --format <format>  specify bundle type: "esm", "cjs", "umd". "esm" by default
   -e, --external <mod>   specify an external dependency
-  --runtime <runtime>    build runtime: "nodejs", "browser". default is "browser"
-  --sourcemap            enable sourcemap generation, sourcemap generation is disabled by default
+  --target <target>      js features target: swc target es versions. "es5" by default
+  --runtime <runtime>    build runtime: "nodejs", "browser". "browser" by default
+  --sourcemap            enable sourcemap generation, false by default
   --cwd <cwd>            specify current working directory
   -h, --help             output usage information
 `
@@ -32,13 +33,14 @@ function exit(err: Error) {
 }
 
 async function run(args: any) {
-  const { source, format, watch, minify, sourcemap, runtime } = args
+  const { source, format, watch, minify, sourcemap, target, runtime } = args
   const cwd = args.cwd || process.cwd()
   const file = args.file ? path.resolve(cwd, args.file) : args.file
   const outputConfig: CliArgs = {
     file,
     format,
     cwd,
+    target,
     runtime,
     external: args.external || [],
     watch: !!watch,

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -34,6 +34,8 @@ function getSourcePathFromExportPath(cwd: string, exportPath: string) {
 function bundle(entryPath: string, { cwd, ...options }: CliArgs = {}): Promise<any> {
   config.rootDir = resolve(process.cwd(), cwd || '')
   assignDefault(options, 'format', 'es')
+  assignDefault(options, 'minify', false)
+  assignDefault(options, 'target', 'es5')
 
   // alias for 'es' in rollup
   if (options.format === 'esm') {

--- a/src/rollup-config.ts
+++ b/src/rollup-config.ts
@@ -55,7 +55,7 @@ function createInputConfig(
     .reduce((a: string[], b: string[]) => a.concat(b), [] as string[])
     .concat((options.external ?? []).concat(pkg.name ? [pkg.name] : []))
 
-  const { useTypescript, runtime, minify = false, exportCondition } = options
+  const { useTypescript, runtime, target: jscTarget, minify, exportCondition } = options
   const typings: string | undefined = pkg.types || pkg.typings
   const cwd: string = config.rootDir
 
@@ -120,7 +120,7 @@ function createInputConfig(
       exclude: 'node_modules',
       tsconfig: 'tsconfig.json',
       jsc: {
-        target: 'es5',
+        target: jscTarget,
         loose: true, // Use loose mode
         externalHelpers: false,
         parser: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import type { JscTarget } from '@swc/core'
 import type { InputOptions, OutputOptions, RollupOptions } from 'rollup'
 
 type ExportType = 'require' | 'export' | 'default' | string // omit other names
@@ -9,6 +10,13 @@ type CommonConfig = {
   sourcemap?: boolean
   external?: string[]
   runtime?: string
+
+  // assigned extra config
+  exportCondition?: {
+    source: string // detected source file
+    name: string // export condition name
+    export: ExportCondition // export condition value
+  }
 }
 
 type PackageMetadata = {
@@ -35,11 +43,7 @@ type CliArgs = CommonConfig & {
   file?: string
   watch?: boolean
   cwd?: string
-  exportCondition?: {
-    source: string // detected source file
-    name: string // export condition name
-    export: ExportCondition // export condition value
-  }
+  target?: JscTarget
 }
 
 type BundleOptions = CliArgs & {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,6 +30,7 @@ export function parseCliArgs(argv: string[]) {
       '--help': Boolean,
       '--version': Boolean,
       '--runtime': String,
+      '--target': String,
       '--sourcemap': Boolean,
       '--external': [String],
 
@@ -58,6 +59,7 @@ export function parseCliArgs(argv: string[]) {
     help: args['--help'],
     version: args['--version'],
     runtime: args['--runtime'],
+    target: args['--target'],
     external: args['--external'],
   }
   return parsedArgs

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -64,7 +64,19 @@ const testCases = [
         ), false]
       ]
     }
-  }
+  },
+  {
+    name: 'es2020-target',
+    args: [resolve('fixtures/es2020.js'), '--target', 'es2020', '-o', resolve('dist/es2020.js')],
+    expected(distFile, { stdout, stderr }) {
+      const content = fs.readFileSync(distFile, { encoding: 'utf-8' })
+      return [
+        [content.includes(`...globalThis`), true],
+        [content.includes(`get?.apply?.bind`), true],
+        [content.includes(`async function`), true],
+      ]
+    }
+  },
 ]
 
 for (const testCase of testCases) {

--- a/test/fixtures/es2020.js
+++ b/test/fixtures/es2020.js
@@ -1,0 +1,3 @@
+export const spread = { ...globalThis }
+export const optionalChainFn = get?.apply?.bind
+export async function loadList() { return Promise.resolve([1, 2, 3]) }


### PR DESCRIPTION
Resolves #45 

With this change you can speicify `--target` with any swc supported es target (like `es5 | es3 | es2018 | es2020`) to speicify your js bundle compiled target