### PR TITLE
Fix ts configuration reoslving

### DIFF
--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -8,8 +8,8 @@ import type {
   FullExportCondition,
 } from './types'
 import type { InputOptions, OutputOptions, Plugin } from 'rollup'
-import { convertCompilerOptions, type TypescriptOptions } from './typescript'
-import type { CompilerOptions } from 'typescript'
+import { type TypescriptOptions } from './typescript'
+
 import { resolve, dirname } from 'path'
 import { wasm } from '@rollup/plugin-wasm'
 import { swc } from 'rollup-plugin-swc3'
@@ -123,7 +123,7 @@ async function buildInputConfig(
   // common plugins for both dts and ts assets that need to be processed
   const commonPlugins = [sizePlugin]
 
-  const baseResolvedTsOptions: CompilerOptions = {
+  const baseResolvedTsOptions: any = {
     declaration: true,
     noEmit: false,
     noEmitOnError: true,
@@ -133,6 +133,9 @@ async function buildInputConfig(
     skipLibCheck: true,
     preserveSymlinks: false,
     incremental: false,
+    target: 'esnext',
+    module: 'esnext',
+    jsx: tsCompilerOptions.jsx || 'react',
   }
 
   const typesPlugins = [
@@ -141,17 +144,11 @@ async function buildInputConfig(
   ]
 
   if (useTypescript) {
-    const { options: resolvedTsOptions } = await convertCompilerOptions(cwd, {
-      ...baseResolvedTsOptions,
-      target: 'esnext',
-      module: 'esnext',
-      jsx: tsCompilerOptions.jsx || 'react',
-    })
     const dtsPlugin = (require('rollup-plugin-dts') as typeof import('rollup-plugin-dts')).default({
       tsconfig: tsConfigPath,
       compilerOptions: {
+        ...baseResolvedTsOptions,
         ...tsCompilerOptions,
-        ...resolvedTsOptions,
       },
     })
     typesPlugins.push(dtsPlugin)

--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -8,7 +8,7 @@ import type {
   FullExportCondition,
 } from './types'
 import type { InputOptions, OutputOptions, Plugin } from 'rollup'
-import { convertCompilerOptions, type TypescriptOptions } from './typescript'
+import { type TypescriptOptions } from './typescript'
 
 import { resolve, dirname } from 'path'
 import { wasm } from '@rollup/plugin-wasm'
@@ -154,7 +154,10 @@ async function buildInputConfig(
 
     // error TS5074: Option '--incremental' can only be specified using tsconfig, emitting to single
     // file or when option '--tsBuildInfoFile' is specified.
-    delete mergedOptions.incremental
+    if (!mergedOptions.incremental) {
+      delete mergedOptions.incremental
+      delete mergedOptions.tsBuildInfoFile
+    }
 
     const dtsPlugin = (require('rollup-plugin-dts') as typeof import('rollup-plugin-dts')).default({
       tsconfig: undefined,

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1,4 +1,5 @@
 import fs from 'fs/promises'
+import fsSync from 'fs'
 import { execSync, fork } from 'child_process'
 import { resolve, join } from 'path'
 import { stripANSIColor, existsFile, assertFilesContent } from './testing-utils'
@@ -221,6 +222,24 @@ const testCases: {
       expect(await fs.readFile(distFiles[1], 'utf-8')).toContain(
         'declare function _default(): string;',
       )
+    },
+  },
+  {
+    name: 'ts-incremental',
+    args: [],
+    async expected(dir) {
+      const distFiles = [
+        './dist/index.js',
+        './dist/index.d.ts',
+      ]
+
+      for (const f of distFiles) {
+        expect(await existsFile(join(dir, f))).toBe(true)
+      }
+      expect(await fs.readFile(join(dir, distFiles[1]), 'utf-8')).toContain(
+        'declare const _default: () => string;',
+      )
+      expect(await existsFile(join(dir, './dist/.tsbuildinfo'))).toBe(false)
     },
   },
   {

--- a/test/integration/ts-incremental/package.json
+++ b/test/integration/ts-incremental/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "ts-incremental",
+  "types": "./dist/index.d.ts",
+  "exports": "./dist/index.js"
+}

--- a/test/integration/ts-incremental/src/index.ts
+++ b/test/integration/ts-incremental/src/index.ts
@@ -1,0 +1,1 @@
+export default () => 'index'

--- a/test/integration/ts-incremental/tsconfig.json
+++ b/test/integration/ts-incremental/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "incremental": true
+  }
+}


### PR DESCRIPTION
Fixes #280 

`convertCompilerOptions` need to be awaited and access the returned options from it.


For `incremental` option, since it's bounded with the `tsBuildInfoFile` option, we delete both of them if increamental is not enabled, for dts plugin as it will fail