### PR TITLE
fix: do not log "Detected using TS but tsconfig is missing" if tsconfig exists

### DIFF
--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -190,12 +190,12 @@ export async function prepare(cwd: string): Promise<void> {
     isUsingTs = true
     if (!fs.existsSync(tsconfigPath)) {
       await fsp.writeFile(tsconfigPath, JSON.stringify(DEFAULT_TS_CONFIG, null, 2), 'utf-8')
+      logger.log(
+        `Detected using TypeScript but tsconfig.json is missing, created a ${pc.blue(
+          'tsconfig.json',
+        )} for you.`,
+      )
     }
-    logger.log(
-      `Detected using TypeScript but tsconfig.json is missing, created a ${pc.blue(
-        'tsconfig.json',
-      )} for you.`,
-    )
   }
 
   // Configure as ESM package by default if there's no package.json

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -736,7 +736,7 @@ const testCases: {
       await fsp.writeFile(join(dir, './package.json'), '{ "name": "prepare-ts-with-pkg-json" }')
       await deleteFile(join(dir, './tsconfig.json'))
     },
-    async expected(dir, { stdout }) {
+    async expected(dir) {
       assertContainFiles(dir, ['package.json'])
       const pkgJson = JSON.parse(
         await fsp.readFile(join(dir, './package.json'), 'utf-8'),

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -734,9 +734,8 @@ const testCases: {
     args: ['--prepare'],
     async before(dir) {
       await fsp.writeFile(join(dir, './package.json'), '{ "name": "prepare-ts-with-pkg-json" }')
-      await deleteFile(join(dir, './tsconfig.json'))
     },
-    async expected(dir) {
+    async expected(dir, { stdout }) {
       assertContainFiles(dir, ['package.json'])
       const pkgJson = JSON.parse(
         await fsp.readFile(join(dir, './package.json'), 'utf-8'),
@@ -745,6 +744,9 @@ const testCases: {
       expect(pkgJson.type).toBeUndefined()
       expect(pkgJson.main).toBe('./dist/cjs/index.js')
       expect(pkgJson.module).toBe('./dist/es/index.mjs')
+      expect(stripANSIColor(stdout)).not.toContain(
+        'Detected using TypeScript but tsconfig.json is missing, created a tsconfig.json for you.',
+      )
     },
   }
 ]

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -734,6 +734,7 @@ const testCases: {
     args: ['--prepare'],
     async before(dir) {
       await fsp.writeFile(join(dir, './package.json'), '{ "name": "prepare-ts-with-pkg-json" }')
+      await deleteFile(join(dir, './tsconfig.json'))
     },
     async expected(dir, { stdout }) {
       assertContainFiles(dir, ['package.json'])
@@ -744,9 +745,6 @@ const testCases: {
       expect(pkgJson.type).toBeUndefined()
       expect(pkgJson.main).toBe('./dist/cjs/index.js')
       expect(pkgJson.module).toBe('./dist/es/index.mjs')
-      expect(stripANSIColor(stdout)).not.toContain(
-        'Detected using TypeScript but tsconfig.json is missing, created a tsconfig.json for you.',
-      )
     },
   }
 ]


### PR DESCRIPTION
This PR ensures to log "Detected using TypeScript but tsconfig.json is missing, created a tsconfig.json for you." only if the tsconfig does not exist.