### PR TITLE
Filter special export type out from alias

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,8 +127,6 @@ packages:
     dependencies:
       '@babel/highlight': 7.23.4
       chalk: 2.4.2
-    dev: false
-    optional: true
 
   /@babel/compat-data@7.18.13:
     resolution: {integrity: sha512-5yUzC5LqyTFp2HLmDoxGQelcdYgSpP9xsnMWBphAscOdFrHSAVbLNzWiy32sVNDqJRDiJK6klfDnAgu6PAGSHw==}
@@ -140,7 +138,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@ampproject/remapping': 2.2.0
-      '@babel/code-frame': 7.22.13
+      '@babel/code-frame': 7.23.5
       '@babel/generator': 7.18.13
       '@babel/helper-compilation-targets': 7.18.9(@babel/core@7.18.13)
       '@babel/helper-module-transforms': 7.18.9
@@ -318,8 +316,6 @@ packages:
       '@babel/helper-validator-identifier': 7.22.20
       chalk: 2.4.2
       js-tokens: 4.0.0
-    dev: false
-    optional: true
 
   /@babel/parser@7.18.13:
     resolution: {integrity: sha512-dgXcIfMuQ0kgzLB2b9tRZs7TTFFaGM2AbtA4fJgUUYukzGH4jwsS7hzQHEGs67jdehpm22vkgKwvbU+aEflgwg==}
