### PR TITLE
Refactor parsing exports

### DIFF
--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -298,10 +298,6 @@ function buildConfig(
   const inputOptions = buildInputConfig(entry, pkg, options, cwd, tsOptions, dtsOnly)
   const outputExports = getExportConditionDist(pkg, exportCondition, cwd)
 
-  // options.exportCondition
-  //   ? getExportConditionDist(pkg, options.exportCondition.export, cwd)
-  //   : getExportDist(pkg, cwd)
-
   let outputConfigs = []
 
   // Generate dts job - single config

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -123,36 +123,37 @@ async function bundle(
   }
 
   let result
-  if (isMultiEntries) {
-    const buildConfigs = await buildEntryConfig(
-      pkg,
-      options,
-      cwd,
-      defaultTsOptions,
-      false,
-    )
-    const assetsJobs = buildConfigs.map((rollupConfig) =>
-      bundleOrWatch(rollupConfig)
-    )
+  const buildConfigs = await buildEntryConfig(
+    pkg,
+    options,
+    cwd,
+    defaultTsOptions,
+    false,
+  )
+  const assetsJobs = buildConfigs.map((rollupConfig) =>
+    bundleOrWatch(rollupConfig)
+  )
 
-    const typesJobs = options.dts
-      ? (
-          await buildEntryConfig(pkg, options, cwd, defaultTsOptions, true)
-        ).map((rollupConfig) => bundleOrWatch(rollupConfig))
-      : []
+  const typesJobs = options.dts
+    ? (
+        await buildEntryConfig(pkg, options, cwd, defaultTsOptions, true)
+      ).map((rollupConfig) => bundleOrWatch(rollupConfig))
+    : []
 
-    result = await Promise.all(assetsJobs.concat(typesJobs))
-  } else {
-    // Generate types
-    if (hasTsConfig && options.dts) {
-      await bundleOrWatch(
-        buildConfig(entryPath, pkg, options, cwd, defaultTsOptions, true)
-      )
-    }
+  result = await Promise.all(assetsJobs.concat(typesJobs))
+  // if (isMultiEntries) {
 
-    const rollupConfig = buildConfig(entryPath, pkg, options, cwd, defaultTsOptions, false)
-    result = await bundleOrWatch(rollupConfig)
-  }
+  // } else {
+  //   // Generate types
+  //   if (hasTsConfig && options.dts) {
+  //     await bundleOrWatch(
+  //       buildConfig(entryPath, pkg, options, cwd, defaultTsOptions, true)
+  //     )
+  //   }
+
+  //   const rollupConfig = buildConfig(entryPath, pkg, options, cwd, defaultTsOptions, false)
+  //   result = await bundleOrWatch(rollupConfig)
+  // }
 
   logSizeStats()
   return result

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -22,7 +22,7 @@ import {
   getSourcePathFromExportPath,
   getExportPath,
 } from './utils'
-import { constructDefaultExportCondition, getExportPaths, getPackageType, getTypings } from './exports'
+import { constructDefaultExportCondition, getExportPaths, getPackageType } from './exports'
 import type { BuildMetadata } from './types'
 import { TypescriptOptions, resolveTsConfig } from './typescript'
 import { logSizeStats } from './logging'

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -14,7 +14,7 @@ import type {
 import fs from 'fs/promises'
 import { resolve, relative } from 'path'
 import { watch as rollupWatch, rollup } from 'rollup'
-import buildConfig, { buildEntryConfig } from './build-config'
+import { buildEntryConfig } from './build-config'
 import {
   getPackageMeta,
   logger,
@@ -22,7 +22,7 @@ import {
   getSourcePathFromExportPath,
   getExportPath,
 } from './utils'
-import { getTypings } from './exports'
+import { constructDefaultExportCondition, getExportPaths, getPackageType, getTypings } from './exports'
 import type { BuildMetadata } from './types'
 import { TypescriptOptions, resolveTsConfig } from './typescript'
 import { logSizeStats } from './logging'
@@ -60,14 +60,21 @@ async function bundle(
   assignDefault(options, 'target', 'es2015')
 
   const pkg = await getPackageMeta(cwd)
-  const packageExportsField = pkg.exports || {}
-  const isMultiEntries = hasMultiEntryExport(pkg)
+  const packageType = getPackageType(pkg)
+  const exportPaths = getExportPaths(pkg)
+
+  const exportPathsLength = Object.keys(exportPaths).length
+  const isMultiEntries = exportPathsLength > 1
+  // const isEmptyEntries = exportPathsLength === 0
+
   const tsConfig = await resolveTsConfig(cwd)
   const hasTsConfig = Boolean(tsConfig?.tsConfigPath)
   const defaultTsOptions: TypescriptOptions = {
     tsConfigPath: tsConfig?.tsConfigPath,
     tsCompilerOptions: tsConfig?.tsCompilerOptions || {},
   }
+
+  // console.log('isMultiEntries', isMultiEntries)
 
   // Handle single entry file
   if (!isMultiEntries) {
@@ -78,6 +85,13 @@ async function bundle(
       (await getSourcePathFromExportPath(cwd, '.')) ||
       ''
   }
+
+  console.log('entryPath', entryPath, 'exportPathsLength', exportPathsLength)
+  if (exportPathsLength === 0 && entryPath) {
+    exportPaths['.'] = constructDefaultExportCondition(entryPath, packageType)
+  }
+
+  console.log('exportPaths', exportPaths)
 
   const bundleOrWatch = (
     rollupConfig: BuncheeRollupConfig
@@ -110,12 +124,8 @@ async function bundle(
   }
 
   // has `types` field in package.json or has `types` exports in any export condition for multi-entries
-  const hasTypings =
-    !!getTypings(pkg) ||
-    (typeof packageExportsField === 'object' &&
-      Array.from(Object.values(packageExportsField || {})).some((condition) =>
-        condition.hasOwnProperty('types')
-      ))
+  const hasTypings = Object.values(exportPaths)
+    .some((condition) => condition.hasOwnProperty('types'))
 
   // Enable types generation if it's types field specified in package.json
   if (hasTypings) {
@@ -125,6 +135,8 @@ async function bundle(
   let result
   const buildConfigs = await buildEntryConfig(
     pkg,
+    entryPath,
+    exportPaths,
     options,
     cwd,
     defaultTsOptions,
@@ -134,26 +146,13 @@ async function bundle(
     bundleOrWatch(rollupConfig)
   )
 
-  const typesJobs = options.dts
+  const typesJobs = hasTsConfig && options.dts
     ? (
-        await buildEntryConfig(pkg, options, cwd, defaultTsOptions, true)
+        await buildEntryConfig(pkg, entryPath, exportPaths, options, cwd, defaultTsOptions, true)
       ).map((rollupConfig) => bundleOrWatch(rollupConfig))
     : []
 
   result = await Promise.all(assetsJobs.concat(typesJobs))
-  // if (isMultiEntries) {
-
-  // } else {
-  //   // Generate types
-  //   if (hasTsConfig && options.dts) {
-  //     await bundleOrWatch(
-  //       buildConfig(entryPath, pkg, options, cwd, defaultTsOptions, true)
-  //     )
-  //   }
-
-  //   const rollupConfig = buildConfig(entryPath, pkg, options, cwd, defaultTsOptions, false)
-  //   result = await bundleOrWatch(rollupConfig)
-  // }
 
   logSizeStats()
   return result

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -1,5 +1,5 @@
-import type { PackageMetadata, ExportCondition, ExportType } from './types'
-import { resolve } from 'path'
+import type { PackageMetadata, ExportCondition, FullExportCondition, PackageType, ParsedExportCondition } from './types'
+import { join, resolve } from 'path'
 
 export function getTypings(pkg: PackageMetadata) {
   return pkg.types || pkg.typings
@@ -9,22 +9,104 @@ function getDistPath(distPath: string, cwd: string) {
   return resolve(cwd, distPath)
 }
 
-function findExport(field: any): string | undefined {
-  if (!field) return
-  if (typeof field === 'string') return field
-  const value = field['.'] || field['import'] || field['module'] || field['default']
-  return findExport(value)
+function isExportLike(field: any): field is string | FullExportCondition {
+  if (typeof field === 'string') return true
+  return Object.entries(field).every(
+    // Every value is string and key is not start with '.'
+    // TODO: check key is ExportType
+    ([key, value]) => typeof value === 'string' && !key.startsWith('.')
+  )
 }
 
-function parseExport(exportsCondition: ExportCondition) {
-  const paths: Record<Exclude<ExportType, 'default'>, string | undefined> = {}
+function constructFullExportCondition(
+  value: string | Record<string, string | undefined>,
+  packageType?: PackageType
+): FullExportCondition {
+  const isCommonjs = packageType === 'commonjs'
+  let result: FullExportCondition
+  if (typeof value === 'string') {
+    // TODO: determine cjs or esm by "type" field in package.json
+    result = {
+      [isCommonjs ? 'require' : 'import']: value,
+    }
+  } else {
+    // TODO: valid export condition, warn if it's not valid
+    const keys: string[] = Object.keys(value)
+    result = {}
+    keys.forEach((key) => {
+      // Filter out nullable value
+      if ((key in value) && value[key]) {
+        result[key] = value[key] as string
+      }
+    })
+  }
+
+  return result
+}
+
+function joinRelativePath(...segments: string[]) {
+  let result = join(...segments)
+  // If the first segment starts with './', ensure the result does too.
+  if (segments[0] === '.' && !result.startsWith('./')) {
+    result = './' + result
+  }
+  return result
+}
+
+function findExport(
+  name: string,
+  value: ExportCondition,
+  paths: Record<string, FullExportCondition>,
+  packageType: 'commonjs' | 'module'
+): void {
+  // TODO: handle export condition based on package.type
+  if (isExportLike(value)) {
+    paths[name] = constructFullExportCondition(value, packageType)
+    return
+  }
+
+  Object.keys(value).forEach((subpath) => {
+    const nextName = joinRelativePath(name, subpath)
+
+    const nestedValue = value[subpath]
+    findExport(nextName, nestedValue, paths, packageType)
+  })
+}
+
+/**
+ *
+ * Convert package.exports field to paths mapping
+ * Example
+ *
+ * Input:
+ * {
+ *   ".": {
+ *     "sub": {
+ *       "import": "./sub.js",
+*        "require": "./sub.cjs",
+ *     }
+ *   }
+ * }
+ *
+ * Output:
+  * {
+  *   "./sub": {
+  *     "import": "./sub.js",
+  *     "require": "./sub.cjs",
+  *   }
+  * }
+  *
+ */
+function parseExport(exportsCondition: ExportCondition, packageType: PackageType) {
+  const paths: Record<string, FullExportCondition> = {}
 
   if (typeof exportsCondition === 'string') {
-    paths.export = exportsCondition
-  } else {
-    paths.main = paths.main || exportsCondition['require'] || exportsCondition['node'] || exportsCondition['default']
-    paths.module = paths.module || exportsCondition['module']
-    paths.export = findExport(exportsCondition)
+    paths['.'] = constructFullExportCondition(exportsCondition, packageType)
+  } else if (typeof exportsCondition === 'object') {
+    Object.keys(exportsCondition).forEach((key: string) => {
+      const value = exportsCondition[key]
+      findExport(key, value, paths, packageType)
+    })
   }
   return paths
 }
@@ -72,75 +154,60 @@ function parseExport(exportsCondition: ExportCondition) {
  */
 
 export function getExportPaths(pkg: PackageMetadata) {
-  const pathsMap: Record<string, Record<string, string | undefined>> = {}
-  const mainExport: Record<Exclude<ExportType, 'default'>, string> = {}
-  if (pkg.main) {
-    mainExport.main = pkg.main
-  }
-  if (pkg.module) {
-    mainExport.module = pkg.module
-  }
-  pathsMap['.'] = mainExport
+  const pathsMap: Record<string, FullExportCondition> = {}
+  const packageType: PackageType = pkg.type || 'commonjs'
+
+  pathsMap['.'] = constructFullExportCondition(
+    {
+      [packageType === 'commonjs' ? 'require' : 'import']: pkg.main,
+      'module': pkg.module,
+    },
+    packageType
+  )
 
   const { exports: exportsConditions } = pkg
   if (exportsConditions) {
-    if (typeof exportsConditions === 'string') {
-      mainExport.export = exportsConditions
-    } else {
-      const exportKeys = Object.keys(exportsConditions)
-      if (exportKeys.some((key) => key.startsWith('.'))) {
-        exportKeys.forEach((subExport) => {
-          pathsMap[subExport] = parseExport(exportsConditions[subExport])
-        })
-      } else {
-        Object.assign(mainExport, parseExport(exportsConditions as ExportCondition))
-      }
-    }
+    const paths = parseExport(exportsConditions, packageType)
+    Object.assign(pathsMap, paths)
   }
-  pathsMap['.'] = mainExport
 
   return pathsMap
 }
 
-export function getExportDist(pkg: PackageMetadata, cwd: string) {
-  const paths = getExportPaths(pkg)['.']
+export function getExportConditionDist(
+  pkg: PackageMetadata,
+  parsedExportCondition: ParsedExportCondition,
+  cwd: string
+) {
   const dist: { format: 'cjs' | 'esm'; file: string }[] = []
-  if (paths.main) {
-    dist.push({ format: 'cjs', file: getDistPath(paths.main, cwd) })
-  }
-  if (paths.module) {
-    dist.push({ format: 'esm', file: getDistPath(paths.module, cwd) })
-  }
-  if (paths.export) {
-    dist.push({ format: 'esm', file: getDistPath(paths.export, cwd) })
-  }
+  const existed = new Set<string>()
 
-  // default fallback to output `dist/index.js` in default esm format
-  if (dist.length === 0) {
-    dist.push({ format: 'esm', file: getDistPath('dist/index.js', cwd) })
-  }
-  return dist
-}
+  const exportTypes = Object.keys(parsedExportCondition.export)
+  console.log('exportTypes', exportTypes)
+  for (const key of exportTypes) {
+    const relativePath = parsedExportCondition.export[key]
+    const distFile = getDistPath(relativePath, cwd)
 
-export function getExportConditionDist(pkg: PackageMetadata, exportCondition: ExportCondition, cwd: string) {
-  const dist: { format: 'cjs' | 'esm'; file: string }[] = []
-  // "exports": "..."
-  if (typeof exportCondition === 'string') {
-    dist.push({ format: pkg.type === 'module' ? 'esm' : 'cjs', file: getDistPath(exportCondition, cwd) })
-  } else {
-    // "./<subexport>": { }
-    const subExports = exportCondition
-    // Ignore json exports, like "./package.json"
-    if (typeof subExports === 'string') {
-      dist.push({ format: 'esm', file: getDistPath(subExports, cwd) })
-    } else {
-      if (subExports.require) {
-        dist.push({ format: 'cjs', file: getDistPath(subExports.require, cwd) })
-      }
-      if (subExports.import) {
-        dist.push({ format: 'esm', file: getDistPath(subExports.import, cwd) })
-      }
+    let format: 'cjs' | 'esm' = 'esm'
+    if ([ 'import', 'module', 'react-native', 'react-server', 'edge-light'].includes(key)) {
+      format = 'esm'
+    } else if (['require', 'main', 'node', 'default']) {
+      format = 'cjs'
     }
+
+    // Deduplicate the same path jobs
+    // TODO: detect conflicts paths but with different format
+    if (existed.has(distFile)) {
+      continue
+    }
+    console.log('add:distFile', distFile)
+    existed.add(distFile)
+    dist.push({ format, file: distFile })
+  }
+
+  if (dist.length === 0) {
+    // TODO: warn there's no exports detected
+    console.error(`Doesn't fin any exports in ${pkg.name}`)
   }
   return dist
 }

--- a/src/plugins/size-plugin.ts
+++ b/src/plugins/size-plugin.ts
@@ -25,7 +25,8 @@ function chunkSizeCollector(): {
           const dir = options.dir || (options.file && path.dirname(options.file))
           let fileName = chunk.fileName
           if (dir) {
-            fileName = path.relative(cwd, path.join(dir, fileName))
+            const filePath = path.join(dir, fileName)
+            fileName = filePath.startsWith(cwd) ? path.relative(cwd, filePath) : filePath
           }
           addSize(fileName, code.length)
           return null

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,7 +98,10 @@ type ParsedExportCondition = {
   export: FullExportCondition
 }
 
+type ExportPaths = Record<string, FullExportCondition>
+
 export type {
+  ExportPaths,
   ExportType,
   CliArgs,
   BundleConfig,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,26 @@
 import type { JscTarget } from '@swc/core'
 import type { InputOptions, OutputOptions, RollupOptions } from 'rollup'
 
-type ExportType = 'require' | 'export' | 'default' | string // omit other names
+type PackageType = 'commonjs' | 'module'
+
+type ExportType =
+  | 'import'
+  | 'module'
+  | 'require'
+  | 'default'
+  | 'node'
+  | 'react-server'
+  | 'react-native'
+  | 'browser'
+  | 'edge-light'
+
+type FullExportCondition = {
+  [key: string]: string
+}
+
+type ExportCondition = string | {
+  [key: string]: ExportCondition | string
+}
 
 // configs which are normalized from cli args
 type BundleConfig = {
@@ -18,7 +37,7 @@ type BundleConfig = {
   dts?: boolean
   runtime?: string
 
-  // assigned extra config
+  // assigned extra config, default is '.' export
   exportCondition?: {
     source: string // detected source file
     name: string // export condition name
@@ -39,7 +58,6 @@ type PackageMetadata = {
   typings?: string
 }
 
-type ExportCondition = string | Record<ExportType, string>
 
 type BuncheeRollupConfig = Partial<Omit<RollupOptions, 'input' | 'output'>> & {
   exportName?: string
@@ -73,13 +91,22 @@ type BuildMetadata = {
   source: string
 }
 
+type ParsedExportCondition = {
+  source: string
+  name: string
+  export: FullExportCondition
+}
+
 export type {
-  CliArgs,
   ExportType,
+  CliArgs,
   BundleConfig,
   BundleOptions,
   ExportCondition,
   PackageMetadata,
   BuildMetadata,
-  BuncheeRollupConfig
+  FullExportCondition,
+  BuncheeRollupConfig,
+  PackageType,
+  ParsedExportCondition,
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,13 +37,6 @@ type BundleConfig = {
   env?: string[]
   dts?: boolean
   runtime?: string
-
-  // assigned extra config, default is '.' export
-  exportCondition?: {
-    source: string // detected source file
-    name: string // export condition name
-    export: ExportCondition // export condition value
-  }
 }
 
 type PackageMetadata = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ type ExportType =
   | 'react-native'
   | 'browser'
   | 'edge-light'
+  | 'types'
 
 type FullExportCondition = {
   [key: string]: string

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -76,24 +76,26 @@ const testCases: {
         join(dir, './dist/client/index.mjs'),
 
         // types
-        join(dir, './dist/client.d.ts'),
+        join(dir, './dist/client/index.d.ts'),
         join(dir, './dist/index.d.ts'),
         join(dir, './dist/lite.d.ts'),
       ]
 
       for (const f of distFiles) {
+        const ext = await existsFile(f)
+        if (!ext) console.log('missing', f)
         expect(await existsFile(f)).toBe(true)
       }
 
       const log = `\
-      ✓  Typed dist/client.d.ts      - 74 B
-      ✓  Typed dist/index.d.ts       - 65 B
-      ✓  Typed dist/lite.d.ts        - 70 B
-      ✓  Typed dist/client.d.ts      - 74 B
-      ✓  Built dist/index.js         - 110 B
-      ✓  Built dist/lite.js          - 132 B
-      ✓  Built dist/client/index.cjs - 138 B
-      ✓  Built dist/client/index.mjs - 78 B`
+      ✓  Typed dist/lite.d.ts         - 70 B
+      ✓  Typed dist/index.d.ts        - 65 B
+      ✓  Typed dist/client/index.d.ts - 74 B
+      ✓  Built dist/client/index.cjs  - 138 B
+      ✓  Built dist/client/index.mjs  - 78 B
+      ✓  Built dist/lite.js           - 132 B
+      ✓  Built dist/index.js          - 110 B
+      `
 
       const rawStdout = stripANSIColor(stdout)
       log.split('\n').forEach((line: string) => {
@@ -109,11 +111,12 @@ const testCases: {
       for (const f of distFiles) {
         expect(await existsFile(f)).toBe(true)
       }
+      expect(await fs.readFile(distFiles[0], 'utf-8')).toContain(`Object.defineProperty(exports, '__esModule', { value: true });`)
       expect(await fs.readFile(distFiles[1], 'utf-8')).toContain('declare const _default: () => string;')
 
       const log = `\
-      ✓  Typed dist/index.d.ts - 70 B
-      ✓  Built dist/index.js   - 56 B`
+      ✓  Typed dist/index.d.ts -
+      ✓  Built dist/index.js   -`
 
       const rawStdout = stripANSIColor(stdout)
       log.split('\n').forEach((line: string) => {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -12,7 +12,10 @@ const getPath = (filepath: string) => join(integrationTestDir, filepath)
 const testCases: {
   name: string
   args: string[]
-  expected(f: string, { stderr, stdout }: { stderr: string; stdout: string }): void
+  expected(
+    f: string,
+    { stderr, stdout }: { stderr: string; stdout: string }
+  ): void
 }[] = [
   // TODO: test externals/sub-path-export
   {
@@ -46,7 +49,11 @@ const testCases: {
     name: 'pkg-exports',
     args: ['index.js'],
     async expected(dir) {
-      const distFiles = [join(dir, './dist/index.cjs'), join(dir, './dist/index.mjs'), join(dir, './dist/index.esm.js')]
+      const distFiles = [
+        join(dir, './dist/index.cjs'),
+        join(dir, './dist/index.mjs'),
+        join(dir, './dist/index.esm.js'),
+      ]
       for (const f of distFiles) {
         expect(await existsFile(f)).toBe(true)
       }
@@ -56,13 +63,22 @@ const testCases: {
     name: 'pkg-exports-default',
     args: ['index.js'],
     async expected(dir) {
-      const distFiles = [join(dir, './dist/index.cjs'), join(dir, './dist/index.mjs')]
+      const distFiles = [
+        join(dir, './dist/index.cjs'),
+        join(dir, './dist/index.mjs'),
+      ]
       for (const f of distFiles) {
         expect(await existsFile(f)).toBe(true)
       }
-      const cjsFile = await fs.readFile(join(dir, './dist/index.cjs'), { encoding: 'utf-8' })
-      expect(cjsFile).toContain(`function _interopDefault (e) { return e && e.__esModule ? e : { default: e }; }`)
-      expect(cjsFile).toContain(`Object.defineProperty(exports, '__esModule', { value: true });`)
+      const cjsFile = await fs.readFile(join(dir, './dist/index.cjs'), {
+        encoding: 'utf-8',
+      })
+      expect(cjsFile).toContain(
+        `function _interopDefault (e) { return e && e.__esModule ? e : { default: e }; }`
+      )
+      expect(cjsFile).toContain(
+        `Object.defineProperty(exports, '__esModule', { value: true });`
+      )
     },
   },
   {
@@ -74,6 +90,8 @@ const testCases: {
         join(dir, './dist/lite.js'),
         join(dir, './dist/client/index.cjs'),
         join(dir, './dist/client/index.mjs'),
+        join(dir, './dist/edge.server/index.mjs'),
+        join(dir, './dist/edge.server/react-server.mjs'),
 
         // types
         join(dir, './dist/client/index.d.ts'),
@@ -88,13 +106,15 @@ const testCases: {
       }
 
       const log = `\
-      ✓  Typed dist/lite.d.ts         - 70 B
-      ✓  Typed dist/index.d.ts        - 65 B
-      ✓  Typed dist/client/index.d.ts - 74 B
-      ✓  Built dist/client/index.cjs  - 138 B
-      ✓  Built dist/client/index.mjs  - 78 B
-      ✓  Built dist/lite.js           - 132 B
-      ✓  Built dist/index.js          - 110 B
+      ✓  Typed dist/index.d.ts                   - 65 B
+      ✓  Typed dist/client/index.d.ts            - 74 B
+      ✓  Typed dist/edge.server.d.ts             - 53 B
+      ✓  Built dist/edge.server/index.mjs        - 45 B
+      ✓  Built dist/edge.server/react-server.mjs - 45 B
+      ✓  Built dist/lite.js                      - 132 B
+      ✓  Built dist/index.js                     - 110 B
+      ✓  Built dist/client/index.cjs             - 138 B
+      ✓  Built dist/client/index.mjs             - 78 B
       `
 
       const rawStdout = stripANSIColor(stdout)
@@ -107,12 +127,19 @@ const testCases: {
     name: 'single-entry',
     args: [],
     async expected(dir, { stdout }) {
-      const distFiles = [join(dir, './dist/index.js'), join(dir, './dist/index.d.ts')]
+      const distFiles = [
+        join(dir, './dist/index.js'),
+        join(dir, './dist/index.d.ts'),
+      ]
       for (const f of distFiles) {
         expect(await existsFile(f)).toBe(true)
       }
-      expect(await fs.readFile(distFiles[0], 'utf-8')).toContain(`Object.defineProperty(exports, '__esModule', { value: true });`)
-      expect(await fs.readFile(distFiles[1], 'utf-8')).toContain('declare const _default: () => string;')
+      expect(await fs.readFile(distFiles[0], 'utf-8')).toContain(
+        `Object.defineProperty(exports, '__esModule', { value: true });`
+      )
+      expect(await fs.readFile(distFiles[1], 'utf-8')).toContain(
+        'declare const _default: () => string;'
+      )
 
       const log = `\
       ✓  Typed dist/index.d.ts -
@@ -128,21 +155,30 @@ const testCases: {
     name: 'ts-allow-js',
     args: [],
     async expected(dir) {
-      const distFiles = [join(dir, './dist/index.js'), join(dir, './dist/index.d.ts')]
+      const distFiles = [
+        join(dir, './dist/index.js'),
+        join(dir, './dist/index.d.ts'),
+      ]
       for (const f of distFiles) {
         expect(await existsFile(f)).toBe(true)
       }
-      expect(await fs.readFile(distFiles[1], 'utf-8')).toContain('declare function _default(): string;')
-    }
+      expect(await fs.readFile(distFiles[1], 'utf-8')).toContain(
+        'declare function _default(): string;'
+      )
+    },
   },
   {
     name: 'publint',
     args: [],
     expected(dir, { stdout }) {
       const text = stripANSIColor(stdout)
-      expect(text).toContain('pkg.types is ./dist/missing.d.ts but the file does not exist.')
-      expect(text).toContain('pkg.exports["."].types is ./dist/missing.d.ts but the file does not exist.')
-    }
+      expect(text).toContain(
+        'pkg.types is ./dist/missing.d.ts but the file does not exist.'
+      )
+      expect(text).toContain(
+        'pkg.exports["."].types is ./dist/missing.d.ts but the file does not exist.'
+      )
+    },
   },
 ]
 
@@ -151,7 +187,11 @@ async function runBundle(
   _args: string[]
 ): Promise<{ code: number | null; stdout: string; stderr: string }> {
   const args = _args.concat(['--cwd', dir])
-  const ps = fork(`${__dirname + '/../node_modules/.bin/tsx'}`, [__dirname + '/../src/cli.ts'].concat(args), { stdio: 'pipe' })
+  const ps = fork(
+    `${__dirname + '/../node_modules/.bin/tsx'}`,
+    [__dirname + '/../src/cli.ts'].concat(args),
+    { stdio: 'pipe' }
+  )
   let stderr = '',
     stdout = ''
   ps.stdout?.on('data', (chunk: any) => (stdout += chunk.toString()))
@@ -172,7 +212,8 @@ function runTests() {
     const { name, args, expected } = testCase
     const dir = getPath(name)
     test(`integration ${name}`, async () => {
-      if (process.env.TEST_DEBUG) console.log(`Command: bunchee ${args.join(' ')}`)
+      if (process.env.TEST_DEBUG)
+        console.log(`Command: bunchee ${args.join(' ')}`)
       execSync(`rm -rf ${join(dir, 'dist')}`)
       const { stdout, stderr } = await runBundle(dir, args)
       if (process.env.TEST_DEBUG) {

--- a/test/integration/multi-entries/package.json
+++ b/test/integration/multi-entries/package.json
@@ -7,7 +7,8 @@
     "./lite": "./dist/lite.js",
     "./client": {
       "require": "./dist/client/index.cjs",
-      "import": "./dist/client/index.mjs"
+      "import": "./dist/client/index.mjs",
+      "types": "./dist/client/index.d.ts"
     }
   }
 }

--- a/test/integration/multi-entries/package.json
+++ b/test/integration/multi-entries/package.json
@@ -9,6 +9,10 @@
       "require": "./dist/client/index.cjs",
       "import": "./dist/client/index.mjs",
       "types": "./dist/client/index.d.ts"
+    },
+    "./edge.server": {
+      "edge-light": "./dist/edge.server/index.mjs",
+      "react-server": "./dist/edge.server/react-server.mjs"
     }
   }
 }

--- a/test/integration/multi-entries/src/edge.server.ts
+++ b/test/integration/multi-entries/src/edge.server.ts
@@ -1,0 +1,1 @@
+export const name = 'edge.server'

--- a/test/lib/exports.test.ts
+++ b/test/lib/exports.test.ts
@@ -1,0 +1,123 @@
+import type { PackageMetadata } from 'src/types'
+import path from 'path'
+import { getExportPaths, getExportConditionDist } from '../../src/exports'
+
+describe('lib exports', () => {
+  describe('getExportPaths', () => {
+    it('should handle the basic main fields paths (cjs)', () => {
+      const pkg = {
+        main: './dist/index.cjs',
+        module: './dist/index.esm.js',
+      }
+      const result = getExportPaths(pkg)
+      expect(result).toEqual({
+        '.': {
+          require: './dist/index.cjs',
+          module: './dist/index.esm.js',
+        },
+      })
+    })
+
+    it('should handle the basic main fields paths (esm)', () => {
+      const pkg: PackageMetadata = {
+        type: 'module',
+        main: './dist/index.mjs',
+        module: './dist/index.esm.js',
+      }
+      const result = getExportPaths(pkg)
+      expect(result).toEqual({
+        '.': {
+          import: './dist/index.mjs',
+          module: './dist/index.esm.js',
+        },
+      })
+    })
+
+    it('should handle the exports conditions', () => {
+      expect(
+        getExportPaths({
+          exports: {
+            '.': {
+              require: './dist/index.cjs',
+              module: './dist/index.esm.js',
+              default: './dist/index.esm.js',
+            },
+          },
+        })
+      ).toEqual({
+        '.': {
+          require: './dist/index.cjs',
+          module: './dist/index.esm.js',
+          default: './dist/index.esm.js',
+        },
+      })
+
+      expect(
+        getExportPaths({
+          exports: {
+            '.': {
+              import: './dist/index.mjs',
+              require: './dist/index.cjs',
+            },
+          },
+        })
+      ).toEqual({
+        '.': {
+          import: './dist/index.mjs',
+          require: './dist/index.cjs',
+        },
+      })
+    })
+
+    it('should handle the mixed exports conditions', () => {
+      const pkg = {
+        main: './dist/index.cjs',
+        exports: {
+          '.': {
+            sub: {
+              require: './dist/index.cjs',
+            },
+          },
+        },
+      }
+      const result = getExportPaths(pkg)
+      expect(result).toEqual({
+        '.': {
+          require: './dist/index.cjs',
+        },
+        './sub': {
+          require: './dist/index.cjs',
+        },
+      })
+    })
+  })
+
+  describe('getExportConditionDist', () => {
+    function getExportConditionDistHelper(
+      pkg: PackageMetadata,
+      exportName: string = '.'
+    ) {
+      const parsedExportCondition = getExportPaths(pkg)
+      const parsedExport = {
+        source: `./src/${exportName === '.' ? 'index' : exportName}.ts`,
+        name: exportName,
+        export: parsedExportCondition[exportName],
+      }
+      // Get only basename to skip path.resolve result for `file` property
+      return getExportConditionDist(pkg, parsedExport, '')
+        .map((item) => ({ ...item, file: path.basename(item.file) }))
+    }
+
+    it('should dedupe the same path import and module if they are the same path', () => {
+      const pkg: PackageMetadata = {
+        type: 'module',
+        main: './dist/index.mjs',
+        module: './dist/index.mjs',
+      }
+
+      expect(getExportConditionDistHelper(pkg)).toEqual([
+        { file: 'index.mjs', format: 'esm' },
+      ])
+    })
+  })
+})

--- a/test/lib/exports.test.ts
+++ b/test/lib/exports.test.ts
@@ -153,5 +153,22 @@ describe('lib exports', () => {
         { file: 'index.mjs', format: 'esm' },
       ])
     })
+
+    it('should handle special exports', () => {
+      const pkg: PackageMetadata = {
+        exports: {
+          '.': {
+            'require': './dist/index.cjs',
+            'edge-light': './dist/index.mjs',
+            'react-server': './dist/index.mjs',
+          }
+        }
+      }
+
+      expect(getExportConditionDistHelper(pkg)).toEqual([
+        { file: 'index.cjs', format: 'cjs' },
+        { file: 'index.mjs', format: 'esm' },
+      ])
+    })
   })
 })

--- a/test/lib/exports.test.ts
+++ b/test/lib/exports.test.ts
@@ -18,6 +18,40 @@ describe('lib exports', () => {
       })
     })
 
+    it('should handle types field', () => {
+      expect(
+        getExportPaths({
+          exports: {
+            '.': {
+              import: './dist/index.mjs',
+              types: './dist/index.d.ts',
+            },
+          },
+        })
+      ).toEqual({
+        '.': {
+          import: './dist/index.mjs',
+          types: './dist/index.d.ts',
+        },
+      })
+
+      expect(
+        getExportPaths({
+          typings: './dist/index.d.ts',
+          exports: {
+            '.': {
+              import: './dist/index.mjs',
+            },
+          },
+        })
+      ).toEqual({
+        '.': {
+          import: './dist/index.mjs',
+          types: './dist/index.d.ts',
+        },
+      })
+    })
+
     it('should handle the basic main fields paths (esm)', () => {
       const pkg: PackageMetadata = {
         type: 'module',


### PR DESCRIPTION
* Parse recursively to get the exports path mapping
* support more fields (browser/node/default/edge-light/react-server/...)

resolves #203 