### PR TITLE
Fix ts incremental error when tsbuildfile is specified

### DIFF
--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -183,13 +183,6 @@ async function buildInputConfig(
         declarationMap: false,
         skipLibCheck: true,
         target: 'ESNext',
-        // Some react types required this to be false by default.
-        // Some type package like express might need this as it has other dependencies.
-        // Let users able to toggle this in tsconfig.
-        preserveSymlinks:
-          'preserveSymlinks' in tsCompilerOptions
-            ? tsCompilerOptions.preserveSymlinks
-            : false,
         ...(!tsCompilerOptions.jsx
           ? {
               jsx: 'react-jsx',
@@ -197,7 +190,11 @@ async function buildInputConfig(
           : undefined),
         // error TS5074: Option '--incremental' can only be specified using tsconfig, emitting to single
         // file or when option '--tsBuildInfoFile' is specified.
-        incremental: false,
+        ...(tsCompilerOptions.incremental && !tsCompilerOptions.tsBuildInfoFile
+          ? {
+            incremental: false,
+          } : undefined
+        )
       })
 
     const dtsPlugin = (

--- a/test/integration/ts-incremental-with-buildinfofile/package.json
+++ b/test/integration/ts-incremental-with-buildinfofile/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "ts-incremental",
+  "types": "./dist/index.d.ts",
+  "exports": "./dist/index.js"
+}

--- a/test/integration/ts-incremental-with-buildinfofile/src/index.ts
+++ b/test/integration/ts-incremental-with-buildinfofile/src/index.ts
@@ -1,0 +1,1 @@
+export default () => 'index'

--- a/test/integration/ts-incremental-with-buildinfofile/tsconfig.json
+++ b/test/integration/ts-incremental-with-buildinfofile/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "incremental": true,
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo"
+  }
+}

--- a/test/testing-utils.ts
+++ b/test/testing-utils.ts
@@ -24,7 +24,7 @@ export async function existsFile(filePath: string) {
 export function assertContainFiles(dir: string, filePaths: string[]) {
   const results = []
   for (const filePath of filePaths) {
-    const fullPath = path.join(dir, filePath)
+    const fullPath = path.resolve(dir, filePath)
     const existed = fs.existsSync(fullPath)
     if (existed) {
       results.push(filePath)


### PR DESCRIPTION
Fixes #386 

can't disable the incremental config for dts generation as it still can work and disabling might breaks ts rules