### PR TITLE
Fix custom entry path is broken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 *.log
 .yalc
 yalc.lock
+test/**/*.js.map

--- a/cli.ts
+++ b/cli.ts
@@ -102,7 +102,7 @@ async function run(args: any) {
   }
 
   const entry = source ? path.resolve(cwd, source) : ''
-  const { bundle } = require('./lib') as typeof import('./lib')
+  const bundle: typeof import('./lib').bundle = require('./lib').bundle
 
   let timeStart = Date.now()
   let timeEnd

--- a/src/rollup-config.ts
+++ b/src/rollup-config.ts
@@ -39,7 +39,7 @@ const minifyOptions: JsMinifyOptions = {
 }
 
 let hasLoggedTsWarning = false
-function resolveTypescript(cwd: string) {
+function resolveTypescript(cwd: string): typeof import('typescript') {
   let ts
   const m = new Module('', undefined)
   m.paths = (Module as any)._nodeModulePaths(cwd)
@@ -65,7 +65,7 @@ function buildInputConfig(
   const externals = [pkg.peerDependencies, pkg.dependencies, pkg.peerDependenciesMeta]
     .filter(<T>(n?: T): n is T => Boolean(n))
     .map((o: { [key: string]: any }): string[] => Object.keys(o))
-    .reduce((a: string[], b: string[]) => a.concat(b), [] as string[])
+    .reduce((a: string[], b: string[]) => a.concat(b), [])
     .concat((options.external ?? []).concat(pkg.name ? [pkg.name] : []))
 
   const { useTypescript, runtime, target: jscTarget, minify } = options
@@ -204,7 +204,7 @@ function buildConfig(entry: string, pkg: PackageMetadata, cliArgs: CliArgs, dtsO
   let tsConfigPath: string | undefined
 
   if (useTypescript) {
-    const ts = resolveTypescript(config.rootDir) as typeof import('typescript')
+    const ts = resolveTypescript(config.rootDir)
     tsConfigPath = resolve(config.rootDir, 'tsconfig.json')
     if (fs.existsSync(tsConfigPath)) {
       const basePath = tsConfigPath ? dirname(tsConfigPath) : config.rootDir

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -139,6 +139,17 @@ const testCases: {
       ]
     }
   },
+  // single entry with custom entry path
+  {
+    name: 'single-entry',
+    dist: path.join(fixturesDir, './single-entry/dist'),
+    args: ['src/index.js', '--cwd', path.join(fixturesDir, './single-entry')],
+    expected(distFile) {
+      return [
+        [fs.existsSync(distFile), true],
+      ]
+    },
+  }
 ]
 
 for (const testCase of testCases) {

--- a/test/fixtures/single-entry/package.json
+++ b/test/fixtures/single-entry/package.json
@@ -1,0 +1,3 @@
+{
+  "exports": "./dist/index.js"
+}

--- a/test/fixtures/single-entry/src/index.js
+++ b/test/fixtures/single-entry/src/index.js
@@ -1,0 +1,3 @@
+const single = 'entry';
+
+export { single };

--- a/test/integration/single-entry/package.json
+++ b/test/integration/single-entry/package.json
@@ -1,8 +1,5 @@
 {
   "name": "single-entry",
   "types": "./dist/index.d.ts",
-  "exports": "./dist/index.js",
-  "bunchee": {
-    "entry": "./src/index.js"
-  }
+  "exports": "./dist/index.js"
 }


### PR DESCRIPTION
Fixes #171 

Use specified entry path as priority when single entry is detected, if there's no specified entry path, then use fallback logic to find the default entry

Also remove few unnecessary `as` casting in the codebase