### PR TITLE
Update target

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "./dist",
-    "target": "es2015",
+    "target": "ES2019",
     "module": "CommonJS",
     "lib": ["ES6"],
     "moduleResolution": "node",


### PR DESCRIPTION
bunchee requires node >= 16, which supports at least > ES2019 according to [this map](https://kangax.github.io/compat-table/es2016plus/#node16_11)


