### PR TITLE
Check existence of tsconfig.json

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -3,7 +3,7 @@
 import type { CliArgs } from './src/types'
 
 import path from 'path'
-import { parseCliArgs, logger } from './src/utils'
+import { parseCliArgs, logger, exit } from './src/utils'
 import { version } from './package.json'
 
 const helpMessage = `
@@ -27,10 +27,6 @@ function help() {
   console.log(helpMessage)
 }
 
-function exit(err: Error) {
-  logger.error(err)
-  process.exit(1)
-}
 
 async function run(args: any) {
   const { source, format, watch, minify, sourcemap, target, runtime } = args

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,11 @@ import path from 'path'
 import config from './config'
 import type { PackageMetadata } from './types'
 
+export function exit(err: string | Error) {
+  logger.error(err)
+  process.exit(1)
+}
+
 export function getPackageMeta(): PackageMetadata {
   const pkgFilePath = path.resolve(config.rootDir, 'package.json')
   let targetPackageJson = {}
@@ -66,13 +71,13 @@ export function parseCliArgs(argv: string[]) {
 }
 
 export const logger = {
-  log(...args: any[]) {
-    console.log(...args)
+  log(arg: any) {
+    console.log(arg)
   },
-  warn(...args: any[]) {
-    console.log('\x1b[33m', ...args, '\x1b[0m')
+  warn(arg: any[]) {
+    console.log('\x1b[33m' + arg + '\x1b[0m')
   },
-  error(...args: any[]) {
-    console.error('\x1b[31m', ...args, '\x1b[0m')
+  error(arg: any) {
+    console.error('\x1b[31m' + arg + '\x1b[0m')
   },
 }


### PR DESCRIPTION
If you're using typescript but without specifying a tsconfig.json, it might cause build error especially when the directory output aren't clear.

So if you're using typescript, `tsconfig.json` is always required to be created in your top level directory