### PR TITLE
Fix type paths with cwd option

### DIFF
--- a/src/rollup-config.ts
+++ b/src/rollup-config.ts
@@ -168,7 +168,7 @@ function buildOutputConfigs(
     file ? name + '.d.ts' :
     exportCondition?.name
       ? resolve(dtsDir, (exportCondition.name === '.' ? 'index' : exportCondition.name) + '.d.ts')
-      : typings
+      : resolve(config.rootDir, typings)
 
   // If there's dts file, use `output.file`
   const dtsPathConfig = dtsFile ? { file: dtsFile } : { dir: dtsDir }

--- a/src/rollup-config.ts
+++ b/src/rollup-config.ts
@@ -168,7 +168,7 @@ function buildOutputConfigs(
     file ? name + '.d.ts' :
     exportCondition?.name
       ? resolve(dtsDir, (exportCondition.name === '.' ? 'index' : exportCondition.name) + '.d.ts')
-      : resolve(config.rootDir, typings)
+      : (typings && resolve(config.rootDir, typings))
 
   // If there's dts file, use `output.file`
   const dtsPathConfig = dtsFile ? { file: dtsFile } : { dir: dtsDir }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -10,6 +10,7 @@ const fixturesDir = resolveFromTest('fixtures')
 const testCases: {
   name: string
   args: string[]
+  dist?: string
   expected(f: string, { stderr, stdout }: { stderr: string; stdout: string }): [boolean, boolean][]
 }[] = [
   {
@@ -125,15 +126,29 @@ const testCases: {
       ]
     },
   },
+  {
+    name: 'workspace',
+    // --cwd without -o option
+    dist: path.join(fixturesDir, './package/dist'),
+    args: ['index.ts', '--cwd', path.join(fixturesDir, './package')],
+    expected(distFile) {
+      return [
+        [fs.existsSync(distFile), true],
+        // same name with input file
+        [fs.existsSync(distFile.replace('.mjs', '.d.ts')), true],
+      ]
+    }
+  },
 ]
 
 for (const testCase of testCases) {
-  const { name, args, expected } = testCase
+  const { name, args, expected, dist } = testCase
   test(`cli ${name} should work properly`, async () => {
-    // Delete dist folder (as last argument)
-    const dist = args[args.length - 1]
+    // Delete the of dist folder: folder of dist file (as last argument) or `dist` option
+    const distDir = dist || path.dirname(args[args.length - 1])
     // TODO: specify working directory for each test
-    execSync(`rm -rf ${path.dirname(dist)}`)
+    execSync(`rm -rf ${distDir}`)
+    console.log(`Command: rm -rf ${distDir}`)
     console.log(`Command: bunchee ${args.join(' ')}`)
     const ps = fork(`${__dirname + '/../node_modules/.bin/tsx'}`, [__dirname + '/../cli.ts'].concat(args), { stdio: 'pipe' })
     let stderr = ''

--- a/test/fixtures/package/index.ts
+++ b/test/fixtures/package/index.ts
@@ -1,0 +1,1 @@
+export default 'package'

--- a/test/fixtures/package/package.json
+++ b/test/fixtures/package/package.json
@@ -1,0 +1,4 @@
+{
+  "types": "./dist/index.d.ts",
+  "exports": "./dist/index.mjs"
+}

--- a/test/fixtures/package/tsconfig.json
+++ b/test/fixtures/package/tsconfig.json
@@ -1,0 +1,2 @@
+// for testing in fixtures
+{}


### PR DESCRIPTION
typing path should be absolute path that resolved with `cwd` option