### PR TITLE
Fix ts resolving of prepare

### DIFF
--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -163,7 +163,7 @@ async function run(args: CliArgs) {
   }
 
   // build mode
-  console.log()
+  logger.log()
   paint('✓', 'green', `bunchee ${version} build completed`)
 
   await lintPackage(cwd)

--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -36,7 +36,7 @@ import {
   isNotNull,
   getSourcePathFromExportPath,
   resolveSourceFile,
-  filenameWithoutExtension,
+  filePathWithoutExtension,
 } from './utils'
 import {
   availableExportConventions,
@@ -374,7 +374,7 @@ function buildOutputConfigs(
   const file = options.file && resolve(cwd, options.file)
 
   const dtsDir = typings ? dirname(resolve(cwd, typings)) : resolve(cwd, 'dist')
-  const name = filenameWithoutExtension(file)
+  const name = filePathWithoutExtension(file)
 
   // TODO: simplify dts file name detection
   const dtsFile = file

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -212,7 +212,6 @@ function runWatch(
         return onError(event.error)
       }
       case 'START': {
-        logger.log(`Start building ${metadata.source} ...`)
         break
       }
       case 'END': {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,10 +19,10 @@ export const dtsExtensionRegex = /\.d\.(m|c)?ts$/
 
 export const SRC = 'src'
 
-export const dtsExtensions = {
-  js: '.d.ts',
-  cjs: '.d.cts',
-  mjs: '.d.mts',
+export const dtsExtensionsMap = {
+  js: 'd.ts',
+  cjs: 'd.cts',
+  mjs: 'd.mts',
 }
 
 export const disabledWarnings = new Set([

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -6,7 +6,7 @@ import type {
   PackageType,
   ParsedExportCondition,
 } from './types'
-import { baseNameWithoutExtension, exit, filePathWithoutExtension, hasCjsExtension } from './utils'
+import { exit, filePathWithoutExtension, hasCjsExtension } from './utils'
 import { dtsExtensionsMap } from './constants'
 
 export function getTypings(pkg: PackageMetadata) {

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -6,8 +6,8 @@ import type {
   PackageType,
   ParsedExportCondition,
 } from './types'
-import { exit, filenameWithoutExtension, hasCjsExtension } from './utils'
-import { dtsExtensions } from './constants'
+import { baseNameWithoutExtension, exit, filePathWithoutExtension, hasCjsExtension } from './utils'
+import { dtsExtensionsMap } from './constants'
 
 export function getTypings(pkg: PackageMetadata) {
   return pkg.types || pkg.typings
@@ -268,9 +268,9 @@ export const getExportTypeDist = (
       existed.add(typeFile)
       continue
     }
-    const ext = extname(filePath).slice(1) as keyof typeof dtsExtensions
+    const ext = extname(filePath).slice(1) as keyof typeof dtsExtensionsMap
     const typeFile = getDistPath(
-      `${filenameWithoutExtension(filePath) || ''}${dtsExtensions[ext]}`,
+      `${filePathWithoutExtension(filePath) || ''}.${dtsExtensionsMap[ext]}`,
       cwd,
     )
     if (existed.has(typeFile)) {
@@ -360,7 +360,7 @@ export function getTypeFilePath(
   exportCondition: ParsedExportCondition | undefined,
   cwd: string,
 ): string {
-  const name = filenameWithoutExtension(entryFilePath)
+  const name = filePathWithoutExtension(entryFilePath)
   const firstDistPath = exportCondition
     ? Object.values(exportCondition.export)[0]
     : undefined

--- a/src/lib/wildcard.ts
+++ b/src/lib/wildcard.ts
@@ -4,7 +4,7 @@ import path from 'path'
 import { SRC } from '../constants'
 import { ExportCondition } from '../types'
 import {
-  filenameWithoutExtension,
+  filePathWithoutExtension,
   hasAvailableExtension,
   nonNullable,
 } from '../utils'
@@ -59,7 +59,7 @@ function mapWildcard(
 ): ExportCondition[] {
   return exportables.map((exportable) => {
     const isFile = exportable.includes('.')
-    const filename = isFile ? filenameWithoutExtension(exportable)! : exportable
+    const filename = isFile ? filePathWithoutExtension(exportable)! : exportable
 
     return {
       [`./${filename}`]: Object.fromEntries(

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -7,7 +7,7 @@ function color(prefixColor: any) {
 
 export const logger = {
   log(...arg: any[]) {
-    console.log(' ', ...arg)
+    console.log(...arg)
   },
   warn(...arg: any[]) {
     console.warn(color('yellow')('⚠️'), ...arg)

--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -266,12 +266,11 @@ export async function prepare(cwd: string): Promise<void> {
     if (exportsEntries.has('index')) {
       const isESM = pkgJson.type === 'module'
       const mainExport = pkgExports['.']
-      const isObjectCondition = typeof mainExport.require === 'object'
       const mainCondition = isESM ? 'import' : 'require'
-      pkgJson.main = isObjectCondition
+      pkgJson.main = isUsingTs
         ? mainExport[mainCondition].default
         : mainExport[mainCondition]
-      pkgJson.module = isObjectCondition
+      pkgJson.module = isUsingTs
         ? mainExport.import.default
         : mainExport.import
 

--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -2,9 +2,13 @@ import fs from 'fs'
 import fsp from 'fs/promises'
 import path from 'path'
 import pc from 'picocolors'
-import { SRC, availableExtensions } from './constants'
+import { SRC, availableExtensions, dtsExtensionsMap } from './constants'
 import { logger } from './logger'
-import { baseNameWithoutExtension, hasAvailableExtension, isTypescriptFile } from './utils'
+import {
+  baseNameWithoutExtension,
+  hasAvailableExtension,
+  isTypescriptFile,
+} from './utils'
 import { relativify } from './lib/format'
 
 const DIST = 'dist'
@@ -24,7 +28,7 @@ function createExportCondition(
   moduleType: string | undefined,
 ) {
   const isTsSourceFile = isTypescriptFile(sourceFile)
-  let cjsExtension = 'js'
+  let cjsExtension: 'js' | 'cjs' = 'js'
   if (moduleType === 'module') {
     cjsExtension = 'cjs'
   }
@@ -35,7 +39,10 @@ function createExportCondition(
         default: getDistPath('es', `${exportName}.mjs`),
       },
       require: {
-        types: getDistPath('cjs', `${exportName}.d.ts`),
+        types: getDistPath(
+          'cjs',
+          `${exportName}.${dtsExtensionsMap[cjsExtension]}`,
+        ),
         default: getDistPath('cjs', `${exportName}.${cjsExtension}`),
       },
     }
@@ -161,22 +168,36 @@ export async function prepare(cwd: string): Promise<void> {
   }
   pkgJson.files = files
 
+  let isUsingTs = false
   // Collect bins and exports entries
   const { bins, exportsEntries } = await collectSourceEntries(sourceFolder)
-
   const tsconfigPath = path.join(cwd, 'tsconfig.json')
+
   if (!fs.existsSync(tsconfigPath)) {
-    const sourceFiles: string[] = [...exportsEntries.values()].concat([...bins.values()])
-    const hasTypeScriptFiles = sourceFiles
-      .some((filename) => isTypescriptFile(filename))
+    const sourceFiles: string[] = [...exportsEntries.values()].concat([
+      ...bins.values(),
+    ])
+    const hasTypeScriptFiles = sourceFiles.some((filename) =>
+      isTypescriptFile(filename),
+    )
     if (hasTypeScriptFiles) {
+      isUsingTs = true
       await fsp.writeFile(tsconfigPath, '{}', 'utf-8')
-      console.log(`Detected using TypeScript but tsconfig.json is missing, created a ${pc.blue('tsconfig.json')} for you.`)
+      logger.log(
+        `Detected using TypeScript but tsconfig.json is missing, created a ${pc.blue(
+          'tsconfig.json',
+        )} for you.`,
+      )
     }
   }
 
+  // Configure as ESM package by default if there's no `type` field
+  if (!pkgJson.type) {
+    pkgJson.type = 'module'
+  }
+
   if (bins.size > 0) {
-    console.log('Discovered binaries entries:')
+    logger.log('Discovered binaries entries:')
     const maxLengthOfBinName = Math.max(
       ...Array.from(bins.keys()).map(
         (binName) => normalizeBaseNameToExportName(binName).length,
@@ -189,7 +210,7 @@ export async function prepare(cwd: string): Promise<void> {
           0,
         ),
       )
-      console.log(
+      logger.log(
         `  ${normalizeBaseNameToExportName(binName)}${spaces}: ${binFile}`,
       )
     }
@@ -205,9 +226,9 @@ export async function prepare(cwd: string): Promise<void> {
       }
     }
   }
-  
+
   if (exportsEntries.size > 0) {
-    console.log('Discovered exports entries:')
+    logger.log('Discovered exports entries:')
     const maxLengthOfExportName = Math.max(
       ...Array.from(exportsEntries.keys()).map(
         (exportName) => normalizeBaseNameToExportName(exportName).length,
@@ -221,12 +242,13 @@ export async function prepare(cwd: string): Promise<void> {
           0,
         ),
       )
-      console.log(
+      logger.log(
         `  ${normalizeBaseNameToExportName(
           exportName,
         )}${spaces}: ${exportFile}`,
       )
     }
+
     const pkgExports: Record<string, any> = {}
     for (const [exportName, sourceFile] of exportsEntries.entries()) {
       const [key, value] = createExportConditionPair(
@@ -242,13 +264,21 @@ export async function prepare(cwd: string): Promise<void> {
 
     // Configure node10 module resolution
     if (exportsEntries.has('index')) {
-      const mainCondition = pkgExports['.']
-      const isObjectCondition = typeof mainCondition.require === 'object'
-      pkgJson.main = isObjectCondition ? mainCondition.require.default : mainCondition.require
-      pkgJson.module = isObjectCondition ? mainCondition.import.default : mainCondition.import
+      const isESM = pkgJson.type === 'module'
+      const mainExport = pkgExports['.']
+      const isObjectCondition = typeof mainExport.require === 'object'
+      const mainCondition = isESM ? 'import' : 'require'
+      pkgJson.main = isObjectCondition
+        ? mainExport[mainCondition].default
+        : mainExport[mainCondition]
+      pkgJson.module = isObjectCondition
+        ? mainExport.import.default
+        : mainExport.import
 
-      if (mainCondition.require.types) {
-        pkgJson.types = mainCondition.require.types
+      if (isUsingTs) {
+        pkgJson.types = isESM
+          ? mainExport.import.types
+          : mainExport.require.types
       }
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -128,7 +128,7 @@ export async function getSourcePathFromExportPath(
 }
 
 // Unlike path.basename, forcedly removing extension
-export function filenameWithoutExtension(file: string | undefined) {
+export function filePathWithoutExtension(file: string | undefined) {
   return file
     ? file.replace(new RegExp(`${path.extname(file)}$`), '')
     : undefined

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -687,8 +687,8 @@ const testCases: {
             default: './dist/es/foo.mjs',
           },
           require: {
-            types: './dist/cjs/foo.d.ts',
-            default: './dist/cjs/foo.js',
+            types: './dist/cjs/foo.d.cts',
+            default: './dist/cjs/foo.cjs',
           },
         },
         '.': {
@@ -698,8 +698,8 @@ const testCases: {
             default: './dist/es/index.mjs',
           },
           require: {
-            types: './dist/cjs/index.d.ts',
-            default: './dist/cjs/index.js',
+            types: './dist/cjs/index.d.cts',
+            default: './dist/cjs/index.cjs',
           },
         },
       })

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -622,7 +622,7 @@ const testCases: {
     name: 'prepare-js',
     args: ['--prepare'],
     async before(dir) {
-      await deleteFile(join(dir, './package.json'))
+      await fsp.writeFile(join(dir, './package.json'), '{ "type": "commonjs" }')
     },
     async expected(dir, { stdout }) {
       assertContainFiles(dir, ['package.json'])

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -629,6 +629,9 @@ const testCases: {
       const pkgJson = JSON.parse(
         await fsp.readFile(join(dir, './package.json'), 'utf-8'),
       )
+      expect(pkgJson.main).toBe('./dist/index.js')
+      expect(pkgJson.module).toBe('./dist/index.mjs')
+      expect(pkgJson.types).toBeFalsy()
       expect(pkgJson.files).toContain('dist')
       expect(pkgJson.bin).toBe('./dist/bin/index.js')
       expect(pkgJson.exports).toEqual({


### PR DESCRIPTION
* Optional configure `types` field
* By default, output `"type": "module"` and esm/cjs exports with correct extension. `require` condition with `.cjs` files