### PR TITLE
Disable hoistTransitiveImports

### DIFF
--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -210,7 +210,7 @@ async function buildInputConfig(
     plugins,
     treeshake: {
       propertyReadSideEffects: false,
-      moduleSideEffects: false,
+      moduleSideEffects: 'no-external',
     },
     onwarn(warning, warn) {
       const code = warning.code || ''

--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -210,7 +210,6 @@ async function buildInputConfig(
     plugins,
     treeshake: {
       propertyReadSideEffects: false,
-      moduleSideEffects: 'no-external',
     },
     onwarn(warning, warn) {
       const code = warning.code || ''
@@ -323,6 +322,9 @@ function buildOutputConfigs(
     sourcemap: options.sourcemap,
     manualChunks: splitChunks,
     chunkFileNames: '[name]-[hash].js',
+    // By default in rollup, when creating multiple chunks, transitive imports of entry chunks
+    // will be added as empty imports to the entry chunks. Disable to avoid imports hoist outside of boundaries
+    hoistTransitiveImports: false,
     entryFileNames: basename(outputFile),
   }
 }

--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -210,6 +210,7 @@ async function buildInputConfig(
     plugins,
     treeshake: {
       propertyReadSideEffects: false,
+      moduleSideEffects: false,
     },
     onwarn(warning, warn) {
       const code = warning.code || ''


### PR DESCRIPTION
`hoistTransitiveImports` behavior of rollup could break RSC due to the imports are hoisted into entry chunk acrossing the server/client boundaries. Disable it to avoid the client imports showing up in entry chunk

Fixes #315 