### PR TITLE
Fix commonjs bundle

### DIFF
--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -76,7 +76,8 @@ function buildInputConfig(
   { tsConfigPath, tsCompilerOptions }: TypescriptOptions,
   dts: boolean,
 ): InputOptions {
-  const externals = options.noExternal
+  const hasNoExternal = options.external === null
+  const externals = hasNoExternal
     ? []
     : [pkg.peerDependencies, pkg.dependencies, pkg.peerDependenciesMeta]
         .filter(<T>(n?: T): n is T => Boolean(n))
@@ -158,7 +159,7 @@ function buildInputConfig(
             extensions: ['.mjs', '.cjs', '.js', '.json', '.node', '.jsx'],
           }),
           commonjs({
-            include: /node_modules\//,
+            exclude: options.external || null,
           }),
           json(),
           wasm(),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -129,7 +129,7 @@ async function run(args: CliArgs) {
     cwd,
     target,
     runtime,
-    external: args.external?.split(',') || [],
+    external: args.external === null ? null : (args.external?.split(',') || []),
     watch: !!watch,
     minify: !!minify,
     sourcemap: sourcemap === false ? false : true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,8 +34,7 @@ type BundleConfig = {
   format?: OutputOptions['format']
   minify?: boolean
   sourcemap?: boolean
-  external?: string[]
-  noExternal?: boolean
+  external?: string[] | null
   env?: string[]
   dts?: boolean
   runtime?: string
@@ -75,7 +74,6 @@ type CliArgs = {
   external?: string
   dts?: boolean
   runtime?: string
-  noExternal?: boolean
 }
 
 type BundleOptions = BundleConfig & {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -242,6 +242,24 @@ const testCases: {
       ]
     },
   },
+  {
+    name: 'cjs-relative-imports',
+    dist: createTempDir,
+    args: [
+      '--cwd',
+      path.join(fixturesDir, './cjs-relative-imports'),
+      '-o',
+      './dist/index.js',
+      './index.js',
+    ],
+    expected(distFile) {
+      const content = fs.readFileSync(distFile, { encoding: 'utf-8' })
+      return [
+        [content.includes('dot-js-dep'), true],
+        [content.includes('dot-cjs-dep'), true],
+      ]
+    }
+  }
 ]
 
 describe('cli', () => {

--- a/test/fixtures/cjs-relative-imports/cjs-dep.cjs
+++ b/test/fixtures/cjs-relative-imports/cjs-dep.cjs
@@ -1,0 +1,1 @@
+module.exports = 'dot-cjs-dep'

--- a/test/fixtures/cjs-relative-imports/index.js
+++ b/test/fixtures/cjs-relative-imports/index.js
@@ -1,0 +1,5 @@
+const jsDep = require('./js-dep')
+const cjsDep = require('./cjs-dep')
+
+exports.jsDep = jsDep
+exports.cjsDep = cjsDep

--- a/test/fixtures/cjs-relative-imports/js-dep.js
+++ b/test/fixtures/cjs-relative-imports/js-dep.js
@@ -1,0 +1,1 @@
+module.exports = 'dot-js-dep'


### PR DESCRIPTION
Closes #254 

* Fix `commonjs` plugin reoslving, should respect to `externals` dependency
* Fix `externals` passing down logic