### PR TITLE
Fix: mixed exports

### DIFF
--- a/src/exports.ts
+++ b/src/exports.ts
@@ -97,7 +97,9 @@ function findExport(
     } else {
       // subpath is exportType, import, require, ...
       const exportType = subpath
-      const defaultPath = (exportCondition[subpath] as any).default
+      const defaultPath = typeof exportCondition[subpath] === 'object'
+        ? (exportCondition[subpath] as any).default
+        : exportCondition[subpath]
       const nestedExportCondition = { [exportType]: defaultPath }
       findExport(exportPath, nestedExportCondition, paths, packageType, currentPath)
     }

--- a/test/unit/exports.test.ts
+++ b/test/unit/exports.test.ts
@@ -102,11 +102,13 @@ describe('lib exports', () => {
               './sub': {
                 require: './dist/index.cjs',
               },
+              import: './dist/index.mjs',
             },
           },
         }),
       ).toEqual({
         '.': {
+          import: './dist/index.mjs',
           require: './dist/index.cjs',
         },
         './sub': {


### PR DESCRIPTION
Need to handle both string and object value of an export condition.

`import: {} | import: ""`

Fixes #352 