### PR TITLE
Fix retrieving bad source file from src folder

### DIFF
--- a/src/lib/wildcard.ts
+++ b/src/lib/wildcard.ts
@@ -1,5 +1,5 @@
 import type { Dirent } from 'fs'
-import fs from 'fs/promises'
+import fsp from 'fs/promises'
 import path from 'path'
 import { SRC } from '../constants'
 import { ExportCondition } from '../types'
@@ -22,7 +22,7 @@ const isExportable = async (
   pathname: string,
 ): Promise<boolean> => {
   if (dirent.isDirectory()) {
-    const innerDirents = await fs.readdir(path.join(pathname, dirent.name), {
+    const innerDirents = await fsp.readdir(path.join(pathname, dirent.name), {
       withFileTypes: true,
     })
     return innerDirents.some(
@@ -41,7 +41,7 @@ async function getExportables(
   excludeKeys: string[],
 ): Promise<string[]> {
   const pathname = path.resolve(cwd, SRC)
-  const dirents = await fs.readdir(pathname, { withFileTypes: true })
+  const dirents = await fsp.readdir(pathname, { withFileTypes: true })
   const exportables: (string | undefined)[] = await Promise.all(
     dirents.map(async (dirent) =>
       (await isExportable(dirent, pathname)) &&

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -89,10 +89,11 @@ export async function findSourceEntryFile(
       exportTypeSuffix ? `.${exportTypeSuffix}` : ''
     }.${ext}`,
   )
-
-  if (await fileExists(subFolderIndexFilename)) {
-    return subFolderIndexFilename
-  }
+  try {
+    if (await fileExists(subFolderIndexFilename)) {
+      return subFolderIndexFilename
+    }
+  } catch {}
   return undefined
 }
 
@@ -106,7 +107,7 @@ export async function getSourcePathFromExportPath(
 ): Promise<string | undefined> {
   for (const ext of availableExtensions) {
     // ignore package.json
-    if (exportPath.endsWith('package.json')) return
+    if (exportPath === '/package.json') return
     if (exportPath === '.') exportPath = './index'
 
     // Find convention-based source file for specific export types

--- a/test/integration/no-entry/package.json
+++ b/test/integration/no-entry/package.json
@@ -1,4 +1,8 @@
 {
   "name": "no-entry",
-  "main": "./dist/index.js"
+  "main": "./dist/index.js",
+  "exports": {
+    "./package.json": "./package.json",
+    "./style.css": "./src/style.css"
+  }
 }


### PR DESCRIPTION
If the dir and source file is not existed, it might error

For example searching `style.css/index.js`