### PR TITLE
fix: no log output state in watch mode

### DIFF
--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -197,7 +197,9 @@ async function bundle(
     )
   }
 
-  logOutputState(sizeCollector)
+  if (!options.watch) {
+    logOutputState(sizeCollector)
+  }
   return result
 }
 


### PR DESCRIPTION
In watch mode, bunchee log output look like: 

```bash
❯ bunchee -w    
Exports  File  Size
Watching assets in /Users/nnecec/Github/bunchee...
```

I think don't need log output state in watch mode.