### PR TITLE
fix: default build target

### DIFF
--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -56,7 +56,7 @@ async function bundle(
   const cwd = resolve(process.cwd(), _cwd || '')
   assignDefault(options, 'format', 'es')
   assignDefault(options, 'minify', false)
-  assignDefault(options, 'target', 'es2015')
+  assignDefault(options, 'target', 'es2016')
 
   const pkg = await getPackageMeta(cwd)
   const resolvedWildcardExports = await resolveWildcardExports(pkg.exports, cwd)


### PR DESCRIPTION
Align default target to `es2016`.

https://github.com/huozhi/bunchee/blob/17121cc1616671533b9d2481d39fdbed003a9457/README.md?plain=1#L79

