### PR TITLE
Support inline env values

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Options:
   -h, --help             output usage information
   --target <target>      js features target: swc target es versions. default: es2015
   --runtime <runtime>    build runtime (nodejs, browser). default: browser
+  --env <env>            process env variables to be inlined. default: NODE_ENV
   --cwd <cwd>            specify current working directory
   --sourcemap            enable sourcemap generation, default: false
   --dts                  determine if need to generate types, default: false

--- a/cli.ts
+++ b/cli.ts
@@ -7,6 +7,8 @@ import arg from 'arg'
 import { logger, exit, formatDuration, getPackageMeta } from './src/utils'
 import { version } from './package.json'
 
+// TODO: add more usage for `bunchee` without options
+
 const helpMessage = `
 Usage: bunchee [options]
 
@@ -20,6 +22,7 @@ Options:
   -h, --help             output usage information
   --target <target>      js features target: swc target es versions. default: es2015
   --runtime <runtime>    build runtime (nodejs, browser). default: browser
+  --env <env>            process env variables to be inlined. default: NODE_ENV
   --cwd <cwd>            specify current working directory
   --sourcemap            enable sourcemap generation, default: false
   --dts                  determine if need to generate types, default: false
@@ -59,7 +62,9 @@ function parseCliArgs(argv: string[]) {
       '--runtime': String,
       '--target': String,
       '--sourcemap': Boolean,
+      // TODO: change --external to String, separate by comma
       '--external': [String],
+      '--env': String,
 
       '-h': '--help',
       '-v': '--version',
@@ -75,7 +80,7 @@ function parseCliArgs(argv: string[]) {
     }
   )
   const source: string = args._[0]
-  const parsedArgs = {
+  const parsedArgs: CliArgs = {
     source,
     format: args['--format'],
     file: args['--output'],
@@ -89,12 +94,13 @@ function parseCliArgs(argv: string[]) {
     runtime: args['--runtime'],
     target: args['--target'],
     external: args['--external'],
+    env: args['--env'],
   }
   return parsedArgs
 }
 
-async function run(args: any) {
-  const { source, format, watch, minify, sourcemap, target, runtime, dts } = args
+async function run(args: CliArgs) {
+  const { source, format, watch, minify, sourcemap, target, runtime, dts, env } = args
   const cwd = args.cwd || process.cwd()
   const file = args.file ? path.resolve(cwd, args.file) : undefined
   const cliArgs: CliArgs = {
@@ -108,6 +114,7 @@ async function run(args: any) {
     watch: !!watch,
     minify: !!minify,
     sourcemap: sourcemap === false ? false : true,
+    env,
   }
   if (args.version) {
     return logger.log(version)

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@rollup/plugin-commonjs": "24.0.1",
     "@rollup/plugin-json": "6.0.0",
     "@rollup/plugin-node-resolve": "15.0.1",
+    "@rollup/plugin-replace": "5.0.2",
     "@swc/core": "1.3.35",
     "arg": "5.0.2",
     "publint": "0.1.11",

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ import type { InputOptions, OutputOptions, RollupOptions } from 'rollup'
 type ExportType = 'require' | 'export' | 'default' | string // omit other names
 
 // Shared config for each build entry
-type CommonConfig = {
+type BundleConfig = {
   dts?: boolean
   format?: OutputOptions['format']
   minify?: boolean
@@ -42,11 +42,15 @@ type BuncheeRollupConfig = Partial<Omit<RollupOptions, 'input' | 'output'>> & {
   dtsOnly: boolean
 }
 
-type CliArgs = CommonConfig & {
+type CliArgs = BundleConfig & {
+  source? : string
   file?: string
   watch?: boolean
   cwd?: string
   target?: JscTarget
+  help?: boolean
+  version?: boolean
+  env?: string
 }
 
 type BundleOptions = CliArgs & {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -37,6 +37,7 @@ const testCases: {
   },
   {
     name: 'format',
+    dist: createTempDir,
     args: [
       resolveFromTest('fixtures/hello.js'),
       '--cwd',
@@ -55,7 +56,8 @@ const testCases: {
   },
   {
     name: 'compress',
-    args: [resolveFromTest('fixtures/hello.js'), '-m', '-o', resolveFromTest('dist/hello.bundle.min.js')],
+    dist: createTempDir,
+    args: [resolveFromTest('fixtures/hello.js'), '-m', '-o', 'dist/hello.bundle.min.js'],
     expected(distFile) {
       return [
         [fs.existsSync(distFile), true],
@@ -92,6 +94,7 @@ const testCases: {
   },
   {
     name: 'externals',
+    dist: createTempDir,
     args: [
       resolveFromTest('fixtures/with-externals.js'),
       '-e',
@@ -120,7 +123,8 @@ const testCases: {
   },
   {
     name: 'es2020-target',
-    args: [resolveFromTest('fixtures/es2020.ts'), '--cwd', fixturesDir, '--target', 'es2020', '-o', resolveFromTest('dist/es2020.js')],
+    dist: createTempDir,
+    args: [resolveFromTest('fixtures/es2020.ts'), '--cwd', fixturesDir, '--target', 'es2020', '-o', 'dist/es2020.js'],
     expected(distFile, { stdout, stderr }) {
       const content = fs.readFileSync(distFile, { encoding: 'utf-8' })
       return [
@@ -133,6 +137,7 @@ const testCases: {
   },
   {
     name: 'dts',
+    dist: createTempDir,
     // need working directory for tsconfig.json
     args: ['./base.ts', '--dts', '--cwd', fixturesDir, '-o', './dist/base.js'],
     expected(distFile) {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,21 +1,36 @@
 jest.setTimeout(10 * 60 * 1000)
 
-import fs from 'fs'
+import fs, { promises as fsp } from 'fs'
 import path from 'path'
+import os from 'os'
 import { fork, execSync } from 'child_process'
 
 const resolveFromTest = (filepath: string) => path.resolve(__dirname, '../test', filepath)
 const fixturesDir = resolveFromTest('fixtures')
 
+async function removeDirectory(tempDirPath: string) {
+  await fsp.rm(tempDirPath, { recursive: true, force: true })
+}
+
+async function createTempDir(): Promise<string> {
+  const tempDir = os.tmpdir()
+  const tempDirPrefix = 'bunchee-test'
+  const tempDirPath = path.join(tempDir, tempDirPrefix)
+
+  return await fsp.mkdtemp(tempDirPath)
+}
+
 const testCases: {
   name: string
   args: string[]
-  dist?: string
+  env?: Record<string, string>
+  dist?: (() => Promise<string>) | string
   expected(f: string, { stderr, stdout }: { stderr: string; stdout: string }): [boolean, boolean][]
 }[] = [
   {
     name: 'basic',
-    args: [resolveFromTest('fixtures/hello.js'), '-o', resolveFromTest('dist/hello.bundle.js')],
+    dist: createTempDir,
+    args: [resolveFromTest('fixtures/hello.js'), '-o', 'dist/hello.bundle.js'],
     expected(distFile) {
       return [[fs.existsSync(distFile), true]]
     },
@@ -29,7 +44,7 @@ const testCases: {
       '-f',
       'cjs',
       '-o',
-      resolveFromTest('dist/hello.cjs'),
+      'dist/hello.cjs',
     ],
     expected(distFile) {
       return [
@@ -51,7 +66,8 @@ const testCases: {
   },
   {
     name: 'with sourcemap',
-    args: [resolveFromTest('fixtures/hello.js'), '--sourcemap', '-o', resolveFromTest('dist/hello.js')],
+    dist: createTempDir,
+    args: [resolveFromTest('fixtures/hello.js'), '--sourcemap', '-o', 'dist/hello.js'],
     expected(distFile) {
       return [
         [fs.existsSync(distFile), true],
@@ -63,7 +79,8 @@ const testCases: {
   },
   {
     name: 'minified with sourcemap',
-    args: [resolveFromTest('fixtures/hello.js'), '-m', '--sourcemap', '-o', resolveFromTest('dist/hello.min.js')],
+    dist: createTempDir,
+    args: [resolveFromTest('fixtures/hello.js'), '-m', '--sourcemap', '-o', 'dist/hello.min.js'],
     expected(distFile) {
       return [
         [fs.existsSync(distFile), true],
@@ -80,7 +97,7 @@ const testCases: {
       '-e',
       'foo',
       '-o',
-      resolveFromTest('dist/with-externals.bundle.js'),
+      'dist/with-externals.bundle.js',
     ],
     expected(distFile, { stdout, stderr }) {
       const output = stdout + stderr
@@ -117,7 +134,7 @@ const testCases: {
   {
     name: 'dts',
     // need working directory for tsconfig.json
-    args: ['./base.ts', '--dts', '--cwd', fixturesDir, '-o', path.resolve(fixturesDir, './dist/base.js')],
+    args: ['./base.ts', '--dts', '--cwd', fixturesDir, '-o', './dist/base.js'],
     expected(distFile) {
       return [
         [fs.existsSync(distFile), true],
@@ -149,34 +166,74 @@ const testCases: {
         [fs.existsSync(distFile), true],
       ]
     },
+  },
+  {
+    name: 'env-var',
+    dist: createTempDir,
+    args: [path.join(fixturesDir, './env-var-consumer/index.js'), '--env', 'MY_TEST_ENV'],
+    env: {
+      'MY_TEST_ENV': 'my-test-value'
+    },
+    expected(distFile) {
+      const content = fs.readFileSync(distFile, { encoding: 'utf-8' })
+      console.log('content', content)
+      return [
+        [content.includes('my-test-value'), true],
+      ]
+    },
   }
 ]
 
-for (const testCase of testCases) {
-  const { name, args, expected, dist } = testCase
-  test(`cli ${name} should work properly`, async () => {
-    // Delete the of dist folder: folder of dist file (as last argument) or `dist` option
-    const distDir = dist || path.dirname(args[args.length - 1])
-    // TODO: specify working directory for each test
-    execSync(`rm -rf ${distDir}`)
-    console.log(`Command: rm -rf ${distDir}`)
-    console.log(`Command: bunchee ${args.join(' ')}`)
-    const ps = fork(`${__dirname + '/../node_modules/.bin/tsx'}`, [__dirname + '/../cli.ts'].concat(args), { stdio: 'pipe' })
-    let stderr = ''
-    let stdout = ''
-    ps.stdout?.on('data', (chunk) => (stdout += chunk.toString()))
-    ps.stderr?.on('data', (chunk) => (stderr += chunk.toString()))
-    const code = await new Promise((resolve) => {
-      ps.on('close', resolve)
+describe('cli', () => {
+  for (const testCase of testCases) {
+    const { name, args, expected, dist, env } = testCase
+    it(`cli ${name} should work properly`, async () => {
+      // Delete the of dist folder: folder of dist file (as last argument) or `dist` option
+      let distDir
+      let distFile
+      if (typeof dist === 'function') {
+        distDir = await dist()
+        distFile = path.join(distDir, 'index.js')
+        args.push('-o', distFile)
+      } else if (typeof dist === 'string') {
+        distDir = dist
+        distFile = args[args.length - 1]
+      } else {
+        distDir = path.dirname(args[args.length - 1])
+        distFile = args[args.length - 1]
+      }
+
+      // TODO: specify working directory for each test
+      execSync(`rm -rf ${distDir}`)
+      console.log(`Command: rm -rf ${distDir}`)
+      console.log(`Command: bunchee ${args.join(' ')}`)
+      const ps = fork(
+        `${__dirname + '/../node_modules/.bin/tsx'}`,
+        [__dirname + '/../cli.ts'].concat(args),
+        {
+          stdio: 'pipe',
+          env,
+        }
+      )
+      let stderr = ''
+      let stdout = ''
+      ps.stdout?.on('data', (chunk) => (stdout += chunk.toString()))
+      ps.stderr?.on('data', (chunk) => (stderr += chunk.toString()))
+      const code = await new Promise((resolve) => {
+        ps.on('close', resolve)
+      })
+      if (stdout) console.log(stdout)
+      if (stderr) console.error(stderr)
+
+      for (const conditions of expected(distFile, { stdout, stderr })) {
+        const [left, right] = conditions
+        expect(left).toBe(right)
+      }
+      expect(fs.existsSync(distFile)).toBe(true)
+      expect(code).toBe(0)
+      console.log(`Clean up ${distDir}`)
+      await removeDirectory(distDir)
     })
-    stdout && console.log(stdout)
-    stderr && console.error(stderr)
-    const distFile = args[args.length - 1]
-    for (const conditions of expected(distFile, { stdout, stderr })) {
-      const [left, right] = conditions
-      expect(left).toBe(right)
-    }
-    expect(fs.existsSync(distFile)).toBe(true)
-    expect(code).toBe(0)
-  })
-}
+  }
+})
+

--- a/test/fixtures/env-var-consumer/index.js
+++ b/test/fixtures/env-var-consumer/index.js
@@ -1,0 +1,1 @@
+export const myTestEnv = process.env.MY_TEST_ENV

--- a/test/fixtures/modules/foo.js
+++ b/test/fixtures/modules/foo.js
@@ -1,1 +1,0 @@
-export default 'foo'

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    "baseUrl": "..",
     "paths": {
       "bunchee": ["./lib.ts"]
     },

--- a/test/typing.test.ts
+++ b/test/typing.test.ts
@@ -1,5 +1,5 @@
 // Import from generated files instead of using tsconfig alias
-import { bundle, type CliArgs } from '../dist/lib'
+import { bundle, type CliArgs } from 'bunchee'
 
 describe('types', () => {
   it('should be able to import the node API and use correct typings', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "include": [
     "./src",
-    "*.d.ts",
-    "./*.ts"
+    "./*.ts",
+    "./*.d.ts"
   ],
   "compilerOptions": {
     "rootDir": ".",
@@ -13,7 +13,7 @@
     "moduleResolution": "node",
     "removeComments": true,
     "strict": true,
-    "noUnusedLocals": true,
+    // "noUnusedLocals": true,
     "noImplicitReturns": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -753,6 +753,14 @@
     is-module "^1.0.0"
     resolve "^1.22.1"
 
+"@rollup/plugin-replace@5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-replace/-/plugin-replace-5.0.2.tgz#45f53501b16311feded2485e98419acb8448c61d"
+  integrity sha512-M9YXNekv/C/iHHK+cvORzfRYfPbq0RDD8r0G+bMiTXjNGKulPnCT9O3Ss46WfhI6ZOCgApOP7xAdmCQJ+U2LAA==
+  dependencies:
+    "@rollup/pluginutils" "^5.0.1"
+    magic-string "^0.27.0"
+
 "@rollup/pluginutils@^4.2.1":
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-4.2.1.tgz#e6c6c3aba0744edce3fb2074922d3776c0af2a6d"


### PR DESCRIPTION
Support a new way to leverage `process.env` into your bundle

```
bunchee --env NODE_ENV,RUNTIME,DOMAIN
```

Resolves #167 