### PR TITLE
Error on invalid main field export

### DIFF
--- a/src/exports.ts
+++ b/src/exports.ts
@@ -6,7 +6,7 @@ import type {
   PackageType,
   ParsedExportCondition,
 } from './types'
-import { filenameWithoutExtension } from './utils'
+import { exit, filenameWithoutExtension, hasCjsExtension } from './utils'
 
 export function getTypings(pkg: PackageMetadata) {
   return pkg.types || pkg.typings
@@ -183,6 +183,10 @@ export function getExportPaths(
   if (exportsConditions) {
     const paths = parseExport(exportsConditions, packageType)
     Object.assign(pathsMap, paths)
+  }
+
+  if (!isCjsPackage && pkg.main && hasCjsExtension(pkg.main)) {
+    exit('Cannot export main field with .cjs extension in ESM package, only .mjs and .js extensions are allowed')
   }
 
   // main export '.' from main/module/typings

--- a/src/lib/wildcard.ts
+++ b/src/lib/wildcard.ts
@@ -8,6 +8,7 @@ import {
   hasAvailableExtension,
   nonNullable,
 } from '../utils'
+import { logger } from '../logger'
 
 // TODO: support nested wildcard exportsCondition (e.g. './foo/*')
 const getWildcardExports = (
@@ -84,7 +85,7 @@ export async function resolveWildcardExports(
   const hasWildcard = !!exportsCondition['./*']
 
   if (hasWildcard) {
-    console.warn(
+    logger.warn(
       `The wildcard export "./*" is experimental and may change or be removed at any time.\n` +
         'To open an issue, please visit https://github.com/huozhi/bunchee/issues' +
         '.\n',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -139,3 +139,6 @@ export const fileExtension = (file: string | undefined) =>
 
 export const hasAvailableExtension = (filename: string): boolean =>
   availableExtensions.includes(path.extname(filename).slice(1))
+
+export const hasCjsExtension = (filename: string): boolean =>
+  path.extname(filename) === '.cjs'

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -284,6 +284,15 @@ const testCases: {
       expect(stderr).toContain(log)
     },
   },
+  {
+    name: 'esm-pkg-cjs-main-field',
+    args: [],
+    async expected(_, { stderr }) {
+      expect(stderr).toContain(
+        'Cannot export main field with .cjs extension in ESM package, only .mjs and .js extensions are allowed',
+      )
+    }
+  }
 ]
 
 async function runBundle(

--- a/test/integration/esm-pkg-cjs-main-field/package.json
+++ b/test/integration/esm-pkg-cjs-main-field/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "main": "./dist/index.cjs"
+}

--- a/test/integration/esm-pkg-cjs-main-field/src/index.cjs
+++ b/test/integration/esm-pkg-cjs-main-field/src/index.cjs
@@ -1,0 +1,1 @@
+exports.value = 'cjs'


### PR DESCRIPTION
Shouldn't configure a cjs file in `main` filed when package is marked as esm module. Give an error for this case

Closes #268 