### PR TITLE
Fix parsing nested exports case

### DIFF
--- a/test/unit/exports.test.ts
+++ b/test/unit/exports.test.ts
@@ -99,7 +99,7 @@ describe('lib exports', () => {
           main: './dist/index.cjs',
           exports: {
             '.': {
-              sub: {
+              './sub': {
                 require: './dist/index.cjs',
               },
             },
@@ -149,6 +149,30 @@ describe('lib exports', () => {
         '.': {
           import: './dist/index.mjs',
           require: './dist/index.cjs',
+        },
+      })
+    })
+
+    it('should handle nested import and exports conditions', () => {
+      expect(
+        getExportPaths({
+          exports: {
+            ".": {
+              "import": {
+                "types": "./dist/index.d.ts",
+                "default": "./dist/index.mjs"
+              },
+              "require": {
+                "types": "./dist/index.d.ts",
+                "default": "./dist/index.js"
+              }
+            }
+          },
+        }),
+      ).toEqual({
+        '.': {
+          import: './dist/index.mjs',
+          require: './dist/index.js',
         },
       })
     })

--- a/test/unit/exports.test.ts
+++ b/test/unit/exports.test.ts
@@ -157,14 +157,14 @@ describe('lib exports', () => {
       expect(
         getExportPaths({
           exports: {
-            ".": {
-              "import": {
-                "types": "./dist/index.d.ts",
-                "default": "./dist/index.mjs"
+            '.': {
+              'import': {
+                'types': './dist/index.d.ts',
+                'default': './dist/index.mjs'
               },
-              "require": {
-                "types": "./dist/index.d.ts",
-                "default": "./dist/index.js"
+              'require': {
+                'types': './dist/index.d.ts',
+                'default': './dist/index.js'
               }
             }
           },


### PR DESCRIPTION
Should support nested export condition (`import` or `require` etc), then the value has both types and default, should get  the path from nested condition

```
       exports: {
            '.': {
              'import': {
                'types': './dist/index.d.ts',
                'default': './dist/index.mjs'
              },
              'require': {
                'types': './dist/index.d.ts',
                'default': './dist/index.js'
              }
            }
          }
```