### PR TITLE
Remove duplicated exports warning

### DIFF
--- a/src/exports.ts
+++ b/src/exports.ts
@@ -172,9 +172,9 @@ export function getExportPaths(pkg: PackageMetadata) {
   const pathsMap: Record<string, FullExportCondition> = {}
   const packageType = getPackageType(pkg)
   const isCjsPackage = packageType === 'commonjs'
-  
+
   const { exports: exportsConditions } = pkg
-  
+
   if (exportsConditions) {
     const paths = parseExport(exportsConditions, packageType)
     Object.assign(pathsMap, paths)
@@ -189,14 +189,10 @@ export function getExportPaths(pkg: PackageMetadata) {
     },
     packageType,
   )
-  
+
   if (isCjsPackage && pathsMap['.']?.['require']) {
     // pathsMap's exports.require are prioritized.
     defaultMainExport['require'] = pathsMap['.']['require']
-
-    console.warn(
-      `(warning) "exports.require" has overwritten "main" since they are duplicated.`,
-    )
   }
 
   // Merge the main export into '.' paths


### PR DESCRIPTION
As we already normalized the `exports` info mation so that it's hard to determine if the `pathsMap['.']?.['require']` is from `package.main` or `exports` field, let's remove this for now and re-add it later properly with detecting if both exists and conflicts

Closes #238 