### PR TITLE
Skip unused import warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ await bundle(path.resolve('./src/index.ts'), {
 
 #### Watch Mode
 
-Bunchee offers a convenient watch mode for rebuilding your library whenever changes are made to the source files. To enable this feature, use either -w or --watch.
+Bunchee offers a convenient watch mode for rebuilding your library whenever changes are made to the source files. To enable this feature, use either `-w` or `--watch`.
 
 #### `target`
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -31,4 +31,5 @@ export const disabledWarnings = new Set([
   'UNRESOLVED_IMPORT',
   'THIS_IS_UNDEFINED',
   'INVALID_ANNOTATION',
+  'UNUSED_EXTERNAL_IMPORT',
 ])


### PR DESCRIPTION
re-export Type `SWRConfiguration` bumps to this warning. We don't need to warn it from bundler

```
"SWRConfiguration" is imported from external module "swr/_internal" but never used in "src/core/serialize.ts", "src/core/use-swr.ts" and "src/core/index.ts".
```