### PR TITLE
Fix export types condition

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -143,3 +143,4 @@ export const hasAvailableExtension = (filename: string): boolean =>
 
 export const hasCjsExtension = (filename: string): boolean =>
   path.extname(filename) === '.cjs'
+

--- a/test/unit/exports.test.ts
+++ b/test/unit/exports.test.ts
@@ -176,6 +176,21 @@ describe('lib exports', () => {
         },
       })
     })
+
+    it('should skip types condition', () => {
+      expect(
+        getExportPaths({
+          exports: {
+            './sub': './dist/index.mjs',
+            types: './dist/index.d.ts',
+          },
+        }),
+      ).toEqual({
+        './sub': {
+          import: './dist/index.mjs',
+        }
+      })
+    })
   })
 
   describe('getExportConditionDist', () => {


### PR DESCRIPTION
Skip `types` condition to avoid collecting non-js entry

Fixes #341 