### PR TITLE
feat: auto inject env for development and production condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Then use use the [exports field in package.json](https://nodejs.org/api/packages
   "files": ["dist"],
   "exports": {
     "import": "./dist/es/index.mjs",
-    "require": "./dist/cjs/index.cjs"
+    "require": "./dist/cjs/index.js"
   },
   "scripts": {
     "build": "bunchee"
@@ -88,8 +88,8 @@ If you're build a TypeScript library, separate the types from the main entry fil
       "default": "./dist/es/index.mjs"
     },
     "require": {
-      "types": "./dist/cjs/index.d.cts",
-      "default": "./dist/cjs/index.cjs"
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.js"
     }
   },
   "scripts": {
@@ -107,13 +107,13 @@ If you're using TypeScript with Node 10 and Node 16 module resolution, you can u
 ```json
 {
   "files": ["dist"],
-  "main": "./dist/cjs/index.cjs",
+  "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.mjs",
   "types": "./dist/cjs/index.d.ts",
   "exports": {
     "import": {
-      "types": "./dist/es/index.d.mts",
-      "default": "./dist/es/index.mjs"
+      "types": "./dist/es/index.d.ts",
+      "default": "./dist/es/index.js"
     },
     "require": {
       "types": "./dist/cjs/index.d.cts",
@@ -322,6 +322,21 @@ You can use `index.<export-type>.<ext>` to override the input source file for sp
 ```
 
 This will match the export name `"react-server"` and `"edge-light"` then use the corresponding input source file to build the bundle.
+
+#### Auto Development and Production Mode
+
+`process.env.NODE_ENV` is injected by default if present that you don't need to manually inject yourself. If you need to separate the development build and production build, `bunchee` provides different export conditions for development and production mode with `development` and `production` export conditions.
+
+```json
+{
+  "exports": {
+    "development": "./dist/index.development.js",
+    "production": "./dist/index.production.js"
+  }
+}
+```
+
+Then you can use `bunchee` to build the development bundle and production bundle automatically.
 
 ### Wildcard Exports
 

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -18,7 +18,6 @@ import {
 import {
   createOutputState,
   logOutputState,
-  type BuildContext,
 } from './plugins/output-state-plugin'
 import { logger } from './logger'
 import {
@@ -33,7 +32,7 @@ import {
   getExportPaths,
   getPackageType,
 } from './exports'
-import type { BuildMetadata } from './types'
+import type { BuildMetadata, BuildContext } from './types'
 import { TypescriptOptions, resolveTsConfig } from './typescript'
 import { resolveWildcardExports } from './lib/wildcard'
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,10 +16,12 @@ export const nodeResolveExtensions = [
   '.node',
   '.jsx',
 ]
-export const availableExportConventions = new Set([
+export const suffixedExportConventions = new Set([
   'react-server',
   'react-native',
   'edge-light',
+  'development',
+  'production',
 ])
 export const availableESExtensionsRegex = /\.(m|c)?[jt]sx?$/
 export const dtsExtensionRegex = /\.d\.(m|c)?ts$/

--- a/src/plugins/output-state-plugin.ts
+++ b/src/plugins/output-state-plugin.ts
@@ -2,26 +2,13 @@ import type { Plugin } from 'rollup'
 import path from 'path'
 import prettyBytes from 'pretty-bytes'
 import pc from 'picocolors'
-import { Entries, FullExportCondition, PackageMetadata } from '../types'
-import type { TypescriptOptions } from '../typescript'
+import { type Entries } from '../types'
 import { relativify } from '../lib/format'
+import { logger } from '../logger'
 
 type Pair = [string, string, number]
 type SizeStats = Map<string, Pair[]>
-// TODO: move BuildContext type to src/types as shared type
-type BuildContext = {
-  entries: Entries
-  pkg: PackageMetadata
-  exportPaths: Record<string, FullExportCondition>
-  cwd: string
-  tsOptions: TypescriptOptions
-  useTypeScript: boolean
-  pluginContext: {
-    outputState: ReturnType<typeof createOutputState>
-    moduleDirectiveLayerMap: Map<string, Set<[string, string]>>
-    entriesAlias: Record<string, string>
-  }
-}
+export type OutputState = ReturnType<typeof createOutputState>
 
 // Example: @foo/bar -> bar
 const removeScope = (exportPath: string) => exportPath.replace(/^@[^/]+\//, '')
@@ -136,6 +123,12 @@ function getExportNameWithoutExportCondition(exportName: string): string {
 
 function logOutputState(sizeCollector: ReturnType<typeof createOutputState>) {
   const stats = sizeCollector.getSizeStats()
+
+  if (stats.size === 0) {
+    logger.warn('No build info can be logged')
+    return
+  }
+
   const allFileNameLengths = Array.from(stats.values())
     .flat(1)
     .map(([filename]) => filename.length)
@@ -197,4 +190,4 @@ function logOutputState(sizeCollector: ReturnType<typeof createOutputState>) {
   })
 }
 
-export { logOutputState, createOutputState, type BuildContext }
+export { logOutputState, createOutputState }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,7 @@
 import type { JscTarget } from '@swc/types'
 import type { InputOptions, OutputOptions, RollupOptions } from 'rollup'
+import type { OutputState } from './plugins/output-state-plugin'
+import type { TypescriptOptions } from './typescript'
 
 type PackageType = 'commonjs' | 'module'
 
@@ -97,6 +99,20 @@ type ExportPaths = Record<string, FullExportCondition>
 
 type Entries = Record<string, ParsedExportCondition>
 
+type BuildContext = {
+  entries: Entries
+  pkg: PackageMetadata
+  exportPaths: Record<string, FullExportCondition>
+  cwd: string
+  tsOptions: TypescriptOptions
+  useTypeScript: boolean
+  pluginContext: {
+    outputState: OutputState
+    moduleDirectiveLayerMap: Map<string, Set<[string, string]>>
+    entriesAlias: Record<string, string>
+  }
+}
+
 export type {
   ExportPaths,
   ExportType,
@@ -111,4 +127,5 @@ export type {
   PackageType,
   ParsedExportCondition,
   Entries,
+  BuildContext,
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@ import path from 'path'
 import { rimraf } from 'rimraf'
 import { PackageMetadata } from './types'
 import {
-  availableExportConventions,
+  suffixedExportConventions,
   availableExtensions,
   SRC,
   tsExtensions,
@@ -119,10 +119,7 @@ export async function getSourcePathFromExportPath(
 
     // Find convention-based source file for specific export types
     // $binary represents `pkg.bin`
-    if (
-      availableExportConventions.has(exportType) &&
-      exportType !== '$binary'
-    ) {
+    if (suffixedExportConventions.has(exportType) && exportType !== '$binary') {
       const filename = await findSourceEntryFile(
         cwd,
         exportPath,

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -761,6 +761,18 @@ const testCases: {
     },
   },
   {
+    name: 'dev-prod-convention',
+    async expected(dir) {
+      const distFiles = ['./dist/development.js', './dist/production.js']
+      assertContainFiles(dir, distFiles)
+
+      assertFilesContent(dir, {
+        './dist/development.js': /= "development"/,
+        './dist/production.js': /= "production"/,
+      })
+    },
+  },
+  {
     name: 'no-clean',
     args: ['--no-clean'],
     async before(dir) {

--- a/test/integration/dev-prod-convention/package.json
+++ b/test/integration/dev-prod-convention/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "dev-prod-convention",
+  "exports": {
+    "development": "./dist/development.js",
+    "production": "./dist/production.js"
+  }
+}

--- a/test/integration/dev-prod-convention/src/index.development.js
+++ b/test/integration/dev-prod-convention/src/index.development.js
@@ -1,0 +1,1 @@
+export const value = process.env.NODE_ENV

--- a/test/integration/dev-prod-convention/src/index.production.js
+++ b/test/integration/dev-prod-convention/src/index.production.js
@@ -1,0 +1,1 @@
+export const value = process.env.NODE_ENV


### PR DESCRIPTION
Resolves #391 

A feature that already has in webpack, and proposed by @amannn 

If you have `"development": "./dist/index.development.js"`, `NODE_ENV: development` will be injected by default;
If you have `"production": "./dist/index.production.js"`, `NODE_ENV: production` will be injected by default;