### PR TITLE
Fix: bad lint rule for main field

### DIFF
--- a/src/lint.ts
+++ b/src/lint.ts
@@ -50,10 +50,6 @@ export function lint(pkg: PackageMetadata) {
 
   // Validate ESM package
   if (isESM) {
-    if (main && hasCjsExtension(main)) {
-      state.badMainExtension = true
-    }
-
     if (exports) {
       if (typeof exports === 'string') {
         if (hasCjsExtension(exports)) {
@@ -87,6 +83,9 @@ export function lint(pkg: PackageMetadata) {
       }
     }
   } else {
+    if (main && path.extname(main) === '.mjs') {
+      state.badMainExtension = true
+    }
     // Validate CJS package
     if (exports) {
       if (typeof exports === 'string') {
@@ -124,7 +123,7 @@ export function lint(pkg: PackageMetadata) {
 
   if (state.badMainExtension) {
     logger.warn(
-      'Cannot export `main` field with .cjs extension in ESM package, only .mjs and .js extensions are allowed',
+      'Cannot export `main` field with .mjs extension in CJS package, only .js extension is allowed',
     )
   }
   if (state.badMainExport) {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -363,11 +363,11 @@ const testCases: {
     },
   },
   {
-    name: 'esm-pkg-cjs-main-field',
+    name: 'cjs-pkg-esm-main-field',
     args: [],
     async expected(_, { stderr }) {
       expect(stderr).toContain(
-        'Cannot export `main` field with .cjs extension in ESM package, only .mjs and .js extensions are allowed',
+        'Cannot export `main` field with .mjs extension in CJS package, only .js extension is allowed',
       )
     },
   },

--- a/test/integration/cjs-pkg-esm-main-field/package.json
+++ b/test/integration/cjs-pkg-esm-main-field/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "commonjs",
+  "main": "./dist/index.mjs"
+}

--- a/test/integration/cjs-pkg-esm-main-field/src/index.js
+++ b/test/integration/cjs-pkg-esm-main-field/src/index.js
@@ -1,0 +1,1 @@
+export const value = 'cjs'

--- a/test/integration/esm-pkg-cjs-main-field/package.json
+++ b/test/integration/esm-pkg-cjs-main-field/package.json
@@ -1,4 +1,0 @@
-{
-  "type": "module",
-  "main": "./dist/index.cjs"
-}

--- a/test/integration/esm-pkg-cjs-main-field/src/index.cjs
+++ b/test/integration/esm-pkg-cjs-main-field/src/index.cjs
@@ -1,1 +1,0 @@
-exports.value = 'cjs'


### PR DESCRIPTION
Fixes #420 

There was a case that`main` field was not built in #268, then we introduced a rule that `main` cannot be `index.cjs` which is wrong. But it should be valid now