### PR TITLE
Output size of generated types and js assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@swc/core": "1.3.46",
     "@swc/helpers": "0.5.0",
     "arg": "5.0.2",
+    "pretty-bytes": "5.6.0",
     "publint": "0.1.11",
     "rollup": "3.20.2",
     "rollup-plugin-dts": "5.3.0",

--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -41,6 +41,7 @@ const minifyOptions: JsMinifyOptions = {
   },
 }
 
+// This can also be passed down as stats from top level
 export const sizeCollector = createChunkSizeCollector()
 
 function getBuildEnv(envs: string[]) {
@@ -78,10 +79,15 @@ function buildInputConfig(
   const hasSpecifiedTsTarget = Boolean(
     tsCompilerOptions?.target && tsConfigPath
   )
+  const sizePlugin = sizeCollector.plugin(cwd)
+  const commonPlugins = [
+    shebang(),
+    sizePlugin,
+  ]
   const plugins: Plugin[] = (
     dtsOnly
       ? [
-          shebang(),
+          ...commonPlugins,
           useTypescript &&
             require('rollup-plugin-dts').default({
               compilerOptions: {
@@ -102,6 +108,7 @@ function buildInputConfig(
             }),
         ]
       : [
+          ...commonPlugins,
           replace({
             values: getBuildEnv(options.env || []),
             preventAssignment: true,
@@ -114,7 +121,6 @@ function buildInputConfig(
             include: /node_modules\//,
           }),
           json(),
-          shebang(),
           swc({
             include: /\.(m|c)?[jt]sx?$/,
             exclude: 'node_modules',
@@ -142,7 +148,6 @@ function buildInputConfig(
             sourceMaps: options.sourcemap,
             inlineSourcesContent: false,
           }),
-          sizeCollector.plugin(cwd),
         ]
   ).filter(isNotNull<Plugin>)
 
@@ -335,7 +340,6 @@ function buildConfig(
     input: inputOptions,
     output: outputConfigs,
     exportName: options.exportCondition?.name || '.',
-    dtsOnly,
   }
 }
 

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -26,8 +26,8 @@ import { getTypings } from './exports'
 import type { BuildMetadata } from './types'
 import { TypescriptOptions, resolveTsConfig } from './typescript'
 
-async function logSizeStats() {
-  const stats = await sizeCollector.getSizeStats()
+function logSizeStats() {
+  const stats = sizeCollector.getSizeStats()
   const maxLength = Math.max(...stats.map(([filename]) => filename.length))
   stats.forEach(([filename, prettiedSize]) => {
     const padding = ' '.repeat(maxLength - filename.length)
@@ -162,7 +162,7 @@ async function bundle(
     result = await bundleOrWatch(rollupConfig)
   }
 
-  await logSizeStats()
+  logSizeStats()
   return result
 }
 

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -27,7 +27,6 @@ import type { BuildMetadata } from './types'
 import { TypescriptOptions, resolveTsConfig } from './typescript'
 
 async function logSizeStats() {
-  logger.log()
   const stats = await sizeCollector.getSizeStats()
   const maxLength = Math.max(...stats.map(([filename]) => filename.length))
   stats.forEach(([filename, prettiedSize]) => {

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -14,7 +14,7 @@ import type {
 import fs from 'fs/promises'
 import { resolve, relative } from 'path'
 import { watch as rollupWatch, rollup } from 'rollup'
-import buildConfig, { buildEntryConfig, sizeCollector } from './build-config'
+import buildConfig, { buildEntryConfig } from './build-config'
 import {
   getPackageMeta,
   logger,
@@ -25,15 +25,7 @@ import {
 import { getTypings } from './exports'
 import type { BuildMetadata } from './types'
 import { TypescriptOptions, resolveTsConfig } from './typescript'
-
-function logSizeStats() {
-  const stats = sizeCollector.getSizeStats()
-  const maxLength = Math.max(...stats.map(([filename]) => filename.length))
-  stats.forEach(([filename, prettiedSize]) => {
-    const padding = ' '.repeat(maxLength - filename.length)
-    logger.log(` ✓  Build ${filename}${padding} - ${prettiedSize}`)
-  })
-}
+import { logSizeStats } from './logging'
 
 function assignDefault(
   options: BundleConfig,
@@ -166,10 +158,8 @@ async function bundle(
   return result
 }
 
-
-
 function runWatch(
-  { input, output, dtsOnly }: BuncheeRollupConfig,
+  { input, output }: BuncheeRollupConfig,
   metadata: BuildMetadata
 ): RollupWatcher {
   const watchOptions: RollupWatchOptions[] = [

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,0 +1,12 @@
+import { sizeCollector } from './build-config'
+import { logger } from './utils'
+
+export function logSizeStats() {
+  const stats = sizeCollector.getSizeStats()
+  const maxLength = Math.max(...stats.map(([filename]) => filename.length))
+  stats.forEach(([filename, prettiedSize]) => {
+    const padding = ' '.repeat(maxLength - filename.length)
+    const action = filename.endsWith('.d.ts') ? 'Typed' : 'Built'
+    logger.log(` ✓  ${action} ${filename}${padding} - ${prettiedSize}`)
+  })
+}

--- a/src/plugins/size-plugin.ts
+++ b/src/plugins/size-plugin.ts
@@ -1,0 +1,46 @@
+import type { Plugin } from 'rollup'
+import path from 'path'
+import prettyBytes from 'pretty-bytes'
+
+type SizeStats = [string, string, number][]
+
+function chunkSizeCollector(): {
+  plugin(cwd: string): Plugin,
+  getSizeStats(): Promise<SizeStats>
+} {
+  const sizes: Map<string, number> = new Map()
+
+  function addSize(name: string, size: number) {
+    sizes.set(name, size)
+  }
+
+  return {
+    plugin: (cwd: string) => {
+      return {
+        name: 'collect-sizes',
+        augmentChunkHash() {
+          // Do nothing, but use the hook to keep the plugin instance alive
+        },
+        renderChunk(code, chunk, options) {
+          const dir = options.dir || (options.file && path.dirname(options.file))
+          let fileName = chunk.fileName
+          if (dir) {
+            fileName = path.relative(cwd, path.join(dir, fileName))
+          }
+          addSize(fileName, code.length)
+          return null
+        },
+      }
+    },
+    async getSizeStats() {
+
+      const sizeStats: SizeStats = []
+      sizes.forEach((size, name) => {
+        sizeStats.push([name, prettyBytes(size), size])
+      })
+      return sizeStats
+    },
+  }
+}
+
+export default chunkSizeCollector

--- a/src/plugins/size-plugin.ts
+++ b/src/plugins/size-plugin.ts
@@ -6,7 +6,7 @@ type SizeStats = [string, string, number][]
 
 function chunkSizeCollector(): {
   plugin(cwd: string): Plugin,
-  getSizeStats(): Promise<SizeStats>
+  getSizeStats(): SizeStats
 } {
   const sizes: Map<string, number> = new Map()
 
@@ -32,8 +32,7 @@ function chunkSizeCollector(): {
         },
       }
     },
-    async getSizeStats() {
-
+    getSizeStats() {
       const sizeStats: SizeStats = []
       sizes.forEach((size, name) => {
         sizeStats.push([name, prettyBytes(size), size])

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,7 +45,6 @@ type BuncheeRollupConfig = Partial<Omit<RollupOptions, 'input' | 'output'>> & {
   exportName?: string
   input: InputOptions
   output: OutputOptions[]
-  dtsOnly: boolean
 }
 
 type CliArgs = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,7 +26,7 @@ export async function getPackageMeta(cwd: string): Promise<PackageMetadata> {
 
 export const logger = {
   log(arg?: any) {
-    arg ? console.log(arg) : console.log()
+    console.log(arg)
   },
   warn(arg: any[]) {
     console.log('\x1b[33m' + arg + '\x1b[0m')

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,8 +25,8 @@ export async function getPackageMeta(cwd: string): Promise<PackageMetadata> {
 }
 
 export const logger = {
-  log(arg: any) {
-    console.log(arg)
+  log(arg?: any) {
+    arg ? console.log(arg) : console.log()
   },
   warn(arg: any[]) {
     console.log('\x1b[33m' + arg + '\x1b[0m')

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -31,7 +31,7 @@ const testCases: {
   expected(
     f: string,
     { stderr, stdout }: { stderr: string; stdout: string }
-  ): [boolean, boolean][]
+  ): [boolean | string, boolean | string][]
 }[] = [
   {
     name: 'basic',
@@ -167,14 +167,17 @@ const testCases: {
   {
     name: 'dts',
     dist: createTempDir,
-    distFile: 'dist/base.d.ts',
+    distFile: 'dist/base.js',
     // need working directory for tsconfig.json
     args: ['./base.ts', '--dts', '--cwd', fixturesDir],
     expected(distFile) {
+      const typeFile = distFile.replace('.js', '.d.ts')
       return [
+        [path.basename(distFile), 'base.js'],
+        [path.basename(typeFile), 'base.d.ts'],
         [fs.existsSync(distFile), true],
         // same name with input file
-        [fs.existsSync(distFile.replace('.js', '.d.ts')), true],
+        [fs.existsSync(typeFile), true],
       ]
     },
   },

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -128,7 +128,7 @@ async function runBundle(
   ps.stderr?.on('data', (chunk) => (stderr += chunk.toString()))
   return new Promise((resolve) => {
     ps.on('close', (code) => {
-      if (process.env.DEBUG_TEST) {
+      if (process.env.TEST_DEBUG) {
         stdout && console.log(stdout)
         stderr && console.error(stderr)
       }
@@ -146,10 +146,10 @@ function runTests() {
     const { name, args, expected } = testCase
     const dir = getPath(name)
     test(`integration ${name}`, async () => {
-      if (process.env.DEBUG_TEST) console.log(`Command: bunchee ${args.join(' ')}`)
+      if (process.env.TEST_DEBUG) console.log(`Command: bunchee ${args.join(' ')}`)
       execSync(`rm -rf ${join(dir, 'dist')}`)
       const { stdout, stderr } = await runBundle(dir, args)
-      if (process.env.DEBUG_TEST) {
+      if (process.env.TEST_DEBUG) {
         stdout && console.log(stdout)
         stderr && console.error(stderr)
       }

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -65,7 +65,7 @@ const testCases: {
   {
     name: 'multi-entries',
     args: [],
-    async expected(dir) {
+    async expected(dir, { stdout }) {
       const distFiles = [
         join(dir, './dist/index.js'),
         join(dir, './dist/lite.js'),
@@ -81,17 +81,41 @@ const testCases: {
       for (const f of distFiles) {
         expect(await existsFile(f)).toBe(true)
       }
+
+      const log = `\
+      ✓  Typed dist/client.d.ts      - 74 B
+      ✓  Typed dist/index.d.ts       - 65 B
+      ✓  Typed dist/lite.d.ts        - 70 B
+      ✓  Typed dist/client.d.ts      - 74 B
+      ✓  Built dist/index.js         - 110 B
+      ✓  Built dist/lite.js          - 132 B
+      ✓  Built dist/client/index.cjs - 138 B
+      ✓  Built dist/client/index.mjs - 78 B`
+
+      const rawStdout = stripANSIColor(stdout)
+      log.split('\n').forEach((line: string) => {
+        expect(rawStdout).toContain(line.trim())
+      })
     },
   },
   {
     name: 'single-entry',
     args: [],
-    async expected(dir) {
+    async expected(dir, { stdout }) {
       const distFiles = [join(dir, './dist/index.js'), join(dir, './dist/index.d.ts')]
       for (const f of distFiles) {
         expect(await existsFile(f)).toBe(true)
       }
       expect(await fs.readFile(distFiles[1], 'utf-8')).toContain('declare const _default: () => string;')
+
+      const log = `\
+      ✓  Typed dist/index.d.ts - 70 B
+      ✓  Built dist/index.js   - 56 B`
+
+      const rawStdout = stripANSIColor(stdout)
+      log.split('\n').forEach((line: string) => {
+        expect(rawStdout).toContain(line.trim())
+      })
     },
   },
   {
@@ -128,10 +152,6 @@ async function runBundle(
   ps.stderr?.on('data', (chunk) => (stderr += chunk.toString()))
   return new Promise((resolve) => {
     ps.on('close', (code) => {
-      if (process.env.TEST_DEBUG) {
-        stdout && console.log(stdout)
-        stderr && console.error(stderr)
-      }
       resolve({
         code,
         stdout,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2374,6 +2374,11 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
+pretty-bytes@5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.6.0.tgz#356256f643804773c82f64723fe78c92c62beaeb"
+  integrity sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==
+
 pretty-format@^29.0.0, pretty-format@^29.0.2:
   version "29.0.2"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.0.2.tgz#7f7666a7bf05ba2bcacde61be81c6db64f6f3be6"


### PR DESCRIPTION
Resolves #194 

Example

```
      ✓  Typed dist/client.d.ts      - 74 B
      ✓  Typed dist/index.d.ts       - 65 B
      ✓  Typed dist/lite.d.ts        - 70 B
      ✓  Typed dist/client.d.ts      - 74 B
      ✓  Built dist/index.js         - 110 B
      ✓  Built dist/lite.js          - 132 B
      ✓  Built dist/client/index.cjs - 138 B
      ✓  Built dist/client/index.mjs - 78 B
```