### PR TITLE
Change required node version to lgt 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        node-version: [16, 18, 20]
+        node-version: [18, 20]
 
     name: Node ${{ matrix.node-version }}
     steps:

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "singleQuote": true
   },
   "engines": {
-    "node": ">= 16"
+    "node": ">= 18.0.0"
   },
   "author": "huozhi (github.com/huozhi)",
   "repository": {


### PR DESCRIPTION
As rollup requires to work with node 18, even node 16 CI is passing but still not recommended to use with node 16