### PR TITLE
fix: Logging is off format

### DIFF
--- a/src/plugins/output-state-plugin.ts
+++ b/src/plugins/output-state-plugin.ts
@@ -173,18 +173,24 @@ function logOutputState(sizeCollector: ReturnType<typeof createOutputState>) {
         const normalizedExportName = normalizeExportName(exportName)
         const prefix =
           index === 0
-            ? normalizedExportName +
-              ' '.repeat(maxLengthOfExportName - normalizedExportName.length)
-            : ' '.repeat(maxLengthOfExportName)
-
-        const sizePadding = ' '.repeat(maxFilenameLength - filename.length)
-        const prettiedSize = prettyBytes(size)
+            ? normalizedExportName
+            : ' '.repeat(normalizedExportName.length)
+        const filenamePadding = ' '.repeat(
+          Math.max(maxLengthOfExportName, 'Exports'.length) -
+            normalizedExportName.length,
+        )
         const isType = isTypeFile(filename)
+        const sizePadding = ' '.repeat(
+          Math.max(maxFilenameLength, 'File'.length) - filename.length,
+        )
+        const prettiedSize = prettyBytes(size)
 
         console.log(
-          ` ${prefix} ${pc[isType ? 'dim' : 'bold'](
-            filename,
-          )}${sizePadding}  ${prettiedSize}`,
+          prefix,
+          filenamePadding,
+          `${pc[isType ? 'dim' : 'bold'](filename)}`,
+          sizePadding,
+          prettiedSize,
         )
       })
   })

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -15,9 +15,10 @@ jest.setTimeout(10 * 60 * 1000)
 
 const integrationTestDir = resolve(__dirname, 'integration')
 const getPath = (filepath: string) => join(integrationTestDir, filepath)
