### PR TITLE
Generate relative path for types

### DIFF
--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -175,11 +175,9 @@ async function buildInputConfig(
   const commonPlugins = [
     sizePlugin,
     aliasEntries({
-      entries: {
-        ...pluginContext.entriesAlias,
-        // Do not alias current alias of package
-        [entry]: null,
-      },
+      entry,
+      entries,
+      reversedAlias: pluginContext.entriesAlias,
     }),
   ]
 

--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -184,7 +184,9 @@ async function buildInputConfig(
     aliasEntries({
       entry,
       entries,
+      entriesAlias: pluginContext.entriesAlias,
       format: aliasFormat,
+      dts,
     }),
   ]
 

--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -108,9 +108,9 @@ export function getReversedAlias(entries: Entries) {
 
 async function buildInputConfig(
   entry: string,
-  options: BundleOptions,
-  buildContext: BuildContext,
+  bundleConfig: BundleOptions,
   exportCondition: ParsedExportCondition,
+  buildContext: BuildContext,
   dts: boolean,
 ): Promise<InputOptions> {
   const {
@@ -120,14 +120,14 @@ async function buildInputConfig(
     tsOptions: { tsConfigPath, tsCompilerOptions },
     pluginContext,
   } = buildContext
-  const hasNoExternal = options.external === null
+  const hasNoExternal = bundleConfig.external === null
   const externals = hasNoExternal
     ? []
     : [pkg.peerDependencies, pkg.dependencies, pkg.peerDependenciesMeta]
         .filter(<T>(n?: T): n is T => Boolean(n))
         .map((o: { [key: string]: any }): string[] => Object.keys(o))
         .reduce((a: string[], b: string[]) => a.concat(b), [])
-        .concat(options.external ?? [])
+        .concat(bundleConfig.external ?? [])
 
   for (const [exportImportPath, exportCondition] of Object.entries(entries)) {
     const entryFilePath = exportCondition.source
@@ -137,10 +137,10 @@ async function buildInputConfig(
     }
   }
 
-  const envValues = getBuildEnv(options.env || [], exportCondition.export)
+  const envValues = getBuildEnv(bundleConfig.env || [], exportCondition.export)
 
   const { useTypeScript } = buildContext
-  const { runtime, target: jscTarget, minify: shouldMinify } = options
+  const { runtime, target: jscTarget, minify: shouldMinify } = bundleConfig
   const hasSpecifiedTsTarget = Boolean(tsCompilerOptions.target && tsConfigPath)
 
   const swcParserConfig = {
@@ -160,11 +160,11 @@ async function buildInputConfig(
       ...(shouldMinify && {
         minify: {
           ...swcMinifyOptions,
-          sourceMap: options.sourcemap,
+          sourceMap: bundleConfig.sourcemap,
         },
       }),
     },
-    sourceMaps: options.sourcemap,
+    sourceMaps: bundleConfig.sourcemap,
     inlineSourcesContent: false,
     isModule: true,
   } as const
@@ -172,12 +172,19 @@ async function buildInputConfig(
   const sizePlugin = pluginContext.outputState.plugin(cwd)
 
   // common plugins for both dts and ts assets that need to be processed
+
+  const aliasFormat = dts
+    ? bundleConfig.file?.endsWith('.d.cts')
+      ? 'cjs'
+      : 'esm'
+    : bundleConfig.format
+
   const commonPlugins = [
     sizePlugin,
     aliasEntries({
       entry,
       entries,
-      reversedAlias: pluginContext.entriesAlias,
+      format: aliasFormat,
     }),
   ]
 
@@ -257,7 +264,7 @@ async function buildInputConfig(
             ...swcOptions,
           }),
           commonjs({
-            exclude: options.external || null,
+            exclude: bundleConfig.external || null,
           }),
           json(),
         ]
@@ -399,13 +406,17 @@ function createSplitChunks(
   }
 }
 
-function buildOutputConfigs(
-  options: BundleOptions,
+async function buildOutputConfigs(
+  entry: string,
+  bundleConfig: BundleConfig,
   exportCondition: ParsedExportCondition,
   buildContext: BuildContext,
   dts: boolean,
-): OutputOptions {
-  const { format } = options
+): Promise<{
+  input: InputOptions
+  output: OutputOptions
+}> {
+  const { format } = bundleConfig
   const {
     entries,
     pkg,
@@ -416,13 +427,14 @@ function buildOutputConfigs(
   } = buildContext
   // Add esm mark and interop helper if esm export is detected
   const useEsModuleMark = hasEsmExport(exportPaths, tsCompilerOptions)
-  const absoluteOutputFile = resolve(cwd, options.file!)
+  const absoluteOutputFile = resolve(cwd, bundleConfig.file!)
   const name = filePathWithoutExtension(absoluteOutputFile)
   const dtsFile = resolve(
     cwd,
     dts
-      ? options.file!
-      : exportCondition.export.types ?? getExportFileTypePath(options.file!),
+      ? bundleConfig.file!
+      : exportCondition.export.types ??
+          getExportFileTypePath(bundleConfig.file!),
   )
   const typesDir = dirname(dtsFile)
   const jsDir = dirname(absoluteOutputFile!)
@@ -431,7 +443,15 @@ function buildOutputConfigs(
     Object.values(entries).map((entry) => entry.source),
   )
 
-  return {
+  const inputOptions = await buildInputConfig(
+    entry,
+    bundleConfig,
+    exportCondition,
+    buildContext,
+    dts,
+  )
+
+  const outputOptions: OutputOptions = {
     name: pkg.name || name,
     dir: dts ? typesDir : jsDir,
     format,
@@ -440,7 +460,7 @@ function buildOutputConfigs(
     interop: 'auto',
     freeze: false,
     strict: false,
-    sourcemap: options.sourcemap,
+    sourcemap: bundleConfig.sourcemap,
     manualChunks: createSplitChunks(
       pluginContext.moduleDirectiveLayerMap,
       entryFiles,
@@ -451,6 +471,11 @@ function buildOutputConfigs(
     hoistTransitiveImports: false,
     entryFileNames: basename(outputFile),
   }
+
+  return {
+    input: inputOptions,
+    output: outputOptions,
+  }
 }
 
 export async function buildEntryConfig(
@@ -458,19 +483,19 @@ export async function buildEntryConfig(
   pluginContext: BuildContext,
   dts: boolean,
 ): Promise<BuncheeRollupConfig[]> {
-  const configs: Promise<BuncheeRollupConfig>[] = []
+  const configs: BuncheeRollupConfig[] = []
   const { entries } = pluginContext
 
   for (const exportCondition of Object.values(entries)) {
-    const rollupConfig = buildConfig(
+    const rollupConfigs = await buildConfig(
       bundleConfig,
       exportCondition,
       pluginContext,
       dts,
     )
-    configs.push(rollupConfig)
+    configs.push(...rollupConfigs)
   }
-  return await Promise.all(configs)
+  return configs
 }
 
 async function collectEntry(
@@ -608,19 +633,11 @@ async function buildConfig(
   exportCondition: ParsedExportCondition,
   pluginContext: BuildContext,
   dts: boolean,
-): Promise<BuncheeRollupConfig> {
+): Promise<BuncheeRollupConfig[]> {
   const { file } = bundleConfig
-  const { pkg, cwd, tsOptions } = pluginContext
-  const useTypescript = Boolean(tsOptions.tsConfigPath)
-  const options = { ...bundleConfig, useTypescript }
+  const { pkg, cwd } = pluginContext
   const entry = exportCondition.source
-  const inputOptions = await buildInputConfig(
-    entry,
-    options,
-    pluginContext,
-    exportCondition,
-    dts,
-  )
+
   const outputExports = getExportsDistFilesOfCondition(
     pkg,
     exportCondition,
@@ -676,13 +693,14 @@ async function buildConfig(
     bundleOptions = Array.from(uniqTypes).map((typeFile) => {
       return {
         resolvedFile: typeFile,
-        format: 'es',
+        format: 'esm',
       }
     })
   }
 
-  const outputConfigs = bundleOptions.map((bundleOption) => {
-    return buildOutputConfigs(
+  const outputConfigs = bundleOptions.map(async (bundleOption) => {
+    return await buildOutputConfigs(
+      entry,
       {
         ...bundleConfig,
         file: bundleOption.resolvedFile,
@@ -694,9 +712,5 @@ async function buildConfig(
     )
   })
 
-  return {
-    input: inputOptions,
-    output: outputConfigs,
-    exportName: exportCondition.name || '.',
-  }
+  return Promise.all(outputConfigs)
 }

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -63,7 +63,7 @@ async function bundle(
   { cwd: _cwd, ...options }: BundleConfig = {},
 ): Promise<any> {
   const cwd = resolve(process.cwd(), _cwd || '')
-  assignDefault(options, 'format', 'es')
+  assignDefault(options, 'format', 'esm')
   assignDefault(options, 'minify', false)
   assignDefault(options, 'target', 'es2015')
 
@@ -119,7 +119,7 @@ async function bundle(
 
   const bundleOrWatch = async (
     rollupConfig: BuncheeRollupConfig,
-  ): Promise<RollupWatcher | RollupOutput[] | void> => {
+  ): Promise<RollupWatcher | RollupOutput | void> => {
     if (options.clean) {
       if (!isFromCli) {
         await removeOutputDir(rollupConfig.output)
@@ -247,20 +247,13 @@ function runWatch({ input, output }: BuncheeRollupConfig): RollupWatcher {
   return watcher
 }
 
-async function removeOutputDir(output: BuncheeRollupConfig['output']) {
-  const dirs = new Set(output.map(({ dir }) => dir))
-
-  for (const dir of dirs) {
-    if (dir) await removeDir(dir)
-  }
+async function removeOutputDir(output: OutputOptions) {
+  if (output.dir) await removeDir(output.dir)
 }
 
 function runBundle({ input, output }: BuncheeRollupConfig) {
   return rollup(input).then((bundle: RollupBuild) => {
-    const writeJobs = output.map((options: OutputOptions) =>
-      bundle.write(options),
-    )
-    return Promise.all(writeJobs)
+    return bundle.write(output)
   }, catchErrorHandler)
 }
 

--- a/src/plugins/alias-plugin.ts
+++ b/src/plugins/alias-plugin.ts
@@ -4,31 +4,6 @@ import path from 'path'
 import { filePathWithoutExtension } from '../utils'
 import { relativify } from '../lib/format'
 
-function findCommonPrefix(strings: string[]): string {
-  if (strings.length === 0) {
-    return ''
-  }
-  let prefix = strings[0]
-  for (const str of strings) {
-    for (let i = 0; i < prefix.length; i++) {
-      if (prefix[i] !== str[i]) {
-        prefix = prefix.slice(0, i)
-        break
-      }
-    }
-  }
-  return prefix
-}
-
-function _findCommonPrefixDirectory(paths: string[]): string {
-  const directories = paths.map((path) => {
-    const dir = path.split('/')
-    dir.pop()
-    return dir.join('/')
-  })
-  return findCommonPrefix(directories)
-}
-
 // Alias entries to import path
 // e.g.
 // For a resolved file, if it's one of the entries,

--- a/src/plugins/alias-plugin.ts
+++ b/src/plugins/alias-plugin.ts
@@ -1,24 +1,78 @@
 import { Plugin } from 'rollup'
+import { Entries } from '../types'
+import path from 'path'
+import { filePathWithoutExtension } from '../utils'
+import { relativify } from '../lib/format'
+
+function findCommonPrefix(strings: string[]): string {
+  if (strings.length === 0) {
+    return ''
+  }
+  let prefix = strings[0]
+  for (const str of strings) {
+    for (let i = 0; i < prefix.length; i++) {
+      if (prefix[i] !== str[i]) {
+        prefix = prefix.slice(0, i)
+        break
+      }
+    }
+  }
+  return prefix
+}
+
+function _findCommonPrefixDirectory(paths: string[]): string {
+  const directories = paths.map((path) => {
+    const dir = path.split('/')
+    dir.pop()
+    return dir.join('/')
+  })
+  return findCommonPrefix(directories)
+}
 
 // Alias entries to import path
 // e.g.
 // For a resolved file, if it's one of the entries,
 // aliases it as export path, such as <absolute file> -> <pkg>/<export path>
 export function aliasEntries({
+  entry,
   entries,
+  reversedAlias,
 }: {
-  entries: Record<string, string | null>
+  entry: string
+  entries: Entries
+  reversedAlias: Record<string, string | null>
 }): Plugin {
+  let currentDistPath = ''
+  const pathToRelativeDistMap = new Map<string, string>()
+  for (const [, exportCondition] of Object.entries(entries)) {
+    // const distPaths = Object.values(exportCondition.export)
+    const firstDistPath =
+      exportCondition.export.import ||
+      exportCondition.export.require ||
+      exportCondition.export.default
+
+    if (entry !== exportCondition.source) {
+      pathToRelativeDistMap.set(exportCondition.source, firstDistPath)
+    } else {
+      currentDistPath = firstDistPath
+    }
+  }
+
   return {
     name: 'alias',
     resolveId: {
       async handler(source, importer, options) {
         const resolvedId = await this.resolve(source, importer, options)
         if (resolvedId != null) {
-          const aliasedId = entries[resolvedId.id]
+          const aliasedId = pathToRelativeDistMap.get(resolvedId.id)
 
-          if (aliasedId != null) {
-            return { id: aliasedId, external: true }
+          if (aliasedId != null && aliasedId !== currentDistPath) {
+            const relativePath = relativify(
+              filePathWithoutExtension(
+                path.relative(path.dirname(currentDistPath), aliasedId),
+              )!,
+            )
+            return { id: relativePath, external: true }
           }
         }
         return null

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,10 +58,9 @@ type PackageMetadata = {
   typings?: string
 }
 
-type BuncheeRollupConfig = Partial<Omit<RollupOptions, 'input' | 'output'>> & {
-  exportName?: string
+type BuncheeRollupConfig = {
   input: InputOptions
-  output: OutputOptions[]
+  output: OutputOptions
 }
 
 type CliArgs = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import type { JscTarget } from '@swc/types'
-import type { InputOptions, OutputOptions, RollupOptions } from 'rollup'
+import type { InputOptions, OutputOptions } from 'rollup'
 import type { OutputState } from './plugins/output-state-plugin'
 import type { TypescriptOptions } from './typescript'
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -137,10 +137,17 @@ export async function getSourcePathFromExportPath(
 
 // TODO: add unit test
 // Unlike path.basename, forcedly removing extension
-export function filePathWithoutExtension(file: string | undefined) {
-  return file
-    ? file.replace(new RegExp(`${path.extname(file)}$`), '')
-    : undefined
+export function filePathWithoutExtension(filePath: string | undefined) {
+  if (!filePath) return
+
+  const lastDotIndex = filePath.lastIndexOf('.')
+  const lastSlashIndex = filePath.lastIndexOf('/')
+
+  if (lastDotIndex !== -1 && lastDotIndex > lastSlashIndex) {
+    return filePath.slice(0, filePath.indexOf('.', lastSlashIndex + 1))
+  }
+
+  return filePath
 }
 
 export const nonNullable = <T>(n?: T): n is T => Boolean(n)

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -117,7 +117,7 @@ const testCases: {
         './dist/react-server.mjs': /'react-server'/,
         './dist/react-native.js': /'react-native'/,
         './dist/index.d.ts': /declare const shared = true/,
-        './dist/api.mjs': /\'pkg-export-ts-rsc\'/,
+        './dist/api.mjs': `import index$1 from './index`,
       })
     },
   },
@@ -566,14 +566,14 @@ const testCases: {
         join(dir, './dist/index.mjs'),
         'utf-8',
       )
-      expect(indexEsm).toContain('shared-entry/shared')
+      expect(indexEsm).toContain('./shared')
       expect(indexEsm).toContain('index-export')
       expect(indexEsm).not.toMatch(/['"]\.\/shared['"]/)
       expect(indexEsm).not.toContain('shared-export')
 
       // CJS bundle imports from <pkg/export>
       const indexCjs = await fsp.readFile(join(dir, './dist/index.js'), 'utf-8')
-      expect(indexCjs).toContain('shared-entry/shared')
+      expect(indexCjs).toContain('./shared')
       expect(indexCjs).toContain('index-export')
       expect(indexCjs).not.toMatch(/['"]\.\/shared['"]/)
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -117,7 +117,7 @@ const testCases: {
         './dist/react-server.mjs': /'react-server'/,
         './dist/react-native.js': /'react-native'/,
         './dist/index.d.ts': /declare const shared = true/,
-        './dist/api.mjs': `import index$1 from './index`,
+        './dist/api.mjs': /\'pkg-export-ts-rsc\'/,
       })
     },
   },
@@ -153,8 +153,10 @@ const testCases: {
         './dist/shared/edge-light.mjs': /'shared.edge-light'/,
         './dist/server/edge.mjs': /'server.edge-light'/,
         './dist/server/react-server.mjs': /'server.react-server'/,
-        './dist/server/index.d.ts':
-          /export { Client } from 'multi-entries\/client';\s*\S*export { Shared } from 'multi-entries\/shared';/,
+        // types
+        './dist/server/index.d.ts': `export { Client } from '../client/index.mjs';\nexport { Shared } from '../shared/index.mjs';`,
+        './dist/client/index.d.mts': `export { Shared } from '../shared/index.mjs'`,
+        './dist/client/index.d.cts': `export { Shared } from '../shared/index.cjs'`,
       }
 
       assertFilesContent(dir, contentsRegex)
@@ -566,14 +568,14 @@ const testCases: {
         join(dir, './dist/index.mjs'),
         'utf-8',
       )
-      expect(indexEsm).toContain('./shared')
+      expect(indexEsm).toContain('shared-entry/shared')
       expect(indexEsm).toContain('index-export')
       expect(indexEsm).not.toMatch(/['"]\.\/shared['"]/)
       expect(indexEsm).not.toContain('shared-export')
 
       // CJS bundle imports from <pkg/export>
       const indexCjs = await fsp.readFile(join(dir, './dist/index.js'), 'utf-8')
-      expect(indexCjs).toContain('./shared')
+      expect(indexCjs).toContain('shared-entry/shared')
       expect(indexCjs).toContain('index-export')
       expect(indexCjs).not.toMatch(/['"]\.\/shared['"]/)
 

--- a/test/integration/multi-entries/package.json
+++ b/test/integration/multi-entries/package.json
@@ -1,5 +1,6 @@
 {
   "name": "multi-entries",
+  "version": "0.0.0",
   "types": "./dist/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
@@ -12,6 +13,7 @@
     },
     "./shared": {
       "import": "./dist/shared/index.mjs",
+      "require": "./dist/shared/index.cjs",
       "edge-light": "./dist/shared/edge-light.mjs"
     },
     "./server": {

--- a/test/integration/pkg-exports-ts-rsc/package.json
+++ b/test/integration/pkg-exports-ts-rsc/package.json
@@ -5,8 +5,12 @@
       "types": "./dist/index.d.ts",
       "react-server": "./dist/react-server.mjs",
       "react-native": "./dist/react-native.js",
-      "import": "./dist/index.mjs"
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
     },
-    "./api": "./dist/api.mjs"
+    "./api": {
+      "import": "./dist/api.mjs",
+      "require": "./dist/api.cjs"
+    }
   }
 }

--- a/test/integration/pkg-exports-ts-rsc/src/api/index.ts
+++ b/test/integration/pkg-exports-ts-rsc/src/api/index.ts
@@ -1,3 +1,5 @@
-import index from '../index'
+import index, { type IString } from '../index'
 
 export default 'api:' + index
+export { IString }
+

--- a/test/integration/pkg-exports-ts-rsc/src/index.ts
+++ b/test/integration/pkg-exports-ts-rsc/src/index.ts
@@ -1,2 +1,4 @@
 export default 'index'
 export const shared = true
+
+export type IString = string


### PR DESCRIPTION
This PR refactors each build to a standalone rollup build job including its own `input` and own `output`, instead of having one `input` and multi `output` before.

For `.d.cts` and `.d.mts` we need to import the proper file, for instance, `.d.cts` matches `.cjs` files and `.d.mts` matches `.mjs` files, so you would have:

In a `.d.mts` file, module resolving situation will be like
```ts
// index.d.mts
export { Shared } from '../shared/index.mjs'; // ✅
export { Shared } from '../shared/index'; // ❌ cannot resolve
export { Shared } from '../shared/index.cjs'; // ❌ cannot resolve
```

This means we need a resolving map for each format of build, if we're building import condition output with esm syntax format, we need to alias the code to mjs output. This rule only applies to types. JS can still do `<pkg>/<export>` import as nodejs is able to resolve that. 

So we created alias for each build, and also put relative path there to make sure they can be resolved

Resolves #390