### PR TITLE
require node 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        node-version: [14, 16, 18]
+        node-version: [16, 18]
 
     name: Node ${{ matrix.node-version }}
     steps:
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        
+
       - name: Use Node ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "dist",
     "*.md"
   ],
+  "engines": {
+    "node": ">= 16"
+  },
   "author": "huozhi (github.com/huozhi)",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Since node 16 is entering maintanance and node 14 will end maintainance soon, change the required version to 16. 
Also this is to prepare for integration of `publint`