### PR TITLE
Refactor logging plugin

### DIFF
--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -20,7 +20,7 @@ import { nodeResolve } from '@rollup/plugin-node-resolve'
 import replace from '@rollup/plugin-replace'
 import esmShim from '@rollup/plugin-esm-shim'
 import preserveDirectives from 'rollup-preserve-directives'
-import { sizeCollector } from './plugins/size-plugin'
+// import { sizeCollector } from './plugins/size-plugin'
 import { inlineCss } from './plugins/inline-css'
 import { rawContent } from './plugins/raw-plugin'
 import { aliasEntries } from './plugins/alias-plugin'
@@ -46,6 +46,7 @@ import {
   nodeResolveExtensions,
 } from './constants'
 import { logger } from './logger'
+import { PluginContext } from './plugins/size-plugin'
 
 const swcMinifyOptions = {
   compress: true,
@@ -90,6 +91,7 @@ async function buildInputConfig(
   options: BundleOptions,
   cwd: string,
   { tsConfigPath, tsCompilerOptions }: TypescriptOptions,
+  pluginContext: PluginContext,
   dts: boolean,
 ): Promise<InputOptions> {
   const entriesAlias = getEntriesAlias(entries)
@@ -145,7 +147,7 @@ async function buildInputConfig(
     isModule: true,
   } as const
 
-  const sizePlugin = sizeCollector.plugin(cwd)
+  const sizePlugin = pluginContext.sizeCollector.plugin(cwd)
   const reversedAlias: Record<string, string> = {}
   for (const [key, value] of Object.entries(entriesAlias)) {
     if (value !== entry) {
@@ -373,6 +375,7 @@ export async function buildEntryConfig(
   bundleConfig: BundleConfig,
   cwd: string,
   tsOptions: TypescriptOptions,
+  pluginContext: PluginContext,
   dts: boolean,
 ): Promise<BuncheeRollupConfig[]> {
   const configs: Promise<BuncheeRollupConfig>[] = []
@@ -386,6 +389,7 @@ export async function buildEntryConfig(
       exportCondition,
       cwd,
       tsOptions,
+      pluginContext,
       dts,
     )
     configs.push(rollupConfig)
@@ -519,6 +523,7 @@ async function buildConfig(
   exportCondition: ParsedExportCondition,
   cwd: string,
   tsOptions: TypescriptOptions,
+  pluginContext: PluginContext,
   dts: boolean,
 ): Promise<BuncheeRollupConfig> {
   const { file } = bundleConfig
@@ -531,6 +536,7 @@ async function buildConfig(
     options,
     cwd,
     tsOptions,
+    pluginContext,
     dts,
   )
   const outputExports = getExportConditionDist(pkg, exportCondition, cwd)

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,4 +1,7 @@
 export const logger = {
+  prefixedLog(prefix: string, ...arg: any[]) {
+    console.log(' ' + prefix, ...arg)
+  },
   log(...arg: any[]) {
     console.log('  ', ...arg)
   },

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,7 +1,4 @@
 export const logger = {
-  prefixedLog(prefix: string, ...arg: any[]) {
-    console.log(' ' + prefix, ...arg)
-  },
   log(...arg: any[]) {
     console.log('  ', ...arg)
   },

--- a/src/plugins/size-plugin.ts
+++ b/src/plugins/size-plugin.ts
@@ -87,7 +87,7 @@ function logSizeStats(sizeCollector: ReturnType<typeof createChunkSizeCollector>
       const padding = ' '.repeat(maxLength - filename.length)
       const action = dtsExtensionRegex.test(filename) ? 'Typed' : 'Built'
       const prettiedSize = prettyBytes(size)
-      logger.log(`${action} ${filename}${padding} - ${prettiedSize}`)
+      logger.info(`${action} ${filename}${padding} - ${prettiedSize}`)
     })
   })
 }

--- a/src/plugins/size-plugin.ts
+++ b/src/plugins/size-plugin.ts
@@ -3,18 +3,41 @@ import path from 'path'
 import prettyBytes from 'pretty-bytes'
 import { dtsExtensionRegex } from '../constants'
 import { logger } from '../logger'
+import { Entries } from '../types'
 
-type SizeStats = [string, string, number][]
+type Pair = [string, string, number]
+type SizeStats = Map<string, Pair[]>
 
-function createChunkSizeCollector(): {
+function createChunkSizeCollector({ entries }: { entries: Entries }): {
   plugin(cwd: string): Plugin
   getSizeStats(): SizeStats
 } {
-  const sizes: Map<string, number> = new Map()
+  const sizeStats: SizeStats = new Map()
 
-  function addSize(name: string, size: number) {
-    sizes.set(name, size)
+  function addSize({
+    fileName,
+    size,
+    sourceFileName,
+    exportPath,
+  }: {
+    fileName: string
+    size: number
+    sourceFileName: string
+    exportPath: string
+  }) {
+    if (!sizeStats.has(exportPath)) {
+      sizeStats.set(exportPath, [])
+    }
+    const distFilesStats = sizeStats.get(exportPath)
+    if (distFilesStats) {
+      distFilesStats.push([fileName, sourceFileName, size])
+    }
   }
+
+  const reversedMapping = new Map<string, string>()
+  Object.entries(entries).forEach(([exportPath, entry]) => {
+    reversedMapping.set(entry.source, entry.name)
+  })
 
   return {
     plugin: (cwd: string) => {
@@ -24,6 +47,8 @@ function createChunkSizeCollector(): {
           // Do nothing, but use the hook to keep the plugin instance alive
         },
         renderChunk(code, chunk, options) {
+          const sourceId = chunk.facadeModuleId!
+
           const dir =
             options.dir || (options.file && path.dirname(options.file))
           let fileName = chunk.fileName
@@ -33,32 +58,48 @@ function createChunkSizeCollector(): {
               ? path.relative(cwd, filePath)
               : filePath
           }
-          addSize(fileName, code.length)
+          addSize({
+            fileName,
+            size: code.length,
+            sourceFileName: sourceId,
+            exportPath: reversedMapping.get(sourceId)!,
+          })
           return null
         },
       }
     },
     getSizeStats() {
-      const sizeStats: SizeStats = []
-      sizes.forEach((size, name) => {
-        sizeStats.push([name, prettyBytes(size), size])
-      })
       return sizeStats
     },
   }
 }
 
-// This can also be passed down as stats from top level
-const sizeCollector = createChunkSizeCollector()
-
-function logSizeStats() {
+function logSizeStats(sizeCollector: ReturnType<typeof createChunkSizeCollector>) {
   const stats = sizeCollector.getSizeStats()
-  const maxLength = Math.max(...stats.map(([filename]) => filename.length))
-  stats.forEach(([filename, prettiedSize]) => {
-    const padding = ' '.repeat(maxLength - filename.length)
-    const action = dtsExtensionRegex.test(filename) ? 'Typed' : 'Built'
-    logger.info(`${action} ${filename}${padding} - ${prettiedSize}`)
+  const allFileNameLengths = Array.from(stats.values()).flat(1).map(([filename]) => filename.length)
+  const maxLength = Math.max(...allFileNameLengths) + 1
+
+
+  ;[...stats.entries()]
+  .sort(([a], [b]) => a.length - b.length)
+  .forEach(([exportPath, filesList]) => {
+    logger.prefixedLog('■', exportPath)
+    filesList.forEach((item: Pair) => {
+      const [filename, , size] = item
+      const padding = ' '.repeat(maxLength - filename.length)
+      const action = dtsExtensionRegex.test(filename) ? 'Typed' : 'Built'
+      const prettiedSize = prettyBytes(size)
+      logger.log(`${action} ${filename}${padding} - ${prettiedSize}`)
+    })
   })
 }
 
-export { logSizeStats, sizeCollector, createChunkSizeCollector }
+type PluginContext = {
+  sizeCollector: ReturnType<typeof createChunkSizeCollector>
+}
+
+export {
+  logSizeStats,
+  createChunkSizeCollector,
+  type PluginContext,
+}


### PR DESCRIPTION
keep the logging state in the same context of the build, and save more info into context