### PR TITLE
docs: add bin docs to readme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - 'v*'
   pull_request:
     paths-ignore:
-      - '**/*.md'
+      - '*.md'
 
 jobs:
   install_and_test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
     tags:
       - 'v*'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
 
 jobs:
   install_and_test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,6 @@ on:
     tags:
       - 'v*'
   pull_request:
-    paths-ignore:
-      - 'README.md'
 
 jobs:
   install_and_test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - 'v*'
   pull_request:
     paths-ignore:
-      - '*.md'
+      - 'README.md'
 
 jobs:
   install_and_test:

--- a/README.md
+++ b/README.md
@@ -200,6 +200,47 @@ This will match the export name `"react-server"` and `"edge-light"` then use the
 
 `bunchee` has support for checking the package bundles are matched with package exports configuration.
 
+
+### `bin` Field Convention
+
+To build executable files with the `bin` field in package.json, `bunchee` requires you to create the `bin` directory inside your `src` directory.
+
+```bash
+|- src/
+  |- bin/
+    |- index.ts
+```
+
+This will match the `bin` field in package.json as:
+
+```json
+{
+  "bin": "./dist/bin.js"
+}
+```
+
+For multiple executable files, you can create multiple files under the `bin` directory.
+
+```bash
+|- src/
+  |- bin/
+    |- foo.ts
+    |- bar.ts
+```
+
+This will match the `bin` field in package.json as:
+
+```json
+{
+  "bin": {
+    "foo": "./dist/bin/a.js",
+    "bar": "./dist/bin/b.js"
+  }
+}
+```
+
+> Note: For multiple `bin` files, the filename should match the key name in the `bin` field.
+
 ### Wildcard Exports (Experimental)
 
 Bunchee implements the Node.js feature of using the asterisk `*` as a wildcard to match the exportable entry files.
@@ -255,46 +296,6 @@ This will match the export names `"foo"` and `"bar"` and will be treated as the 
 ```
 
 > Note: Wildcard Exports currently only supports the exports key `"./*"`, which will match all the available entries.
-
-### `bin` Field Convention
-
-To build executable files with the `bin` field in package.json, `bunchee` requires you to create the `bin` directory inside your `src` directory.
-
-```bash
-|- src/
-  |- bin/
-    |- index.ts
-```
-
-This will match the `bin` field in package.json as:
-
-```json
-{
-  "bin": "./dist/bin.js"
-}
-```
-
-For multiple executable files, you can create multiple files under the `bin` directory.
-
-```bash
-|- src/
-  |- bin/
-    |- foo.ts
-    |- bar.ts
-```
-
-This will match the `bin` field in package.json as:
-
-```json
-{
-  "bin": {
-    "foo": "./dist/bin/a.js",
-    "bar": "./dist/bin/b.js"
-  }
-}
-```
-
-> Note: For multiple `bin` files, the filename should match the key name in the `bin` field.
 
 ### CSS
 

--- a/README.md
+++ b/README.md
@@ -256,9 +256,49 @@ This will match the export names `"foo"` and `"bar"` and will be treated as the 
 
 > Note: Wildcard Exports currently only supports the exports key `"./*"`, which will match all the available entries.
 
+### `bin` Field Convention
+
+To build executable files with the `bin` field in package.json, `bunchee` requires you to create the `bin` directory inside your `src` directory.
+
+```bash
+|- src/
+  |- bin/
+    |- index.ts
+```
+
+This will match the `bin` field in package.json as:
+
+```json
+{
+  "bin": "./dist/bin.js"
+}
+```
+
+For multiple executable files, you can create multiple files under the `bin` directory.
+
+```bash
+|- src/
+  |- bin/
+    |- foo.ts
+    |- bar.ts
+```
+
+This will match the `bin` field in package.json as:
+
+```json
+{
+  "bin": {
+    "foo": "./dist/bin/a.js",
+    "bar": "./dist/bin/b.js"
+  }
+}
+```
+
+> Note: For multiple `bin` files, the filename should match the key name in the `bin` field.
+
 ### CSS
 
-`bunchee`` has basic CSS support for pure CSS file imports. It will be bundled into js bundle and insert the style tag into the document head when the bundle is loaded by browser.
+`bunchee` has basic CSS support for pure CSS file imports. It will be bundled into js bundle and insert the style tag into the document head when the bundle is loaded by browser.
 
 ```css
 /* src/style.css */


### PR DESCRIPTION
This PR added usage and a few examples for the `bin` field support.

Resolves #291 