### PR TITLE
Fix ts-composite project build failure

### DIFF
--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -186,6 +186,20 @@ async function buildInputConfig(
   const typesPlugins = [...commonPlugins, inlineCss({ skip: true })]
 
   if (useTypeScript) {
+    const enableIncrementalWithoutBuildInfo =
+      tsCompilerOptions.incremental && !tsCompilerOptions.tsBuildInfoFile
+    const incrementalOptions = enableIncrementalWithoutBuildInfo
+      ? {
+          incremental: false,
+        }
+      : undefined
+    const compositeOptions =
+      tsCompilerOptions.composite && enableIncrementalWithoutBuildInfo
+        ? {
+            composite: false,
+          }
+        : undefined
+
     const { options: overrideResolvedTsOptions }: any =
       await convertCompilerOptions(cwd, {
         declaration: true,
@@ -203,11 +217,9 @@ async function buildInputConfig(
           : undefined),
         // error TS5074: Option '--incremental' can only be specified using tsconfig, emitting to single
         // file or when option '--tsBuildInfoFile' is specified.
-        ...(tsCompilerOptions.incremental && !tsCompilerOptions.tsBuildInfoFile
-          ? {
-              incremental: false,
-            }
-          : undefined),
+        ...incrementalOptions,
+        // error TS6379: Composite projects may not disable incremental compilation.
+        ...compositeOptions,
       })
 
     const dtsPlugin = (

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -846,8 +846,6 @@ const testCases: {
   {
     name: 'ts-composite',
     dir: 'monorepo/packages/package',
-    skip: true,
-    args: [],
     async expected(dir) {
       expect(await existsFile(join(dir, './dist/index.js'))).toBe(true)
       expect(await existsFile(join(dir, './dist/index.d.ts'))).toBe(true)


### PR DESCRIPTION
Fixes #406 


Ideally would pull all the ts compiler option values from `tsconfig.json` as override config for dts plugin. or let dts plugin not use the partial compiler options as override options. Then there's no `{ incremental: true }` or `{ composite: true, incremental: false }` case that being resolved


Or avoid dts plugin avoid resolving the tsconfig.json to read options, so we can always use the simple overriden ones