-const getSizeIndex = (line: string): number => {
+
+const getOutputSizeColumnIndex = (line: string): number => {
   let match
-  while ((match = /\d+\sB/g.exec(line)) !== null) {
+  if ((match = /\d+\sK?B/g.exec(line)) !== null) {
     return match.index
   }
   return -1
@@ -637,11 +638,11 @@ const testCases: {
 
       expect(cliLine.indexOf('cli (bin)')).toEqual(exportsIndex)
       expect(cliLine.indexOf('dist/cli.js')).toEqual(fileIndex)
-      expect(getSizeIndex(cliLine)).toEqual(sizeIndex)
+      expect(getOutputSizeColumnIndex(cliLine)).toEqual(sizeIndex)
 
       expect(indexLine.indexOf('.')).toEqual(exportsIndex)
       expect(indexLine.indexOf('dist/index.js')).toEqual(fileIndex)
-      expect(getSizeIndex(indexLine)).toEqual(sizeIndex)
+      expect(getOutputSizeColumnIndex(indexLine)).toEqual(sizeIndex)
 
       expect(indexReactServerLine.indexOf('. (react-server)')).toEqual(
         exportsIndex,
@@ -649,11 +650,11 @@ const testCases: {
       expect(
         indexReactServerLine.indexOf('dist/index.react-server.js'),
       ).toEqual(fileIndex)
-      expect(getSizeIndex(indexReactServerLine)).toEqual(sizeIndex)
+      expect(getOutputSizeColumnIndex(indexReactServerLine)).toEqual(sizeIndex)
 
       expect(fooLine.indexOf('./foo')).toEqual(exportsIndex)
       expect(fooLine.indexOf('dist/foo.js')).toEqual(fileIndex)
-      expect(getSizeIndex(fooLine)).toEqual(sizeIndex)
+      expect(getOutputSizeColumnIndex(fooLine)).toEqual(sizeIndex)
     },
   },
   {
@@ -682,7 +683,7 @@ const testCases: {
 
       expect(indexLine.indexOf('.')).toEqual(exportsIndex)
       expect(indexLine.indexOf('dist/index.js')).toEqual(fileIndex)
-      expect(getSizeIndex(indexLine)).toEqual(sizeIndex)
+      expect(getOutputSizeColumnIndex(indexLine)).toEqual(sizeIndex)
     },
   },
   {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -15,6 +15,13 @@ jest.setTimeout(10 * 60 * 1000)
 
 const integrationTestDir = resolve(__dirname, 'integration')
 const getPath = (filepath: string) => join(integrationTestDir, filepath)
+const getSizeIndex = (line: string): number => {
+  let match
+  while ((match = /\d+\sB/g.exec(line)) !== null) {
+    return match.index
+  }
+  return -1
+}
 
 const testCases: {
   name: string
@@ -603,7 +610,7 @@ const testCases: {
       ./foo            dist/foo.js                 103 B
       */
 
-      const lines = stdout.split('\n')
+      const lines = stripANSIColor(stdout).split('\n')
       const [tableHeads, cliLine, indexLine, indexReactServerLine, fooLine] =
         lines
       expect(tableHeads).toContain('Exports')
@@ -621,6 +628,61 @@ const testCases: {
 
       expect(fooLine).toContain('./foo')
       expect(fooLine).toContain('dist/foo.js')
+
+      const [exportsIndex, fileIndex, sizeIndex] = [
+        tableHeads.indexOf('Exports'),
+        tableHeads.indexOf('File'),
+        tableHeads.indexOf('Size'),
+      ]
+
+      expect(cliLine.indexOf('cli (bin)')).toEqual(exportsIndex)
+      expect(cliLine.indexOf('dist/cli.js')).toEqual(fileIndex)
+      expect(getSizeIndex(cliLine)).toEqual(sizeIndex)
+
+      expect(indexLine.indexOf('.')).toEqual(exportsIndex)
+      expect(indexLine.indexOf('dist/index.js')).toEqual(fileIndex)
+      expect(getSizeIndex(indexLine)).toEqual(sizeIndex)
+
+      expect(indexReactServerLine.indexOf('. (react-server)')).toEqual(
+        exportsIndex,
+      )
+      expect(
+        indexReactServerLine.indexOf('dist/index.react-server.js'),
+      ).toEqual(fileIndex)
+      expect(getSizeIndex(indexReactServerLine)).toEqual(sizeIndex)
+
+      expect(fooLine.indexOf('./foo')).toEqual(exportsIndex)
+      expect(fooLine.indexOf('dist/foo.js')).toEqual(fileIndex)
+      expect(getSizeIndex(fooLine)).toEqual(sizeIndex)
+    },
+  },
+  {
+    name: 'output-short',
+    args: [],
+    async expected(dir, { stdout, stderr }) {
+      /*
+      output:
+
+      Exports File          Size
+      .       dist/index.js 30 B
+      */
+      const [tableHeads, indexLine] = stripANSIColor(stdout).split('\n')
+      expect(tableHeads).toContain('Exports')
+      expect(tableHeads).toContain('File')
+      expect(tableHeads).toContain('Size')
+
+      expect(indexLine).toContain('.')
+      expect(indexLine).toContain('dist/index.js')
+
+      const [exportsIndex, fileIndex, sizeIndex] = [
+        tableHeads.indexOf('Exports'),
+        tableHeads.indexOf('File'),
+        tableHeads.indexOf('Size'),
+      ]
+
+      expect(indexLine.indexOf('.')).toEqual(exportsIndex)
+      expect(indexLine.indexOf('dist/index.js')).toEqual(fileIndex)
+      expect(getSizeIndex(indexLine)).toEqual(sizeIndex)
     },
   },
   {
@@ -895,6 +957,7 @@ function runTests() {
         await before(dir)
       }
       const { stdout, stderr } = await runBundle(dir, args)
+
       stdout && debug.log(stdout)
       stderr && debug.error(stderr)
 

--- a/test/integration/output-short/package.json
+++ b/test/integration/output-short/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "output-short",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js"
+    }
+  }
+}

--- a/test/integration/output-short/package.json
+++ b/test/integration/output-short/package.json
@@ -2,7 +2,7 @@
   "name": "output-short",
   "exports": {
     ".": {
-      "import": "./dist/index.js"
+      "require": "./dist/index.js"
     }
   }
 }

--- a/test/integration/output-short/src/index.js
+++ b/test/integration/output-short/src/index.js
@@ -1,0 +1,1 @@
+export const o = 'o'


### PR DESCRIPTION
resolve https://github.com/huozhi/bunchee/issues/404 (✌️I fixed the 404 issue)

Because of `console.log` will auto add a space between two args, I cancel combine `arg + space` like `prefix` before.