### PR TITLE
Conventional entry for special platform exports

### DIFF
--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -83,7 +83,7 @@ async function bundle(
     // e.g. "exports": "./dist/index.js" -> use "./index.<ext>" as entry
     entryPath =
       entryPath ||
-      (await getSourcePathFromExportPath(cwd, '.')) ||
+      (await getSourcePathFromExportPath(cwd, '.', 'default')) ||
       ''
   }
 

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -1,5 +1,5 @@
 import type { PackageMetadata, ExportCondition, FullExportCondition, PackageType, ParsedExportCondition } from './types'
-import { join, resolve, dirname } from 'path'
+import { join, resolve, dirname, extname } from 'path'
 import { filenameWithoutExtension } from './utils'
 
 export function getTypings(pkg: PackageMetadata) {
@@ -210,12 +210,12 @@ export function constructDefaultExportCondition(
   )
 }
 
-export function isEsmExportName(name: string) {
-  return ['import', 'module', 'react-native', 'react-server', 'edge-light'].includes(name)
+export function isEsmExportName(name: string, ext: string) {
+  return ['import', 'module'].includes(name) || ext === 'mjs'
 }
 
-export function isCjsExportName(name: string) {
-  return ['require', 'main', 'node', 'default'].includes(name)
+export function isCjsExportName(name: string, ext: string) {
+  return ['require', 'main', 'node', 'default'].includes(name) || ext === 'cjs'
 }
 
 export function getExportConditionDist(
@@ -231,13 +231,15 @@ export function getExportConditionDist(
     if (key === 'types') {
       continue
     }
+    const filePath = parsedExportCondition.export[key]
+    const ext = extname(filePath).slice(1)
     const relativePath = parsedExportCondition.export[key]
     const distFile = getDistPath(relativePath, cwd)
 
     let format: 'cjs' | 'esm' = 'esm'
-    if (isEsmExportName(key)) {
+    if (isEsmExportName(key, ext)) {
       format = 'esm'
-    } else if (isCjsExportName(key)) {
+    } else if (isCjsExportName(key, ext)) {
       format = 'cjs'
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,7 +32,7 @@ export const logger = {
     console.log('\x1b[33m' + arg + '\x1b[0m')
   },
   error(arg: any) {
-    console.error('\x1b[31m' + arg + '\x1b[0m')
+    console.error('\x1b[31m' + (arg instanceof Error ? arg.stack : arg) + '\x1b[0m')
   },
 }
 
@@ -67,20 +67,57 @@ const SRC = 'src' // resolve from src/ directory
 export function resolveSourceFile(cwd: string, filename: string) {
   return path.resolve(cwd, SRC, filename)
 }
+
+async function findSourceEntryFile(
+  cwd: string,
+  exportPath: string,
+  exportTypeSuffix: string | null,
+  ext: string
+): Promise<string | undefined> {
+  const filename = resolveSourceFile(
+    cwd,
+    `${exportPath}${exportTypeSuffix ? `.${exportTypeSuffix}` : ''}.${ext}`
+  )
+
+  if (await fileExists(filename)) {
+    return filename
+  }
+
+  const subFolderIndexFilename = resolveSourceFile(
+    cwd,
+    `${exportPath}/index${exportTypeSuffix ? `.${exportTypeSuffix}` : ''}.${ext}`
+  )
+
+  if (await fileExists(subFolderIndexFilename)) {
+    return subFolderIndexFilename
+  }
+  return undefined
+}
+
+
 // Map '.' -> './index.[ext]'
 // Map './lite' -> './lite.[ext]'
 // Return undefined if no match or if it's package.json exports
-export async function getSourcePathFromExportPath(cwd: string, exportPath: string): Promise<string | undefined> {
-  const exts = ['js', 'cjs', 'mjs', 'jsx', 'ts', 'tsx']
-  for (const ext of exts) {
+export const availableExtensions = ['js', 'cjs', 'mjs', 'jsx', 'ts', 'tsx']
+export const availableExportConventions = ['react-server', 'react-native', 'edge-light']
+export async function getSourcePathFromExportPath(
+  cwd: string,
+  exportPath: string,
+  exportType: string
+): Promise<string | undefined> {
+  for (const ext of availableExtensions) {
     // ignore package.json
     if (exportPath.endsWith('package.json')) return
     if (exportPath === '.') exportPath = './index'
-    const filename = resolveSourceFile(cwd, `${exportPath}.${ext}`)
 
-    if (await fileExists(filename)) {
-      return filename
+    // Find convention-based source file for specific export types
+    if (availableExportConventions.includes(exportType)) {
+      const filename = await findSourceEntryFile(cwd, exportPath, exportType, ext)
+      if (filename) return filename
     }
+
+    const filename = await findSourceEntryFile(cwd, exportPath, null, ext)
+    if (filename) return filename
   }
   return
 }
@@ -91,3 +128,5 @@ export function filenameWithoutExtension(file: string | undefined) {
     ? file.replace(new RegExp(`${path.extname(file)}$`), '')
     : undefined
 }
+
+export const nonNullable = <T>(n?: T): n is T => Boolean(n)

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -87,31 +87,53 @@ const testCases: {
     args: [],
     async expected(dir, { stdout }) {
       const distFiles = [
-        join(dir, './dist/index.js'),
-        join(dir, './dist/lite.js'),
-        join(dir, './dist/client/index.cjs'),
-        join(dir, './dist/client/index.mjs'),
-        join(dir, './dist/edge.server/index.mjs'),
-        join(dir, './dist/edge.server/react-server.mjs'),
+        './dist/index.js',
+        './dist/lite.js',
+        './dist/client/index.cjs',
+        './dist/client/index.mjs',
+        './dist/shared/index.mjs',
+        './dist/shared/edge-light.mjs',
+        './dist/server/edge.mjs',
+        './dist/server/react-server.mjs',
 
         // types
-        join(dir, './dist/client/index.d.ts'),
-        join(dir, './dist/index.d.ts'),
+        './dist/client/index.d.ts',
+        './dist/index.d.ts',
       ]
 
-      for (const f of distFiles) {
-        expect({ [f]: await existsFile(f) ? 'existed' : 'missing' }).toMatchObject({ [f]: 'existed' })
+      const contentsRegex = {
+        './dist/index.js': /'index'/,
+        './dist/shared/index.mjs': /'shared'/,
+        './dist/shared/edge-light.mjs': /'shared.edge-light'/,
+        './dist/server/edge.mjs': /'server.edge-light'/,
+        './dist/server/react-server.mjs': /'server.react-server'/,
+      }
+
+      for (const relativeFile of distFiles) {
+        const file = join(dir, relativeFile)
+        expect({
+          [file]: await existsFile(file) ? 'existed' : 'missing'
+        }).toMatchObject({ [file]: 'existed' })
+      }
+
+      for (const [file, regex] of Object.entries(contentsRegex)) {
+        const content = await fs.readFile(join(dir, file), {
+          encoding: 'utf-8',
+        })
+        expect(content).toMatch(regex)
       }
 
       const log = `\
-      ✓  Typed dist/index.d.ts                   - 65 B
-      ✓  Typed dist/client/index.d.ts            - 74 B
-      ✓  Built dist/index.js                     - 110 B
-      ✓  Built dist/client/index.cjs             - 138 B
-      ✓  Built dist/client/index.mjs             - 78 B
-      ✓  Built dist/edge.server/index.mjs        - 45 B
-      ✓  Built dist/edge.server/react-server.mjs - 45 B
-      ✓  Built dist/lite.js                      - 132 B
+      ✓  Typed dist/client/index.d.ts       - 74 B
+      ✓  Typed dist/index.d.ts              - 65 B
+      ✓  Built dist/client/index.cjs        - 138 B
+      ✓  Built dist/client/index.mjs        - 78 B
+      ✓  Built dist/index.js                - 110 B
+      ✓  Built dist/shared/index.mjs        - 53 B
+      ✓  Built dist/lite.js                 - 132 B
+      ✓  Built dist/shared/edge-light.mjs   - 84 B
+      ✓  Built dist/server/react-server.mjs - 53 B
+      ✓  Built dist/server/edge.mjs         - 51 B
       `
 
       const rawStdout = stripANSIColor(stdout)

--- a/test/integration/multi-entries/package.json
+++ b/test/integration/multi-entries/package.json
@@ -10,9 +10,13 @@
       "import": "./dist/client/index.mjs",
       "types": "./dist/client/index.d.ts"
     },
-    "./edge.server": {
-      "edge-light": "./dist/edge.server/index.mjs",
-      "react-server": "./dist/edge.server/react-server.mjs"
+    "./shared": {
+      "import": "./dist/shared/index.mjs",
+      "edge-light": "./dist/shared/edge-light.mjs"
+    },
+    "./server": {
+      "edge-light": "./dist/server/edge.mjs",
+      "react-server": "./dist/server/react-server.mjs"
     }
   }
 }

--- a/test/integration/multi-entries/src/edge.server.ts
+++ b/test/integration/multi-entries/src/edge.server.ts
@@ -1,1 +1,0 @@
-export const name = 'edge.server'

--- a/test/integration/multi-entries/src/server/index.edge-light.ts
+++ b/test/integration/multi-entries/src/server/index.edge-light.ts
@@ -1,0 +1,1 @@
+export const name = 'server.edge-light'

--- a/test/integration/multi-entries/src/server/index.react-server.ts
+++ b/test/integration/multi-entries/src/server/index.react-server.ts
@@ -1,0 +1,1 @@
+export const name = 'server.react-server'

--- a/test/integration/multi-entries/src/shared.edge-light.ts
+++ b/test/integration/multi-entries/src/shared.edge-light.ts
@@ -1,0 +1,1 @@
+export default 'shared.edge-light'

--- a/test/integration/multi-entries/src/shared.ts
+++ b/test/integration/multi-entries/src/shared.ts
@@ -1,0 +1,1 @@
+export default 'shared'


### PR DESCRIPTION
## New convention for convenience

For special platform that potential could have different entry file such as `react-server`, `edge-light` or `react-native` as they could contain their own thing or could potentially have different exports.

So bunchee provides a new convention `index.[export-type].js` to override the special exports

For instance, you have `index.js` as entry file for `exports.import` and `exports.require`. But you wanna use a similar entry file which is slightly different that doesn't contain some exports for `exports.react-server` condition.

```js
"exports": {
  "import": "./dist/index.mjs",
  "react-server": "./dist/react-server.mjs",
}
```

For `index.js` you might export stuffs that both available for client and server
```js
// ./dist/index.mjs
export const name = 'name'
export function useClientState(state) {
  return React.useState('prefix:' + state)
}
```

For `react-server` condition which could be picked by for react server components (RSC), and which only contain RSC available stuffs, which could exclude the hooks work for client 

```js
./dist/react-server.mjs
export const name = 'name'
```

Then you can use `index.react-server.js` to override the default input file

### Other Updates

* Detect the output based on the dist file name (will use CommonJS output for `.cjs` extensions, use ESM for '.mjs')
* Besides detecting entry file besides `src/<export>.js`, also detect the index file in the folder like `src/<export>/index.js`. This will also cover the new convention case above, e.g. `src/<export>/index.react-server.js`