### PR TITLE
Generate hash for chunk

### DIFF
--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -321,7 +321,7 @@ function buildOutputConfigs(
     strict: false,
     sourcemap: options.sourcemap,
     manualChunks: splitChunks,
-    chunkFileNames: '[name].js',
+    chunkFileNames: '[name]-[hash].js',
     entryFileNames: basename(outputFile),
   }
 }

--- a/test/integration/server-components/package.json
+++ b/test/integration/server-components/package.json
@@ -1,8 +1,14 @@
 {
   "type": "module",
   "exports": {
-    ".": "./dist/index.js",
-    "./ui": "./dist/ui.js"
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./ui": {
+      "import": "./dist/ui.js",
+      "require": "./dist/ui.cjs"
+    }
   },
   "peerDependencies": {
     "react": "*"

--- a/test/unit/use-client/__snapshot__/use-client.js.snapshot
+++ b/test/unit/use-client/__snapshot__/use-client.js.snapshot
@@ -1,5 +1,5 @@
 'use strict';
-import { c as client } from './client-client.js';
+import { c as client } from './client-client-0x7cvmaL.js';
 
 var input = (()=>{
     return client();

--- a/test/unit/use-client/__snapshot__/use-client.min.js.snapshot
+++ b/test/unit/use-client/__snapshot__/use-client.min.js.snapshot
@@ -1,1 +1,1 @@
-"use strict";import{c as t}from"./client-client.js";var e=()=>t();export{e as default};
+"use strict";import{c as t}from"./client-client-w7FbcvRI.js";var e=()=>t();export{e as default};


### PR DESCRIPTION
Add hash to make sure the chunks are unique, when there're both esm and cjs builds the chunks will still be bound to the syntax correctly