### PR TITLE
Respect jsx setting in tsconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "devDependencies": {
     "jest": "29.0.1",
+    "react": "18.2.0",
     "tsx": "3.4.3",
     "typescript": "4.8.2"
   },

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,6 +1,6 @@
-const fs = require('fs');
-const path = require('path');
-const { fork, execSync } = require('child_process');
+const fs = require('fs')
+const path = require('path')
+const { fork, execSync } = require('child_process')
 
 const resolve = filepath => path.resolve(__dirname, '../test', filepath)
 
@@ -81,7 +81,7 @@ const testCases = [
 ]
 
 for (const testCase of testCases) {
-  const {name, args, expected} = testCase;
+  const {name, args, expected} = testCase
   test(`cli ${name} should work properly`, async () => {
     // Delete dist folder (as last argument)
     const dist = args[args.length - 1]
@@ -90,21 +90,21 @@ for (const testCase of testCases) {
       __dirname + '/../dist/cli.js',
       args,
       {stdio: 'pipe'}
-    );
-    let stderr = '', stdout = '';
-    ps.stdout.on('data', chunk => stdout += chunk.toString());
-    ps.stderr.on('data', chunk => stderr += chunk.toString());
+    )
+    let stderr = '', stdout = ''
+    ps.stdout.on('data', chunk => stdout += chunk.toString())
+    ps.stderr.on('data', chunk => stderr += chunk.toString())
     const code = await new Promise((resolve) => {
-      ps.on('close', resolve);
-    });
-    stdout && console.log(stdout);
-    stderr && console.error(stderr);
-    const distFile = args[args.length - 1];
+      ps.on('close', resolve)
+    })
+    stdout && console.log(stdout)
+    stderr && console.error(stderr)
+    const distFile = args[args.length - 1]
     for (const conditions of expected(distFile, { stdout, stderr })) {
-      const [left, right] = conditions;
-      expect(left).toBe(right);
+      const [left, right] = conditions
+      expect(left).toBe(right)
     }
-    expect(fs.existsSync(distFile)).toBe(true);
-    expect(code).toBe(0);
-  });
+    expect(fs.existsSync(distFile)).toBe(true)
+    expect(code).toBe(0)
+  })
 }

--- a/test/unit/jsx-preserve/__snapshot__/jsx-preserve.js.snapshot
+++ b/test/unit/jsx-preserve/__snapshot__/jsx-preserve.js.snapshot
@@ -1,0 +1,5 @@
+function Jsx() {
+    return /*#__PURE__*/ React.createElement(React.Fragment, null, /*#__PURE__*/ React.createElement("div", null, "hello"), /*#__PURE__*/ React.createElement("h1", null, "yep"));
+}
+
+export { Jsx as default };

--- a/test/unit/jsx-preserve/__snapshot__/jsx-preserve.min.js.snapshot
+++ b/test/unit/jsx-preserve/__snapshot__/jsx-preserve.min.js.snapshot
@@ -1,0 +1,1 @@
+function e(){return React.createElement(React.Fragment,null,React.createElement("div",null,"hello"),React.createElement("h1",null,"yep"))}export{e as default}

--- a/test/unit/jsx-preserve/input.tsx
+++ b/test/unit/jsx-preserve/input.tsx
@@ -1,0 +1,10 @@
+function Jsx() {
+  return (
+    <>
+      <div>hello</div>
+      <h1>yep</h1>
+    </>
+  )
+}
+
+export default Jsx

--- a/test/unit/jsx-preserve/tsconfig.json
+++ b/test/unit/jsx-preserve/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve"
+  }
+}

--- a/test/unit/jsx-react-automatic/__snapshot__/jsx-react-automatic.js.snapshot
+++ b/test/unit/jsx-react-automatic/__snapshot__/jsx-react-automatic.js.snapshot
@@ -1,0 +1,16 @@
+import { jsxs, Fragment, jsx } from 'react/jsx-runtime';
+
+function Jsx() {
+    return jsxs(Fragment, {
+        children: [
+            jsx("div", {
+                children: "hello"
+            }),
+            jsx("h1", {
+                children: "yep"
+            })
+        ]
+    });
+}
+
+export { Jsx as default };

--- a/test/unit/jsx-react-automatic/__snapshot__/jsx-react-automatic.min.js.snapshot
+++ b/test/unit/jsx-react-automatic/__snapshot__/jsx-react-automatic.min.js.snapshot
@@ -1,0 +1,1 @@
+import{jsxs as r,Fragment as e,jsx as n}from"react/jsx-runtime";function i(){return r(e,{children:[n("div",{children:"hello"}),n("h1",{children:"yep"})]})}export{i as default}

--- a/test/unit/jsx-react-automatic/input.tsx
+++ b/test/unit/jsx-react-automatic/input.tsx
@@ -1,0 +1,10 @@
+function Jsx() {
+  return (
+    <>
+      <div>hello</div>
+      <h1>yep</h1>
+    </>
+  )
+}
+
+export default Jsx

--- a/test/unit/jsx-react-automatic/package.json
+++ b/test/unit/jsx-react-automatic/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "jsx-react-automatic",
+  "peerDependencies": {
+    "react": "*"
+  }
+}

--- a/test/unit/jsx-react-automatic/tsconfig.json
+++ b/test/unit/jsx-react-automatic/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2138,7 +2138,7 @@ joycon@^3.1.1:
   resolved "https://registry.yarnpkg.com/joycon/-/joycon-3.1.1.tgz#bce8596d6ae808f8b68168f5fc69280996894f03"
   integrity sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==
 
-js-tokens@^4.0.0:
+"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
@@ -2192,6 +2192,13 @@ locate-path@^5.0.0:
   integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
     p-locate "^4.1.0"
+
+loose-envify@^1.1.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
 
 lru-cache@^6.0.0:
   version "6.0.0"
@@ -2408,6 +2415,13 @@ react-is@^18.0.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
+react@18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
+  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
+  dependencies:
+    loose-envify "^1.1.0"
 
 require-directory@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
Resolves #117 

Reading tsconfig if there's one from the working directory, and passdown the `compilerOptions.jsx` option value to typescript plugin to align the compilation result with what tsconfig specified.

Notice that we're using swc to compile the typescript now, so `"jsx": "preserve"` won't preserve the original jsx syntax but will still compile to js code. Here's the [thread about that feature on swc side](https://github.com/swc-project/swc/pull/5661).