### PR TITLE
Fix missing dts for special exports

### DIFF
--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -403,7 +403,6 @@ export async function collectEntries(
   entryPath: string,
   exportPaths: ExportPaths,
   cwd: string,
-  dts: boolean,
 ): Promise<Entries> {
   const entries: Entries = {}
 
@@ -501,13 +500,9 @@ export async function collectEntries(
     const exportCond = exportPaths[entryExport]
     await collectEntry('', exportCond, entryExport)
 
-    // For dts job, only build the default config.
-    // For assets job, build all configs.
-    if (!dts) {
-      for (const exportType of availableExportConventions) {
-        if (exportCond[exportType]) {
-          await collectEntry(exportType, exportCond, entryExport)
-        }
+    for (const exportType of availableExportConventions) {
+      if (exportCond[exportType]) {
+        await collectEntry(exportType, exportCond, entryExport)
       }
     }
   })

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -144,7 +144,7 @@ async function bundle(
   }
 
   let result
-  const entries = await collectEntries(pkg, entryPath, exportPaths, cwd, false)
+  const entries = await collectEntries(pkg, entryPath, exportPaths, cwd)
   const buildConfigs = await buildEntryConfig(
     entries,
     pkg,
@@ -161,7 +161,7 @@ async function bundle(
   const typesJobs = hasTsConfig
     ? (
         await buildEntryConfig(
-          await collectEntries(pkg, entryPath, exportPaths, cwd, true),
+          entries,
           pkg,
           exportPaths,
           options,

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -107,23 +107,26 @@ const testCases: {
       assertFilesContent(dir, contentsRegex)
 
       const log = `\
-      ✓ Typed dist/server/index.d.ts       - 87 B
-      ✓ Typed dist/server/index.d.mts      - 87 B
-      ✓ Typed dist/lite.d.ts               - 70 B
-      ✓ Typed dist/shared/index.d.mts      - 66 B
-      ✓ Typed dist/client/index.d.cts      - 74 B
-      ✓ Typed dist/client/index.d.mts      - 74 B
-      ✓ Typed dist/client/index.d.ts       - 74 B
-      ✓ Typed dist/index.d.ts              - 65 B
-      ✓ Built dist/index.js                - 110 B
-      ✓ Built dist/shared/edge-light.mjs   - 84 B
-      ✓ Built dist/client/index.cjs        - 138 B
-      ✓ Built dist/client/index.mjs        - 78 B
-      ✓ Built dist/lite.js                 - 132 B
-      ✓ Built dist/server/index.mjs        - 71 B
-      ✓ Built dist/shared/index.mjs        - 53 B
-      ✓ Built dist/server/react-server.mjs - 53 B
-      ✓ Built dist/server/edge.mjs         - 51 B
+      ✓ Typed dist/shared/index.d.mts        - 66 B
+      ✓ Typed dist/index.d.ts                - 65 B
+      ✓ Typed dist/server/index.d.ts         - 87 B
+      ✓ Typed dist/server/index.d.mts        - 87 B
+      ✓ Typed dist/lite.d.ts                 - 70 B
+      ✓ Typed dist/server/edge.d.mts         - 59 B
+      ✓ Typed dist/shared/edge-light.d.mts   - 77 B
+      ✓ Typed dist/server/react-server.d.mts - 61 B
+      ✓ Typed dist/client/index.d.ts         - 74 B
+      ✓ Typed dist/client/index.d.cts        - 74 B
+      ✓ Typed dist/client/index.d.mts        - 74 B
+      ✓ Built dist/shared/edge-light.mjs     - 84 B
+      ✓ Built dist/shared/index.mjs          - 53 B
+      ✓ Built dist/index.js                  - 110 B
+      ✓ Built dist/client/index.cjs          - 138 B
+      ✓ Built dist/client/index.mjs          - 78 B
+      ✓ Built dist/lite.js                   - 132 B
+      ✓ Built dist/server/react-server.mjs   - 53 B
+      ✓ Built dist/server/edge.mjs           - 51 B
+      ✓ Built dist/server/index.mjs          - 71 B
       `
 
       const rawStdout = stripANSIColor(stdout)
@@ -264,20 +267,23 @@ const testCases: {
       assertFilesContent(dir, contentsRegex)
 
       const log = `\
-      ✓ Typed dist/lite.d.ts               - 70 B
-      ✓ Typed dist/input.d.ts              - 65 B
-      ✓ Typed dist/index.d.ts              - 65 B
-      ✓ Typed dist/server/index.d.ts       - 87 B
-      ✓ Typed dist/layout/index.d.ts       - 66 B
-      ✓ Typed dist/button.d.ts             - 66 B
-      ✓ Built dist/input.js                - 50 B
-      ✓ Built dist/index.js                - 50 B
-      ✓ Built dist/button.js               - 53 B
-      ✓ Built dist/lite.js                 - 72 B
-      ✓ Built dist/layout/index.js         - 51 B
-      ✓ Built dist/server/react-server.mjs - 53 B
-      ✓ Built dist/server/edge.mjs         - 51 B
-      ✓ Built dist/server/index.mjs        - 71 B
+      ✓ Typed dist/button.d.ts               - 66 B
+      ✓ Typed dist/server/index.d.ts         - 87 B
+      ✓ Typed dist/server/index.d.mts        - 87 B
+      ✓ Typed dist/index.d.ts                - 65 B
+      ✓ Typed dist/layout/index.d.ts         - 66 B
+      ✓ Typed dist/server/react-server.d.mts - 61 B
+      ✓ Typed dist/lite.d.ts                 - 70 B
+      ✓ Typed dist/server/edge.d.mts         - 59 B
+      ✓ Typed dist/input.d.ts                - 65 B
+      ✓ Built dist/input.js                  - 50 B
+      ✓ Built dist/lite.js                   - 72 B
+      ✓ Built dist/button.js                 - 53 B
+      ✓ Built dist/index.js                  - 50 B
+      ✓ Built dist/server/react-server.mjs   - 53 B
+      ✓ Built dist/layout/index.js           - 51 B
+      ✓ Built dist/server/index.mjs          - 71 B
+      ✓ Built dist/server/edge.mjs           - 51 B
       `
 
       const rawStdout = stripANSIColor(stdout)


### PR DESCRIPTION
Declaration type files are not correctly generated for react-server, edge, react-native condition.
This also simplify the collect entries calls into only one.