@@ -470,7 +466,7 @@ packages:
     resolution: {integrity: sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.22.13
+      '@babel/code-frame': 7.23.5
       '@babel/parser': 7.18.13
       '@babel/types': 7.18.13
     dev: true
@@ -479,7 +475,7 @@ packages:
     resolution: {integrity: sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.22.13
+      '@babel/code-frame': 7.23.5
       '@babel/parser': 7.23.0
       '@babel/types': 7.23.0
     dev: true
@@ -488,7 +484,7 @@ packages:
     resolution: {integrity: sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.22.13
+      '@babel/code-frame': 7.23.5
       '@babel/generator': 7.23.0
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.23.0
@@ -2947,7 +2943,7 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/code-frame': 7.22.13
+      '@babel/code-frame': 7.23.5
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4

--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -78,7 +78,7 @@ function getBuildEnv(envs: string[]) {
 export function getReversedAlias(entries: Entries) {
   const alias: Record<string, string> = {}
   for (const [entryImportPath, exportCondition] of Object.entries(entries)) {
-    const exportType = entryImportPath.split('.').pop()
+    const exportType = entryImportPath.split('.')[1] // e.g. index.react-server, pick react-server
     if (!exportType) {
       alias[exportCondition.source] = entryImportPath
     }
@@ -150,7 +150,7 @@ async function buildInputConfig(
   } as const
 
   const sizePlugin = pluginContext.sizeCollector.plugin(cwd)
-
+  console.log('pluginContext.entriesAlias', pluginContext.entriesAlias)
   // common plugins for both dts and ts assets that need to be processed
   const commonPlugins = [
     sizePlugin,

--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -150,7 +150,7 @@ async function buildInputConfig(
   } as const
 
   const sizePlugin = pluginContext.sizeCollector.plugin(cwd)
-  console.log('pluginContext.entriesAlias', pluginContext.entriesAlias)
+
   // common plugins for both dts and ts assets that need to be processed
   const commonPlugins = [
     sizePlugin,

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -10,7 +10,7 @@ import type { BuncheeRollupConfig, BundleConfig, ExportPaths } from './types'
 import fs from 'fs/promises'
 import { resolve, relative } from 'path'
 import { watch as rollupWatch, rollup } from 'rollup'
-import { buildEntryConfig, collectEntries } from './build-config'
+import { buildEntryConfig, collectEntries, getReversedAlias } from './build-config'
 import { createChunkSizeCollector, logSizeStats, type PluginContext } from './plugins/size-plugin'
 import { logger } from './logger'
 import {
@@ -145,9 +145,11 @@ async function bundle(
 
   const entries = await collectEntries(pkg, entryPath, exportPaths, cwd)
   const sizeCollector = createChunkSizeCollector({ entries })
+  const entriesAlias = getReversedAlias(entries)
   const pluginContext: PluginContext = {
     sizeCollector,
     moduleDirectiveLayerMap: new Map(),
+    entriesAlias,
   }
   const buildConfigs = await buildEntryConfig(
     entries,

--- a/src/plugins/alias-plugin.ts
+++ b/src/plugins/alias-plugin.ts
@@ -4,7 +4,7 @@ import { Plugin } from 'rollup'
 // e.g.
 // For a resolved file, if it's one of the entries,
 // aliases it as export path, such as <absolute file> -> <pkg>/<export path>
-export function aliasEntries({ entries }: { entries: Record<string, string>}): Plugin {
+export function aliasEntries({ entries }: { entries: Record<string, string | null> }): Plugin {
   return {
     name: 'alias',
     resolveId: {

--- a/src/plugins/size-plugin.ts
+++ b/src/plugins/size-plugin.ts
@@ -93,6 +93,7 @@ function logSizeStats(sizeCollector: ReturnType<typeof createChunkSizeCollector>
 type PluginContext = {
   sizeCollector: ReturnType<typeof createChunkSizeCollector>
   moduleDirectiveLayerMap: Map<string, Set<[string, string]>>
+  entriesAlias: Record<string, string>
 }
 
 export {

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -15,8 +15,8 @@ function resolveTypescript(cwd: string): typeof import('typescript') {
   m.paths = (Module as any)._nodeModulePaths(cwd)
   try {
     ts = m.require('typescript')
-  } catch (_) {
-    console.error(_)
+  } catch (e) {
+    console.error(e)
     if (!hasLoggedTsWarning) {
       hasLoggedTsWarning = true
       exit(

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -83,6 +83,7 @@ const testCases: {
         './dist/react-server.mjs': /'react-server'/,
         './dist/react-native.js': /'react-native'/,
         './dist/index.d.ts': /declare const shared = true/,
+        './dist/api.mjs': /\'pkg-export-ts-rsc\'/,
       })
     },
   },

--- a/test/integration/pkg-exports-ts-rsc/package.json
+++ b/test/integration/pkg-exports-ts-rsc/package.json
@@ -1,9 +1,12 @@
 {
   "name": "pkg-export-ts-rsc",
   "exports": {
-    "types": "./dist/index.d.ts",
-    "react-server": "./dist/react-server.mjs",
-    "react-native": "./dist/react-native.js",
-    "import": "./dist/index.mjs"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "react-server": "./dist/react-server.mjs",
+      "react-native": "./dist/react-native.js",
+      "import": "./dist/index.mjs"
+    },
+    "./api": "./dist/api.mjs"
   }
 }

--- a/test/integration/pkg-exports-ts-rsc/src/api/index.ts
+++ b/test/integration/pkg-exports-ts-rsc/src/api/index.ts
@@ -1,0 +1,3 @@
+import index from '../index'
+
+export default 'api:' + index

--- a/test/integration/pkg-exports-ts-rsc/tsconfig.json
+++ b/test/integration/pkg-exports-ts-rsc/tsconfig.json
@@ -1,7 +1,1 @@
-{
-  "compilerOptions": {
-    "paths": {
-      "pkg-exports-ts-rsc/*": ["./src/*"]
-    }
-  }
-}
+{}

--- a/test/integration/pkg-exports-ts-rsc/tsconfig.json
+++ b/test/integration/pkg-exports-ts-rsc/tsconfig.json
@@ -1,1 +1,7 @@
-{}
+{
+  "compilerOptions": {
+    "paths": {
+      "pkg-exports-ts-rsc/*": ["./src/*"]
+    }
+  }
+}


### PR DESCRIPTION
When users provide the special entry (react-server, react-native), avoid the package name being alias to `<pkg.react-server>`