### PR TITLE
Detect ts project by tsconfig and emit types if presented

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
     "dist",
     "*.md"
   ],
+  "prettier": {
+    "semi": false,
+    "singleQuote": true
+  },
   "engines": {
     "node": ">= 16"
   },

--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -263,7 +263,7 @@ function buildConfig(
   tsOptions: TypescriptOptions
 ): BuncheeRollupConfig {
   const { file } = bundleConfig
-  const useTypescript = isTypescriptFile(entry)
+  const useTypescript = Boolean(tsOptions.tsConfigPath) // isTypescriptFile(entry)
   const options = { ...bundleConfig, useTypescript }
   const inputOptions = buildInputConfig(entry, pkg, options, tsOptions)
   const outputExports = options.exportCondition

--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -228,7 +228,7 @@ function buildOutputConfigs(
 // build configs for each entry from package exports
 export async function buildEntryConfig(
   pkg: PackageMetadata,
-  options: BundleConfig,
+  bundleConfig: BundleConfig,
   cwd: string,
   tsOptions: TypescriptOptions
 ): Promise<BuncheeRollupConfig[]> {
@@ -241,14 +241,14 @@ export async function buildEntryConfig(
     if (!source) return undefined
     if (tsOptions.dtsOnly && !tsOptions?.tsConfigPath) return
 
-    options.exportCondition = {
+    bundleConfig.exportCondition = {
       source,
       name: entryExport,
       export: packageExports[entryExport],
     }
 
     const entry = resolveSourceFile(cwd!, source)
-    const rollupConfig = buildConfig(entry, pkg, options, cwd, tsOptions)
+    const rollupConfig = buildConfig(entry, pkg, bundleConfig, cwd, tsOptions)
     return rollupConfig
   })
 
@@ -258,13 +258,13 @@ export async function buildEntryConfig(
 function buildConfig(
   entry: string,
   pkg: PackageMetadata,
-  _options: BundleConfig,
+  bundleConfig: BundleConfig,
   cwd: string,
   tsOptions: TypescriptOptions
 ): BuncheeRollupConfig {
-  const { file } = _options
+  const { file } = bundleConfig
   const useTypescript = isTypescriptFile(entry)
-  const options = { ..._options, useTypescript }
+  const options = { ...bundleConfig, useTypescript }
   const inputOptions = buildInputConfig(entry, pkg, options, tsOptions)
   const outputExports = options.exportCondition
     ? getExportConditionDist(pkg, options.exportCondition.export, cwd)
@@ -278,7 +278,7 @@ function buildConfig(
       buildOutputConfigs(
         pkg,
         {
-          ..._options,
+          ...bundleConfig,
           format: 'es',
           useTypescript,
         },
@@ -292,7 +292,7 @@ function buildConfig(
       return buildOutputConfigs(
         pkg,
         {
-          ..._options,
+          ...bundleConfig,
           file: exportDist.file,
           format: exportDist.format,
           useTypescript,
@@ -308,9 +308,9 @@ function buildConfig(
         buildOutputConfigs(
           pkg,
           {
-            ..._options,
+            ...bundleConfig,
             file,
-            format: _options.format || fallbackFormat,
+            format: bundleConfig.format || fallbackFormat,
             useTypescript,
           },
           cwd,

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -1,111 +1,111 @@
-import type { RollupWatcher, RollupWatchOptions, OutputOptions, RollupBuild, RollupOutput } from 'rollup'
-import type { BuncheeRollupConfig, BundleConfig, ExportCondition, PackageMetadata } from './types'
+import type {
+  RollupWatcher,
+  RollupWatchOptions,
+  OutputOptions,
+  RollupBuild,
+  RollupOutput,
+} from 'rollup'
+import type {
+  BuncheeRollupConfig,
+  BundleConfig,
+  PackageMetadata,
+} from './types'
 
 import fs from 'fs/promises'
-import { resolve, join, basename, relative } from 'path'
+import { resolve, relative } from 'path'
 import { watch as rollupWatch, rollup } from 'rollup'
-import buildConfig from './rollup-config'
-import { getPackageMeta, isTypescript, logger, formatDuration, fileExists } from './utils'
-import config from './config'
+import buildConfig, { buildEntryConfig } from './build-config'
+import {
+  getPackageMeta,
+  logger,
+  formatDuration,
+  fileExists,
+  getSourcePathFromExportPath,
+  getExportPath,
+} from './utils'
 import { getTypings } from './exports'
 import type { BuildMetadata } from './types'
-
-const SRC = 'src' // resolve from src/ directory
+import { TypescriptOptions, resolveTsConfig } from './typescript'
 
 function logBuild(exportPath: string, dtsOnly: boolean, duration: number) {
-  logger.log(` ✓  ${dtsOnly ? 'Typed' : 'Built'} ${exportPath} ${formatDuration(duration)}`)
+  logger.log(
+    ` ✓  ${dtsOnly ? 'Typed' : 'Built'} ${exportPath} ${formatDuration(
+      duration
+    )}`
+  )
 }
 
-function assignDefault(options: BundleConfig, name: keyof BundleConfig, defaultValue: any) {
+function assignDefault(
+  options: BundleConfig,
+  name: keyof BundleConfig,
+  defaultValue: any
+) {
   if (!(name in options) || options[name] == null) {
     options[name] = defaultValue
   }
 }
 
-function resolveSourceFile(cwd: string, filename: string) {
-  return resolve(cwd, SRC, filename)
-}
-
-// Map '.' -> './index.[ext]'
-// Map './lite' -> './lite.[ext]'
-// Return undefined if no match or if it's package.json exports
-async function getSourcePathFromExportPath(cwd: string, exportPath: string): Promise<string | undefined> {
-  const exts = ['js', 'cjs', 'mjs', 'jsx', 'ts', 'tsx']
-  for (const ext of exts) {
-    // ignore package.json
-    if (exportPath.endsWith('package.json')) return
-    if (exportPath === '.') exportPath = './index'
-    const filename = resolveSourceFile(cwd, `${exportPath}.${ext}`)
-
-    if (await fileExists(filename)) {
-      return filename
-    }
-  }
-  return
-}
-
 function hasMultiEntryExport(pkg: PackageMetadata): boolean {
   const packageExportsField = pkg.exports || {}
-  if (typeof packageExportsField === 'string')  return false
+  if (typeof packageExportsField === 'string') return false
 
-  const exportKeys = (packageExportsField ? Object.keys(packageExportsField) : [])
-    .filter(key => key !== './package.json')
+  const exportKeys = (
+    packageExportsField ? Object.keys(packageExportsField) : []
+  ).filter((key) => key !== './package.json')
 
-  return exportKeys.length > 0 && exportKeys.every(name => name.startsWith('.'))
+  return (
+    exportKeys.length > 0 && exportKeys.every((name) => name.startsWith('.'))
+  )
 }
 
-async function bundle(entryPath: string, { cwd, ...options }: BundleConfig = {}): Promise<any> {
-  config.rootDir = resolve(process.cwd(), cwd || '')
+async function bundle(
+  entryPath: string,
+  { cwd: _cwd, ...options }: BundleConfig = {}
+): Promise<any> {
+  const cwd = resolve(process.cwd(), _cwd || '')
   assignDefault(options, 'format', 'es')
   assignDefault(options, 'minify', false)
   assignDefault(options, 'target', 'es2015')
 
-  const pkg = await getPackageMeta(config.rootDir)
+  const pkg = await getPackageMeta(cwd)
   const packageExportsField = pkg.exports || {}
   const isMultiEntries = hasMultiEntryExport(pkg)
+  const tsConfig = await resolveTsConfig(cwd)
+  const hasTsConfig = Boolean(tsConfig?.tsConfigPath)
+  const defaultTsOptions: TypescriptOptions = {
+    tsConfigPath: tsConfig?.tsConfigPath,
+    tsCompilerOptions: tsConfig?.tsCompilerOptions || {},
+    dtsOnly: false,
+  }
+
+  // const useTypescript = isTypescriptFile(entryPath)
+  // if (useTypescript && !hasTsConfig) {
+  //   return exit(`tsconfig.json is missing in project directory ${cwd}`)
+  // }
 
   // Handle single entry file
   if (!isMultiEntries) {
     // Use specified string file path if possible, then fallback to the default behavior entry picking logic
     // e.g. "exports": "./dist/index.js" -> use "./index.<ext>" as entry
-    entryPath = entryPath || await getSourcePathFromExportPath(config.rootDir, '.') || ''
-  }
-
-  async function buildEntryConfig(
-    packageExports: Record<string, ExportCondition>,
-    dtsOnly: boolean
-  ): Promise<BuncheeRollupConfig[]> {
-    const configs = Object.keys(packageExports).map(async (entryExport) => {
-      const source = await getSourcePathFromExportPath(config.rootDir, entryExport)
-      if (!source) return undefined
-      if (dtsOnly && !isTypescript(source)) return
-
-      options.exportCondition = {
-        source,
-        name: entryExport,
-        export: packageExports[entryExport]
-      }
-
-      const entry = resolveSourceFile(cwd!, source)
-      const rollupConfig = buildConfig(entry, pkg, options, dtsOnly)
-      return rollupConfig
-    })
-
-    return (await Promise.all(configs)).filter(<T>(n?: T): n is T => Boolean(n))
+    entryPath =
+      entryPath ||
+      (await getSourcePathFromExportPath(cwd, '.')) ||
+      ''
   }
 
   const bundleOrWatch = (
     rollupConfig: BuncheeRollupConfig
   ): Promise<RollupWatcher | RollupOutput[] | void> => {
     const { input, exportName } = rollupConfig
-    const exportPath = getExportPath(pkg, exportName)
+    const exportPath = getExportPath(pkg, cwd, exportName)
     // Log original entry file relative path
-    const source = typeof input.input === 'string'
-      ? relative(config.rootDir, input.input)
-      : exportPath
+    const source =
+      typeof input.input === 'string'
+        ? relative(cwd, input.input)
+        : exportPath
 
     const buildMetadata: BuildMetadata = {
-      source
+      source,
     }
     if (options.watch) {
       return Promise.resolve(runWatch(rollupConfig, buildMetadata))
@@ -125,8 +125,11 @@ async function bundle(entryPath: string, { cwd, ...options }: BundleConfig = {})
 
   // has `types` field in package.json or has `types` exports in any export condition for multi-entries
   const hasTypings =
-    !!getTypings(pkg)
-    || typeof packageExportsField === 'object' && Array.from(Object.values(packageExportsField || {})).some(condition => condition.hasOwnProperty('types'))
+    !!getTypings(pkg) ||
+    (typeof packageExportsField === 'object' &&
+      Array.from(Object.values(packageExportsField || {})).some((condition) =>
+        condition.hasOwnProperty('types')
+      ))
 
   // Enable types generation if it's types field specified in package.json
   if (hasTypings) {
@@ -134,34 +137,49 @@ async function bundle(entryPath: string, { cwd, ...options }: BundleConfig = {})
   }
 
   if (isMultiEntries) {
-    const pkgExports = packageExportsField as Record<string, ExportCondition>
-    const buildConfigs = await buildEntryConfig(pkgExports, false)
-    const assetsJobs = buildConfigs.map((rollupConfig) => bundleOrWatch(rollupConfig))
-
+    const buildConfigs = await buildEntryConfig(
+      pkg,
+      options,
+      cwd,
+      {
+        ...defaultTsOptions,
+        dtsOnly: false,
+      }
+    )
+    const assetsJobs = buildConfigs.map((rollupConfig) =>
+      bundleOrWatch(rollupConfig)
+    )
 
     const typesJobs = options.dts
-      ? (await buildEntryConfig(pkgExports, true)).map((rollupConfig) => bundleOrWatch(rollupConfig))
+      ? (
+          await buildEntryConfig(pkg, options, cwd, {
+            ...defaultTsOptions,
+            dtsOnly: true,
+          })
+        ).map((rollupConfig) => bundleOrWatch(rollupConfig))
       : []
 
     return await Promise.all(assetsJobs.concat(typesJobs))
   }
 
   // Generate types
-  if (isTypescript(entryPath) && options.dts) {
-    await bundleOrWatch(buildConfig(entryPath, pkg, options, true))
+  if (hasTsConfig && options.dts) {
+    await bundleOrWatch(
+      buildConfig(entryPath, pkg, options, cwd, {
+        ...defaultTsOptions,
+        dtsOnly: true,
+      })
+    )
   }
 
-  const rollupConfig = buildConfig(entryPath, pkg, options, false)
+  const rollupConfig = buildConfig(entryPath, pkg, options, cwd, {
+    ...defaultTsOptions,
+    dtsOnly: false,
+  })
   return bundleOrWatch(rollupConfig)
 }
 
-// . -> pkg name
-// ./lite -> <pkg name>/lite
-function getExportPath(pkg: PackageMetadata, exportName?: string) {
-  const name = pkg.name || basename(config.rootDir)
-  if (exportName === '.' || !exportName) return name
-  return join(name, exportName)
-}
+
 
 function runWatch(
   { input, output, dtsOnly }: BuncheeRollupConfig,
@@ -194,7 +212,8 @@ function runWatch(
         logBuild(metadata.source, dtsOnly, duration)
         break
       }
-      default: return
+      default:
+        return
     }
   })
   return watcher
@@ -207,13 +226,12 @@ function runBundle(
   const startTime = Date.now()
 
   return rollup(input)
-    .then(
-      (bundle: RollupBuild) => {
-        const writeJobs = output.map((options: OutputOptions) => bundle.write(options))
-        return Promise.all(writeJobs)
-      },
-      onError
-    )
+    .then((bundle: RollupBuild) => {
+      const writeJobs = output.map((options: OutputOptions) =>
+        bundle.write(options)
+      )
+      return Promise.all(writeJobs)
+    }, onError)
     .then(() => {
       const duration = Date.now() - startTime
       logBuild(jobOptions.source, dtsOnly, duration)

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -78,11 +78,6 @@ async function bundle(
     dtsOnly: false,
   }
 
-  // const useTypescript = isTypescriptFile(entryPath)
-  // if (useTypescript && !hasTsConfig) {
-  //   return exit(`tsconfig.json is missing in project directory ${cwd}`)
-  // }
-
   // Handle single entry file
   if (!isMultiEntries) {
     // Use specified string file path if possible, then fallback to the default behavior entry picking logic

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -75,7 +75,6 @@ async function bundle(
   const defaultTsOptions: TypescriptOptions = {
     tsConfigPath: tsConfig?.tsConfigPath,
     tsCompilerOptions: tsConfig?.tsCompilerOptions || {},
-    dtsOnly: false,
   }
 
   // Handle single entry file
@@ -136,10 +135,8 @@ async function bundle(
       pkg,
       options,
       cwd,
-      {
-        ...defaultTsOptions,
-        dtsOnly: false,
-      }
+      defaultTsOptions,
+      false,
     )
     const assetsJobs = buildConfigs.map((rollupConfig) =>
       bundleOrWatch(rollupConfig)
@@ -147,10 +144,7 @@ async function bundle(
 
     const typesJobs = options.dts
       ? (
-          await buildEntryConfig(pkg, options, cwd, {
-            ...defaultTsOptions,
-            dtsOnly: true,
-          })
+          await buildEntryConfig(pkg, options, cwd, defaultTsOptions, true)
         ).map((rollupConfig) => bundleOrWatch(rollupConfig))
       : []
 
@@ -160,17 +154,11 @@ async function bundle(
   // Generate types
   if (hasTsConfig && options.dts) {
     await bundleOrWatch(
-      buildConfig(entryPath, pkg, options, cwd, {
-        ...defaultTsOptions,
-        dtsOnly: true,
-      })
+      buildConfig(entryPath, pkg, options, cwd, defaultTsOptions, true)
     )
   }
 
-  const rollupConfig = buildConfig(entryPath, pkg, options, cwd, {
-    ...defaultTsOptions,
-    dtsOnly: false,
-  })
+  const rollupConfig = buildConfig(entryPath, pkg, options, cwd, defaultTsOptions, false)
   return bundleOrWatch(rollupConfig)
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@ import type { CliArgs, BundleConfig } from './types'
 
 import path from 'path'
 import arg from 'arg'
-import { logger, exit, formatDuration, getPackageMeta } from './utils'
+import { logger, exit, formatDuration, getPackageMeta, hasPackageJson } from './utils'
 import { version } from '../package.json'
 
 const helpMessage = `
@@ -32,6 +32,11 @@ function help() {
 }
 
 async function lintPackage(cwd: string) {
+  // Not package.json detected, skip package linting
+  if (!(await hasPackageJson(cwd))) {
+    return
+  }
+
   const { publint } = await import('publint')
   const { printMessage } = await import('publint/utils')
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,0 @@
-const rootDir = process.cwd()
-
-export default {
-  rootDir,
-}

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -82,16 +82,14 @@ export function getExportDist(pkg: PackageMetadata, cwd: string) {
 }
 
 export function getExportConditionDist(pkg: PackageMetadata, exportCondition: ExportCondition, cwd: string) {
-  // const pkgExports = pkg.exports || {}
   const dist: { format: 'cjs' | 'esm'; file: string }[] = []
   // "exports": "..."
   if (typeof exportCondition === 'string') {
     dist.push({ format: pkg.type === 'module' ? 'esm' : 'cjs', file: getDistPath(exportCondition, cwd) })
   } else {
     // "./<subexport>": { }
-    const subExports = exportCondition // pkgExports[subExport]
+    const subExports = exportCondition
     // Ignore json exports, like "./package.json"
-    // if (subExport.endsWith('.json')) return dist
     if (typeof subExports === 'string') {
       dist.push({ format: 'esm', file: getDistPath(subExports, cwd) })
     } else {

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -1,13 +1,12 @@
 import type { PackageMetadata, ExportCondition, ExportType } from './types'
 import { resolve } from 'path'
-import config from './config'
 
 export function getTypings(pkg: PackageMetadata) {
   return pkg.types || pkg.typings
 }
 
-function getDistPath(distPath: string) {
-  return resolve(config.rootDir, distPath)
+function getDistPath(distPath: string, cwd: string) {
+  return resolve(cwd, distPath)
 }
 
 function findExport(field: any): string | undefined {
@@ -62,45 +61,45 @@ export function getExportPaths(pkg: PackageMetadata) {
   return pathsMap
 }
 
-export function getExportDist(pkg: PackageMetadata) {
+export function getExportDist(pkg: PackageMetadata, cwd: string) {
   const paths = getExportPaths(pkg)['.']
   const dist: { format: 'cjs' | 'esm'; file: string }[] = []
   if (paths.main) {
-    dist.push({ format: 'cjs', file: getDistPath(paths.main) })
+    dist.push({ format: 'cjs', file: getDistPath(paths.main, cwd) })
   }
   if (paths.module) {
-    dist.push({ format: 'esm', file: getDistPath(paths.module) })
+    dist.push({ format: 'esm', file: getDistPath(paths.module, cwd) })
   }
   if (paths.export) {
-    dist.push({ format: 'esm', file: getDistPath(paths.export) })
+    dist.push({ format: 'esm', file: getDistPath(paths.export, cwd) })
   }
 
   // default fallback to output `dist/index.js` in default esm format
   if (dist.length === 0) {
-    dist.push({ format: 'esm', file: getDistPath('dist/index.js') })
+    dist.push({ format: 'esm', file: getDistPath('dist/index.js', cwd) })
   }
   return dist
 }
 
-export function getExportConditionDist(pkg: PackageMetadata, exportCondition: ExportCondition) {
+export function getExportConditionDist(pkg: PackageMetadata, exportCondition: ExportCondition, cwd: string) {
   // const pkgExports = pkg.exports || {}
   const dist: { format: 'cjs' | 'esm'; file: string }[] = []
   // "exports": "..."
   if (typeof exportCondition === 'string') {
-    dist.push({ format: pkg.type === 'module' ? 'esm' : 'cjs', file: getDistPath(exportCondition) })
+    dist.push({ format: pkg.type === 'module' ? 'esm' : 'cjs', file: getDistPath(exportCondition, cwd) })
   } else {
     // "./<subexport>": { }
     const subExports = exportCondition // pkgExports[subExport]
     // Ignore json exports, like "./package.json"
     // if (subExport.endsWith('.json')) return dist
     if (typeof subExports === 'string') {
-      dist.push({ format: 'esm', file: getDistPath(subExports) })
+      dist.push({ format: 'esm', file: getDistPath(subExports, cwd) })
     } else {
       if (subExports.require) {
-        dist.push({ format: 'cjs', file: getDistPath(subExports.require) })
+        dist.push({ format: 'cjs', file: getDistPath(subExports.require, cwd) })
       }
       if (subExports.import) {
-        dist.push({ format: 'esm', file: getDistPath(subExports.import) })
+        dist.push({ format: 'esm', file: getDistPath(subExports.import, cwd) })
       }
     }
   }

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -1,0 +1,52 @@
+import type { CompilerOptions } from 'typescript'
+import { resolve, dirname } from 'path'
+import { Module } from 'module'
+import { exit, fileExists } from './utils'
+
+export type TypescriptOptions = {
+  tsConfigPath: string | undefined
+  tsCompilerOptions: CompilerOptions
+  dtsOnly: boolean
+}
+
+let hasLoggedTsWarning = false
+function resolveTypescript(cwd: string): typeof import('typescript') {
+  let ts
+  const m = new Module('', undefined)
+  m.paths = (Module as any)._nodeModulePaths(cwd)
+  try {
+    ts = m.require('typescript')
+  } catch (_) {
+    console.error(_)
+    if (!hasLoggedTsWarning) {
+      hasLoggedTsWarning = true
+      exit(
+        'Could not load TypeScript compiler. Try to install `typescript` as dev dependency'
+      )
+    }
+  }
+  return ts
+}
+
+export async function resolveTsConfig(cwd: string): Promise<null | Omit<TypescriptOptions, 'dtsOnly'>> {
+  let tsCompilerOptions: CompilerOptions = {}
+  let tsConfigPath: string | undefined
+  const ts = resolveTypescript(cwd)
+  tsConfigPath = resolve(cwd, 'tsconfig.json')
+  if (await fileExists(tsConfigPath)) {
+    const basePath = tsConfigPath ? dirname(tsConfigPath) : cwd
+    const tsconfigJSON = ts.readConfigFile(tsConfigPath, ts.sys.readFile).config
+    tsCompilerOptions = ts.parseJsonConfigFileContent(
+      tsconfigJSON,
+      ts.sys,
+      basePath
+    ).options
+  } else {
+    tsConfigPath = undefined
+    return null
+  }
+  return {
+    tsCompilerOptions,
+    tsConfigPath,
+  }
+}

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -6,7 +6,6 @@ import { exit, fileExists } from './utils'
 export type TypescriptOptions = {
   tsConfigPath: string | undefined
   tsCompilerOptions: CompilerOptions
-  dtsOnly: boolean
 }
 
 let hasLoggedTsWarning = false

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,6 +10,10 @@ export function exit(err: string | Error) {
 export const formatDuration = (duration: number) =>
   duration >= 1000 ? `${duration / 1000}s` : `${duration}ms`
 
+export async function hasPackageJson(cwd: string) {
+  return await fileExists(path.resolve(cwd, 'package.json'))
+}
+
 export async function getPackageMeta(cwd: string): Promise<PackageMetadata> {
   const pkgFilePath = path.resolve(cwd, 'package.json')
   let targetPackageJson = {}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -6,7 +6,8 @@ import os from 'os'
 import { fork, execSync } from 'child_process'
 import { stripANSIColor } from './testing-utils'
 
-const resolveFromTest = (filepath: string) => path.resolve(__dirname, '../test', filepath)
+const resolveFromTest = (filepath: string) =>
+  path.resolve(__dirname, '../test', filepath)
 const fixturesDir = resolveFromTest('fixtures')
 
 async function removeDirectory(tempDirPath: string) {
@@ -24,14 +25,19 @@ async function createTempDir(): Promise<string> {
 const testCases: {
   name: string
   args: string[]
+  distFile?: string
   env?: Record<string, string>
   dist?: (() => Promise<string>) | string
-  expected(f: string, { stderr, stdout }: { stderr: string; stdout: string }): [boolean, boolean][]
+  expected(
+    f: string,
+    { stderr, stdout }: { stderr: string; stdout: string }
+  ): [boolean, boolean][]
 }[] = [
   {
     name: 'basic',
     dist: createTempDir,
-    args: [resolveFromTest('fixtures/hello.js'), '-o', 'dist/hello.bundle.js'],
+    args: [resolveFromTest('fixtures/hello.js')],
+    distFile: 'dist/hello.bundle.js',
     expected(distFile) {
       return [[fs.existsSync(distFile), true]]
     },
@@ -39,43 +45,49 @@ const testCases: {
   {
     name: 'format',
     dist: createTempDir,
-    args: [
-      resolveFromTest('fixtures/hello.js'),
-      '--cwd',
-      fixturesDir,
-      '-f',
-      'cjs',
-      '-o',
-      'dist/hello.cjs',
-    ],
+    args: [resolveFromTest('fixtures/hello.js'), '-f', 'cjs'],
+    distFile: 'dist/hello.cjs',
     expected(distFile) {
       return [
         [fs.existsSync(distFile), true],
-        [fs.readFileSync(distFile, { encoding: 'utf-8' }).includes('exports.'), true],
+        [
+          fs.readFileSync(distFile, { encoding: 'utf-8' }).includes('exports.'),
+          true,
+        ],
       ]
     },
   },
   {
     name: 'compress',
     dist: createTempDir,
-    args: [resolveFromTest('fixtures/hello.js'), '-m', '-o', 'dist/hello.bundle.min.js'],
+    distFile: 'dist/hello.bundle.min.js',
+    args: [resolveFromTest('fixtures/hello.js'), '-m'],
     expected(distFile) {
       return [
         [fs.existsSync(distFile), true],
         // original function name is compressed
-        [fs.readFileSync(distFile, { encoding: 'utf-8' }).includes('sayHello'), false],
+        [
+          fs.readFileSync(distFile, { encoding: 'utf-8' }).includes('sayHello'),
+          false,
+        ],
       ]
     },
   },
   {
     name: 'with sourcemap',
     dist: createTempDir,
-    args: [resolveFromTest('fixtures/hello.js'), '--sourcemap', '-o', 'dist/hello.js'],
+    args: [resolveFromTest('fixtures/hello.js'), '--sourcemap'],
+    distFile: 'dist/hello.js',
     expected(distFile) {
       return [
         [fs.existsSync(distFile), true],
         //# sourceMappingURL is set
-        [fs.readFileSync(distFile, { encoding: 'utf-8' }).includes('sourceMappingURL'), true],
+        [
+          fs
+            .readFileSync(distFile, { encoding: 'utf-8' })
+            .includes('sourceMappingURL'),
+          true,
+        ],
         [fs.existsSync(distFile + '.map'), true],
       ]
     },
@@ -83,12 +95,18 @@ const testCases: {
   {
     name: 'minified with sourcemap',
     dist: createTempDir,
-    args: [resolveFromTest('fixtures/hello.js'), '-m', '--sourcemap', '-o', 'dist/hello.min.js'],
+    distFile: 'dist/hello.min.js',
+    args: [resolveFromTest('fixtures/hello.js'), '-m', '--sourcemap'],
     expected(distFile) {
       return [
         [fs.existsSync(distFile), true],
         //# sourceMappingURL is set
-        [fs.readFileSync(distFile, { encoding: 'utf-8' }).includes('sourceMappingURL'), true],
+        [
+          fs
+            .readFileSync(distFile, { encoding: 'utf-8' })
+            .includes('sourceMappingURL'),
+          true,
+        ],
         [fs.existsSync(distFile + '.map'), true],
       ]
     },
@@ -96,13 +114,13 @@ const testCases: {
   {
     name: 'externals',
     dist: createTempDir,
+    distFile: 'dist/with-externals.bundle.js',
     args: [
       resolveFromTest('fixtures/with-externals.js'),
       '--external',
       '@huozhi/testing-package',
-      '-o',
-      'dist/with-externals.bundle.js',
     ],
+
     expected(distFile) {
       const content = fs.readFileSync(distFile, { encoding: 'utf-8' })
       return [
@@ -114,11 +132,10 @@ const testCases: {
   {
     name: 'no-externals',
     dist: createTempDir,
+    distFile: 'dist/with-externals.bundle.js',
     args: [
       resolveFromTest('fixtures/with-externals.js'),
       '--no-external',
-      '-o',
-      'dist/with-externals.bundle.js',
     ],
     expected(distFile) {
       const content = fs.readFileSync(distFile, { encoding: 'utf-8' })
@@ -131,8 +148,15 @@ const testCases: {
   {
     name: 'es2020-target',
     dist: createTempDir,
-    args: [resolveFromTest('fixtures/es2020.ts'), '--cwd', fixturesDir, '--target', 'es2020', '-o', 'dist/es2020.js'],
-    expected(distFile, { stdout, stderr }) {
+    distFile: 'dist/es2020.js',
+    args: [
+      resolveFromTest('fixtures/es2020.ts'),
+      '--cwd',
+      fixturesDir,
+      '--target',
+      'es2020',
+    ],
+    expected(distFile) {
       const content = fs.readFileSync(distFile, { encoding: 'utf-8' })
       return [
         [content.includes(`...globalThis`), true],
@@ -145,8 +169,9 @@ const testCases: {
   {
     name: 'dts',
     dist: createTempDir,
+    distFile: 'dist/base.d.ts',
     // need working directory for tsconfig.json
-    args: ['./base.ts', '--dts', '--cwd', fixturesDir, '-o', './dist/base.js'],
+    args: ['./base.ts', '--dts', '--cwd', fixturesDir],
     expected(distFile) {
       return [
         [fs.existsSync(distFile), true],
@@ -166,48 +191,62 @@ const testCases: {
         // same name with input file
         [fs.existsSync(distFile.replace('.mjs', '.d.ts')), true],
       ]
-    }
+    },
   },
   // single entry with custom entry path
   {
     name: 'single-entry-js',
     dist: path.join(fixturesDir, './single-entry-js/dist'),
-    args: ['src/index.js', '--cwd', path.join(fixturesDir, './single-entry-js')],
+    args: [
+      'src/index.js',
+      '--cwd',
+      path.join(fixturesDir, './single-entry-js'),
+    ],
     expected(distFile, { stdout }) {
       return [
         [fs.existsSync(distFile), true],
         // specifying types in package.json for js entry file won't work
-        [stripANSIColor(stdout).includes('pkg.types is ./dist/index.d.ts but the file does not exist.'), true]
+        [
+          stripANSIColor(stdout).includes(
+            'pkg.types is ./dist/index.d.ts but the file does not exist.'
+          ),
+          true,
+        ],
       ]
     },
   },
   {
     name: 'env-var',
     dist: createTempDir,
-    args: [path.join(fixturesDir, './env-var-consumer/index.js'), '--env', 'MY_TEST_ENV'],
+    args: [
+      path.join(fixturesDir, './env-var-consumer/index.js'),
+      '--env',
+      'MY_TEST_ENV',
+    ],
     env: {
-      'MY_TEST_ENV': 'my-test-value'
+      MY_TEST_ENV: 'my-test-value',
     },
     expected(distFile) {
       const content = fs.readFileSync(distFile, { encoding: 'utf-8' })
-      return [
-        [content.includes('my-test-value'), true],
-      ]
+      return [[content.includes('my-test-value'), true]]
     },
-  }
+  },
 ]
 
 describe('cli', () => {
   for (const testCase of testCases) {
-    const { name, args, expected, dist, env } = testCase
+    const { name, args, expected, dist, distFile: _distFile, env } = testCase
     it(`cli ${name} should work properly`, async () => {
       // Delete the of dist folder: folder of dist file (as last argument) or `dist` option
       let distDir
       let distFile
       if (typeof dist === 'function') {
         distDir = await dist()
-        distFile = path.join(distDir, 'index.js')
+        distFile = path.join(distDir, _distFile || 'index.js')
         args.push('-o', distFile)
+        if (args.indexOf('--cwd') === -1) {
+          args.push('--cwd', path.dirname(args[0]))
+        }
       } else if (typeof dist === 'string') {
         distDir = dist
         distFile = args[args.length - 1]
@@ -218,7 +257,7 @@ describe('cli', () => {
 
       // TODO: specify working directory for each test
       execSync(`rm -rf ${distDir}`)
-      if (process.env.TEST_DBEUG) {
+      if (process.env.TEST_DEBUG) {
         console.log(`Command: rm -rf ${distDir}`)
         console.log(`Command: bunchee ${args.join(' ')}`)
       }
@@ -246,11 +285,10 @@ describe('cli', () => {
       }
       expect(fs.existsSync(distFile)).toBe(true)
       expect(code).toBe(0)
-      if (process.env.TEST_DBEUG) {
+      if (process.env.TEST_DEBUG) {
         console.log(`Clean up ${distDir}`)
       }
       await removeDirectory(distDir)
     })
   }
 })
-

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -151,8 +151,6 @@ const testCases: {
     distFile: 'dist/es2020.js',
     args: [
       resolveFromTest('fixtures/es2020.ts'),
-      '--cwd',
-      fixturesDir,
       '--target',
       'es2020',
     ],
@@ -206,6 +204,7 @@ const testCases: {
       return [
         [fs.existsSync(distFile), true],
         // specifying types in package.json for js entry file won't work
+        // if there's no tsconfig.json and entry file is js
         [
           stripANSIColor(stdout).includes(
             'pkg.types is ./dist/index.d.ts but the file does not exist.'

--- a/test/compile.test.ts
+++ b/test/compile.test.ts
@@ -1,42 +1,52 @@
 jest.setTimeout(10 * 60 * 1000)
 
-import fs from 'fs'
+import fs, { promises as fsp } from 'fs'
 import { resolve, dirname } from 'path'
 import { bundle } from 'bunchee'
+import { existsFile } from './testing-utils'
 
 const baseUnitTestDir = resolve(__dirname, 'unit')
 const unitTestDirs = fs.readdirSync(baseUnitTestDir)
 
 type CompareFn = (a: string, b: string | undefined) => void
 
-function ensureDir(dir: string) {
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true })
+async function ensureDir(dir: string) {
+  if (!(await existsFile(dir))) {
+    await fsp.mkdir(dir, { recursive: true })
   }
 }
 
-function compareOrUpdateSnapshot(filename: string, unitName: string, onCompare: CompareFn) {
+async function compareOrUpdateSnapshot(
+  filename: string,
+  unitName: string,
+  onCompare: CompareFn
+) {
   const dirPath = resolve(baseUnitTestDir, unitName)
-  const bundledAssetContent = fs.readFileSync(filename, {encoding: 'utf-8'}).replace(/\r\n/g, '\n')
+  const bundledAssetContent = (
+    await fsp.readFile(filename, { encoding: 'utf-8' })
+  ).replace(/\r\n/g, '\n')
   const outputFilePath = resolve(
     dirPath,
     '__snapshot__',
     `${unitName}${filename.endsWith('.min.js') ? '.min' : ''}.js.snapshot`
   )
 
-
-  ensureDir(dirname(outputFilePath))
+  await ensureDir(dirname(outputFilePath))
 
   let currentOutputSnapshot
-  if (fs.existsSync(outputFilePath)) {
-    currentOutputSnapshot = fs.readFileSync(outputFilePath, { encoding: 'utf-8' }).replace(/\r\n/g, '\n')
+  if (await existsFile(outputFilePath)) {
+    currentOutputSnapshot = (
+      await fsp.readFile(outputFilePath, { encoding: 'utf-8' })
+    ).replace(/\r\n/g, '\n')
   }
 
   if (bundledAssetContent !== currentOutputSnapshot) {
-    console.log(`Snapshot ${unitName} is not matched, use TEST_UPDATE_SNAPSHOT=1 yarn test to update it`)
+    console.log(
+      `Snapshot ${unitName} is not matched, use TEST_UPDATE_SNAPSHOT=1 yarn test to update it`
+    )
 
     if (process.env.TEST_UPDATE_SNAPSHOT) {
-      fs.writeFileSync(outputFilePath, bundledAssetContent)
+      await fsp.writeFile(outputFilePath, bundledAssetContent)
       currentOutputSnapshot = bundledAssetContent
     }
   }
@@ -47,17 +57,18 @@ for (const unitName of unitTestDirs) {
   it(`should compile ${unitName} case correctly`, async () => {
     const dir = resolve(baseUnitTestDir, unitName)
     const inputFile = resolve(dir, 'input')
-    const inputFileName = inputFile + [
-      '.js',
-      '.jsx',
-      '.ts',
-      '.tsx'
-    ].find(ext => fs.existsSync(`${inputFile}${ext}`))
+    const inputFileName =
+      inputFile +
+      ['.js', '.jsx', '.ts', '.tsx'].find((ext) =>
+        fs.existsSync(`${inputFile}${ext}`)
+      )
 
     const distFile = resolve(dir, 'dist/bundle.js')
     const minifiedDistFile = distFile.replace('.js', '.min.js')
-    const pkgJson = fs.existsSync(resolve(dir, 'package.json'))
-      ? JSON.parse(fs.readFileSync(resolve(dir, `package.json`), { encoding: 'utf-8' }))
+    const pkgJson = await existsFile(resolve(dir, 'package.json'))
+      ? JSON.parse(
+          await fsp.readFile(resolve(dir, `package.json`), { encoding: 'utf-8' })
+        )
       : {}
 
     const baseOptions = {
@@ -67,13 +78,20 @@ for (const unitName of unitTestDirs) {
 
     // build dist file and minified file
     await bundle(inputFileName, { ...baseOptions, file: distFile })
-    await bundle(inputFileName, { ...baseOptions, file: minifiedDistFile, minify: true })
+    await bundle(inputFileName, {
+      ...baseOptions,
+      file: minifiedDistFile,
+      minify: true,
+    })
 
-    const compareSnapshot: CompareFn = (bundledAssetContent, currentOutputSnapshot) => {
+    const compareSnapshot: CompareFn = (
+      bundledAssetContent,
+      currentOutputSnapshot
+    ) => {
       expect(bundledAssetContent).toEqual(currentOutputSnapshot)
     }
 
-    compareOrUpdateSnapshot(distFile, unitName, compareSnapshot)
-    compareOrUpdateSnapshot(minifiedDistFile, unitName, compareSnapshot)
+    await compareOrUpdateSnapshot(distFile, unitName, compareSnapshot)
+    await compareOrUpdateSnapshot(minifiedDistFile, unitName, compareSnapshot)
   })
 }

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -91,7 +91,7 @@ const testCases: {
       for (const f of distFiles) {
         expect(await existsFile(f)).toBe(true)
       }
-      expect(await fs.readFile(distFiles[1], 'utf-8')).toContain('declare function _default(): string;')
+      expect(await fs.readFile(distFiles[1], 'utf-8')).toContain('declare const _default: () => string;')
     },
   },
   {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1,9 +1,9 @@
 jest.setTimeout(10 * 60 * 1000)
 
-import fs from 'fs'
+import fs from 'fs/promises'
 import { execSync, fork } from 'child_process'
 import { resolve, join } from 'path'
-import { stripANSIColor } from './testing-utils'
+import { stripANSIColor, existsFile } from './testing-utils'
 
 const integrationTestDir = resolve(__dirname, 'integration')
 
@@ -18,9 +18,9 @@ const testCases: {
   {
     name: 'externals',
     args: ['index.js', '-o', './dist/index.js'],
-    expected(dir) {
+    async expected(dir) {
       const distFile = join(dir, './dist/index.js')
-      const content = fs.readFileSync(distFile, { encoding: 'utf-8' })
+      const content = await fs.readFile(distFile, { encoding: 'utf-8' })
       expect(content).toMatch(/['"]peer-dep['"]/)
       expect(content).toMatch(/['"]peer-dep-meta['"]/)
     },
@@ -28,40 +28,44 @@ const testCases: {
   {
     name: 'ts-error',
     args: ['index.ts', '-o', './dist/index.js'],
-    expected(dir, { stdout, stderr }) {
+    async expected(dir, { stdout, stderr }) {
       const distFile = join(dir, './dist/index.js')
       expect(stderr).toMatch(/Could not load TypeScript compiler/)
-      expect(fs.existsSync(distFile)).toBe(false)
+      expect(await existsFile(distFile)).toBe(false)
     },
   },
   {
     name: 'no-ts-require-for-js',
     args: ['index.js', '-o', './dist/index.js'],
-    expected(dir) {
+    async expected(dir) {
       const distFile = join(dir, './dist/index.js')
-      expect(fs.existsSync(distFile)).toBe(true)
+      expect(await existsFile(distFile)).toBe(true)
     },
   },
   {
     name: 'pkg-exports',
     args: ['index.js'],
-    expected(dir) {
+    async expected(dir) {
       const distFiles = [join(dir, './dist/index.cjs'), join(dir, './dist/index.mjs'), join(dir, './dist/index.esm.js')]
-      expect(distFiles.every((f) => fs.existsSync(f))).toBe(true)
+      for (const f of distFiles) {
+        expect(await existsFile(f)).toBe(true)
+      }
     },
   },
   {
     name: 'pkg-exports-default',
     args: ['index.js'],
-    expected(dir) {
+    async expected(dir) {
       const distFiles = [join(dir, './dist/index.cjs'), join(dir, './dist/index.mjs')]
-      expect(distFiles.every((f) => fs.existsSync(f))).toBe(true)
+      for (const f of distFiles) {
+        expect(await existsFile(f)).toBe(true)
+      }
     },
   },
   {
     name: 'multi-entries',
     args: [],
-    expected(dir) {
+    async expected(dir) {
       const distFiles = [
         join(dir, './dist/index.js'),
         join(dir, './dist/lite.js'),
@@ -74,16 +78,32 @@ const testCases: {
         join(dir, './dist/lite.d.ts'),
       ]
 
-      expect(distFiles.every((f) => fs.existsSync(f))).toBe(true)
+      for (const f of distFiles) {
+        expect(await existsFile(f)).toBe(true)
+      }
     },
   },
   {
     name: 'single-entry',
     args: [],
-    expected(dir) {
+    async expected(dir) {
       const distFiles = [join(dir, './dist/index.js'), join(dir, './dist/index.d.ts')]
-      expect(distFiles.every((f) => fs.existsSync(f))).toBe(true)
+      for (const f of distFiles) {
+        expect(await existsFile(f)).toBe(true)
+      }
+      expect(await fs.readFile(distFiles[1], 'utf-8')).toContain('declare function _default(): string;')
     },
+  },
+  {
+    name: 'ts-allow-js',
+    args: [],
+    async expected(dir) {
+      const distFiles = [join(dir, './dist/index.js'), join(dir, './dist/index.d.ts')]
+      for (const f of distFiles) {
+        expect(await existsFile(f)).toBe(true)
+      }
+      expect(await fs.readFile(distFiles[1], 'utf-8')).toContain('declare function _default(): string;')
+    }
   },
   {
     name: 'publint',
@@ -134,7 +154,7 @@ function runTests() {
         stderr && console.error(stderr)
       }
 
-      expected(dir, { stdout, stderr })
+      await expected(dir, { stdout, stderr })
     })
   }
 }

--- a/test/integration/ts-allow-js/package.json
+++ b/test/integration/ts-allow-js/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "ts-allow-js",
+  "types": "./dist/index.d.ts",
+  "exports": "./dist/index.js"
+}

--- a/test/integration/ts-allow-js/src/index.js
+++ b/test/integration/ts-allow-js/src/index.js
@@ -1,0 +1,1 @@
+export default () => 'index'

--- a/test/integration/ts-allow-js/tsconfig.json
+++ b/test/integration/ts-allow-js/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "allowJs": true
+  }
+}

--- a/test/testing-utils.ts
+++ b/test/testing-utils.ts
@@ -1,4 +1,18 @@
+import fs from 'fs/promises'
+
 export function stripANSIColor(str: string) {
   return str.replace(
     /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '')
+}
+
+export async function existsFile(filePath: string) {
+  try {
+    await fs.access(filePath)
+    return true
+  } catch (err: any) {
+    if (err.code === 'ENOENT') {
+      return false
+    }
+    throw err
+  }
 }

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
+    "module": "ESNext",
+    "target": "ESNext",
     "baseUrl": "..",
     "paths": {
       "bunchee": ["./src/index.ts"]


### PR DESCRIPTION
### Feature

Detect if there's `tsconfig.json` then treat it as typescript project weather users enabled `allowJs` configuration. As you always need custom `tsconfig.json` for typescript files.

When users have allowJs, source js file should emit types as well like ts files

Resolves #193 

### Misc

* Refactor the `cwd` passing, remove `config.rootDir` as we only need it consume it on top level of bundling process
* Extract more helpers for building config into `src/build-config.ts` to decouple the logic from `bundle.ts`
* Improve test suite, specify `distFile` explicitly and use more async operations