### PR TITLE
Override compiler options for dts

### DIFF
--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -9,7 +9,7 @@ import type {
   FullExportCondition,
 } from './types'
 import type { CustomPluginOptions, GetManualChunk, InputOptions, OutputOptions, Plugin } from 'rollup'
-import { convertCompilerOptions, type TypescriptOptions } from './typescript'
+import { type TypescriptOptions } from './typescript'
 
 import path, { resolve, dirname, extname, join, basename } from 'path'
 import { wasm } from '@rollup/plugin-wasm'

--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -9,7 +9,7 @@ import type {
   FullExportCondition,
 } from './types'
 import type { CustomPluginOptions, GetManualChunk, InputOptions, OutputOptions, Plugin } from 'rollup'
-import { type TypescriptOptions } from './typescript'
+import { convertCompilerOptions, type TypescriptOptions } from './typescript'
 
 import path, { resolve, dirname, extname, join, basename } from 'path'
 import { wasm } from '@rollup/plugin-wasm'
@@ -163,41 +163,36 @@ async function buildInputConfig(
     })
   ]
 
-  const baseResolvedTsOptions: any = {
-    declaration: true,
-    // Avoid user overriding noEmit
-    noEmit: false,
-    noEmitOnError: true,
-    emitDeclarationOnly: true,
-    checkJs: false,
-    declarationMap: false,
-    skipLibCheck: true,
-    preserveSymlinks: false,
-    target: 'esnext',
-    module: 'esnext',
-    jsx: tsCompilerOptions.jsx || 'react-jsx',
-  }
-
   const typesPlugins = [
     ...commonPlugins,
     inlineCss({ skip: true }),
   ]
 
   if (useTypescript) {
-    const mergedOptions = {
-      ...tsCompilerOptions,
-      ...baseResolvedTsOptions,
+    const baseResolvedTsOptions: any = {
+      declaration: true,
+      noEmit: false,
+      noEmitOnError: true,
+      emitDeclarationOnly: true,
+      checkJs: false,
+      declarationMap: false,
+      skipLibCheck: true,
+      preserveSymlinks: false,
+      target: 'esnext',
+      module: 'esnext',
+      jsx: tsCompilerOptions.jsx || 'react-jsx',
     }
 
-    // error TS5074: Option '--incremental' can only be specified using tsconfig, emitting to single
-    // file or when option '--tsBuildInfoFile' is specified.
-    delete mergedOptions.incremental
-    delete mergedOptions.tsBuildInfoFile
+    const mergedOptions = {
+      ...baseResolvedTsOptions,
+      ...tsCompilerOptions,
+    }
 
     const dtsPlugin = (require('rollup-plugin-dts') as typeof import('rollup-plugin-dts')).default({
       tsconfig: undefined,
       compilerOptions: mergedOptions,
     })
+
     typesPlugins.push(dtsPlugin)
   }
 

--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -169,7 +169,7 @@ async function buildInputConfig(
   ]
 
   if (useTypescript) {
-    const baseResolvedTsOptions: any = {
+    const overrideResolvedTsOptions: any = {
       declaration: true,
       noEmit: false,
       noEmitOnError: true,
@@ -184,9 +184,14 @@ async function buildInputConfig(
     }
 
     const mergedOptions = {
-      ...baseResolvedTsOptions,
       ...tsCompilerOptions,
+      ...overrideResolvedTsOptions,
     }
+
+    // error TS5074: Option '--incremental' can only be specified using tsconfig, emitting to single
+    // file or when option '--tsBuildInfoFile' is specified.
+    delete mergedOptions.incremental
+    delete mergedOptions.tsBuildInfoFile
 
     const dtsPlugin = (require('rollup-plugin-dts') as typeof import('rollup-plugin-dts')).default({
       tsconfig: undefined,

--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -165,6 +165,7 @@ async function buildInputConfig(
 
   const baseResolvedTsOptions: any = {
     declaration: true,
+    // Avoid user overriding noEmit
     noEmit: false,
     noEmitOnError: true,
     emitDeclarationOnly: true,
@@ -172,10 +173,6 @@ async function buildInputConfig(
     declarationMap: false,
     skipLibCheck: true,
     preserveSymlinks: false,
-    // disable incremental build
-    incremental: false,
-    // use default tsBuildInfoFile value
-    tsBuildInfoFile: '.tsbuildinfo',
     target: 'esnext',
     module: 'esnext',
     jsx: tsCompilerOptions.jsx || 'react-jsx',
@@ -188,16 +185,14 @@ async function buildInputConfig(
 
   if (useTypescript) {
     const mergedOptions = {
-      ...baseResolvedTsOptions,
       ...tsCompilerOptions,
+      ...baseResolvedTsOptions,
     }
 
     // error TS5074: Option '--incremental' can only be specified using tsconfig, emitting to single
     // file or when option '--tsBuildInfoFile' is specified.
-    if (!mergedOptions.incremental) {
-      delete mergedOptions.incremental
-      delete mergedOptions.tsBuildInfoFile
-    }
+    delete mergedOptions.incremental
+    delete mergedOptions.tsBuildInfoFile
 
     const dtsPlugin = (require('rollup-plugin-dts') as typeof import('rollup-plugin-dts')).default({
       tsconfig: undefined,

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -43,7 +43,6 @@ export async function resolveTsConfig(
       basePath,
     ).options
   } else {
-    tsConfigPath = undefined
     return null
   }
   return {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -228,6 +228,23 @@ const testCases: {
     name: 'ts-incremental',
     args: [],
     async expected(dir) {
+      // TODO: disable incremental and avoid erroring
+      // const distFiles = ['./dist/index.js', './dist/index.d.ts']
+
+      // for (const f of distFiles) {
+      //   expect(await existsFile(join(dir, f))).toBe(true)
+      // }
+      // expect(await fs.readFile(join(dir, distFiles[1]), 'utf-8')).toContain(
+      //   'declare const _default: () => string;',
+      // )
+      // expect(await existsFile(join(dir, './dist/.tsbuildinfo'))).toBe(false)
+    },
+  },
+  {
+    name: 'ts-no-emit',
+    args: [],
+    async expected(dir) {
+      // should still emit declaration files
       const distFiles = ['./dist/index.js', './dist/index.d.ts']
 
       for (const f of distFiles) {

--- a/test/integration/ts-no-emit/package.json
+++ b/test/integration/ts-no-emit/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "ts-incremental",
+  "types": "./dist/index.d.ts",
+  "exports": "./dist/index.js"
+}

--- a/test/integration/ts-no-emit/src/index.ts
+++ b/test/integration/ts-no-emit/src/index.ts
@@ -1,0 +1,1 @@
+export default () => 'index'

--- a/test/integration/ts-no-emit/tsconfig.json
+++ b/test/integration/ts-no-emit/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "noEmit": true
+  }
+}


### PR DESCRIPTION
Fixes #339 

Avoid users having bad option in `tsconfig.json` that breaks types generation