### PR TITLE
Fix applying interop

### DIFF
--- a/src/exports.ts
+++ b/src/exports.ts
@@ -30,6 +30,47 @@ function parseExport(exportsCondition: ExportCondition) {
 }
 
 
+/**
+ * Get package exports paths
+ *
+ * Example:
+ *
+ * ```json
+ * {
+ *  "exports": {
+ *    ".": {
+ *      "require": "./dist/index.cjs",
+ *      "module": "./dist/index.esm.js",
+ *      "default": "./dist/index.esm.js"
+ *    },
+ *    "./foo": {
+ *      "require": "./dist/foo.cjs",
+ *      "module": "./dist/foo.esm.js",
+ *      "default": "./dist/foo.esm.js"
+ *   }
+ * }
+ *
+ * ```
+ *
+ * will be parsed to:
+ *
+ * ```js
+ * {
+ *   '.': {
+ *     main: './dist/index.cjs',
+ *     module: './dist/index.esm.js',
+ *     export: './dist/index.esm.js'
+ *   },
+ *   './foo': {
+ *     main: './dist/foo.cjs',
+ *     module: './dist/foo.esm.js',
+ *     export: './dist/foo.esm.js'
+ *   }
+ *
+ *
+ * pkg.main and pkg.module will be added to ['.'] if exists
+ */
+
 export function getExportPaths(pkg: PackageMetadata) {
   const pathsMap: Record<string, Record<string, string | undefined>> = {}
   const mainExport: Record<Exclude<ExportType, 'default'>, string> = {}

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -60,6 +60,9 @@ const testCases: {
       for (const f of distFiles) {
         expect(await existsFile(f)).toBe(true)
       }
+      const cjsFile = await fs.readFile(join(dir, './dist/index.cjs'), { encoding: 'utf-8' })
+      expect(cjsFile).toContain(`function _interopDefault (e) { return e && e.__esModule ? e : { default: e }; }`)
+      expect(cjsFile).toContain(`Object.defineProperty(exports, '__esModule', { value: true });`)
     },
   },
   {

--- a/test/integration/pkg-exports-default/index.js
+++ b/test/integration/pkg-exports-default/index.js
@@ -1,1 +1,7 @@
+import myMod from 'my-mod'
+
 export default 'exports-sugar-default'
+
+export function method() {
+  return myMod.test()
+}


### PR DESCRIPTION
* refactor the code: should generate esMark when available, now also checking `exports` field
* set interop to `'auto'`, always use interop for cjs

x-ref: https://github.com/vercel/swr/issues/2580