### PR TITLE
feat: print end status in watch mode

### DIFF
--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -156,7 +156,7 @@ async function run(args: CliArgs) {
 
   // watching mode
   if (watch) {
-    logger.log(`Watching assets in ${cwd}...`)
+    logger.log(`Watching project ${cwd}...`)
     return
   }
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -260,7 +260,7 @@ const testCases: {
     name: 'output-in-watch',
     dist: createTempDir,
     timeoutClose: 4000,
-    expectedCode: 143,
+    expectedCode: 143, // finish watch mode by `ps.kill('SIGTERM')`, and it will send 143 code
     args: [resolveFromTest('hello.js'), '-w'],
     expected(_, { stdout }) {
       const watchOutputRegex = /Build in \d+(.\d{2})ms/
@@ -285,7 +285,7 @@ describe('cli', () => {
       timeoutClose,
       expectedCode,
     } = testCase
-    it(`cli ${name} should work properly`, async () => {
+    it(`cli ${name} should work properly`, async (done) => {
       // Delete the of dist folder: folder of dist file (as last argument) or `dist` option
       let distDir
       let distFile

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -265,7 +265,7 @@ const testCases: {
     expected(_, { stdout }) {
       const watchOutputRegex = /Build in \d+(.\d{2})ms/
       return [
-        [stdout.includes('Watching assets in'), true],
+        [stdout.includes('Watching project'), true],
         [watchOutputRegex.test(stdout), true],
         [stdout.includes('Exports'), false],
       ]


### PR DESCRIPTION
I sometimes wonder if I've built done in watch mode, because it print nothing when built sucessfully.
 
Do we need to print some hint like these in watch mode?

```bash
> bunchee -w

Watching project /Users/nnecec/Github/bunchee...
📦 Build in: 1.956s
📦 Build in: 595.334ms
src/bundle.ts(25,3): error TS6133: 'getPackageMeta' is declared but its value is never read.
src/bundle.ts(70,64): error TS2304: Cannot find name 'pkg'.
src/bundle.ts(71,38): error TS2304: Cannot find name 'pkg'.
src/bundle.ts(73,38): error TS2304: Cannot find name 'pkg'.
src/bundle.ts(75,26): error TS2304: Cannot find name 'pkg'.
src/bundle.ts(153,40): error TS2304: Cannot find name 'pkg'.
src/bundle.ts(177,5): error TS18004: No value exists in scope for the shorthand property 'pkg'. Either declare one or provide an initializer.

📦 Build in: 652.215ms
📦 Build in: 512.592ms
```