### PR TITLE
feat: esm shims

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "license": "MIT",
   "dependencies": {
     "@rollup/plugin-commonjs": "^25.0.4",
+    "@rollup/plugin-esm-shim": "^0.1.5",
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-node-resolve": "^15.2.1",
     "@rollup/plugin-replace": "^5.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ dependencies:
   '@rollup/plugin-commonjs':
     specifier: ^25.0.4
     version: 25.0.4(rollup@3.28.1)
+  '@rollup/plugin-esm-shim':
+    specifier: ^0.1.5
+    version: 0.1.5(rollup@3.28.1)
   '@rollup/plugin-json':
     specifier: ^6.0.0
     version: 6.0.0(rollup@3.28.1)
@@ -1141,6 +1144,19 @@ packages:
       glob: 8.1.0
       is-reference: 1.2.1
       magic-string: 0.27.0
+      rollup: 3.28.1
+    dev: false
+
+  /@rollup/plugin-esm-shim@0.1.5(rollup@3.28.1):
+    resolution: {integrity: sha512-xnIjDm/0EbqAw0/rR1UE7eAo9db0ftGPqT8RUCFtkFxtCuspbbmj+wutoyxm32jBytyO3SgkxSG17OR893fV7A==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      magic-string: 0.30.3
       rollup: 3.28.1
     dev: false
 

--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -17,6 +17,7 @@ import commonjs from '@rollup/plugin-commonjs'
 import json from '@rollup/plugin-json'
 import { nodeResolve } from '@rollup/plugin-node-resolve'
 import replace from '@rollup/plugin-replace'
+import esmShim from '@rollup/plugin-esm-shim'
 import { sizeCollector } from './plugins/size-plugin'
 import { inlineCss } from './plugins/inline-css'
 import swcPreserveDirectivePlugin from 'rollup-swc-preserve-directives'
@@ -192,6 +193,7 @@ async function buildInputConfig(
             tsconfig: tsConfigPath,
             ...swcOptions,
           }),
+          esmShim()
         ]
   ).filter(isNotNull<Plugin>)
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -316,10 +316,23 @@ const testCases: {
     name: 'esm-shims',
     args: [],
     async expected(dir) {
-      expect(await fs.readFile(join(dir, './dist/index.mjs'), 'utf-8'))
-        .toContain(`const __filename = cjsUrl.fileURLToPath(import.meta.url);
-const __dirname = cjsPath.dirname(__filename);
-const require = cjsModule.createRequire(import.meta.url);`)
+      const shimsCode = [
+        'const __filename = cjsUrl.fileURLToPath(import.meta.url)',
+        'const __dirname = cjsPath.dirname(__filename)',
+        'const require = cjsModule.createRequire(import.meta.url)',
+      ]
+      const esmOutput = await fs.readFile(join(dir, './dist/index.mjs'), 'utf-8')
+      const cjsOutput = await fs.readFile(join(dir, './dist/index.cjs'), 'utf-8')
+      expect(
+        shimsCode.every((code) => esmOutput.includes(code)),
+      ).toBe(true)
+      expect(
+        shimsCode.map((code) => cjsOutput.includes(code)),
+      ).toEqual([false, false, false])
+      // for import.meta.url, should use pathToFileURL + URL polyfill
+      expect(cjsOutput).toContain('pathToFileURL')
+      expect(cjsOutput).toContain('new URL')
+      expect(cjsOutput).not.toContain('import.meta.url')
     },
   },
 ]

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -228,7 +228,10 @@ const testCases: {
     name: 'ts-incremental',
     args: [],
     async expected(dir) {
-      const distFiles = ['./dist/index.js', './dist/index.d.ts']
+      const distFiles = [
+        './dist/index.js',
+        './dist/index.d.ts',
+      ]
 
       for (const f of distFiles) {
         expect(await existsFile(join(dir, f))).toBe(true)

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -228,10 +228,7 @@ const testCases: {
     name: 'ts-incremental',
     args: [],
     async expected(dir) {
-      const distFiles = [
-        './dist/index.js',
-        './dist/index.d.ts',
-      ]
+      const distFiles = ['./dist/index.js', './dist/index.d.ts']
 
       for (const f of distFiles) {
         expect(await existsFile(join(dir, f))).toBe(true)
@@ -310,6 +307,16 @@ const testCases: {
       expect(stderr).toContain(
         'Cannot export main field with .cjs extension in ESM package, only .mjs and .js extensions are allowed',
       )
+    },
+  },
+  {
+    name: 'esm-shims',
+    args: [],
+    async expected(dir) {
+      expect(await fs.readFile(join(dir, './dist/index.mjs'), 'utf-8'))
+        .toContain(`const __filename = cjsUrl.fileURLToPath(import.meta.url);
+const __dirname = cjsPath.dirname(__filename);
+const require = cjsModule.createRequire(import.meta.url);`)
     },
   },
 ]

--- a/test/integration/esm-shims/package.json
+++ b/test/integration/esm-shims/package.json
@@ -1,7 +1,8 @@
 {
   "exports": {
     ".": {
-      "import": "./dist/index.mjs"
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
     }
   }
 }

--- a/test/integration/esm-shims/package.json
+++ b/test/integration/esm-shims/package.json
@@ -1,0 +1,7 @@
+{
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs"
+    }
+  }
+}

--- a/test/integration/esm-shims/src/index.js
+++ b/test/integration/esm-shims/src/index.js
@@ -1,0 +1,3 @@
+console.log(__dirname)
+console.log(__filename)
+console.log(import.meta.url)


### PR DESCRIPTION
Resolve #275. 

Inject esm shims by `@rollup/plugin-esm-shim`. 

The  `@rollup/plugin-esm-shim` is enabled by default, not sure if we should disable it by default and enable it via a `shims` option like `tsup` and `unbuild`