### PR TITLE
Replace EdgeRuntime for edge build

### DIFF
--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -64,7 +64,7 @@ const swcMinifyOptions = {
 } as const
 
 // return { 'process.env.<key>': '<value>' }
-function getBuildEnv(
+function getDefinedInlineVariables(
   envs: string[],
   parsedExportCondition: ParsedExportCondition,
 ): Record<string, string> {
@@ -92,6 +92,10 @@ function getBuildEnv(
     envVars['process.env.NODE_ENV'] = JSON.stringify('development')
   } else if (exportConditionNames.has('production')) {
     envVars['process.env.NODE_ENV'] = JSON.stringify('production')
+  }
+
+  if (exportConditionNames.has('edge-light')) {
+    envVars['EdgeRuntime'] = JSON.stringify('edge-runtime')
   }
 
   return envVars
@@ -144,7 +148,10 @@ async function buildInputConfig(
     }
   }
 
-  const envValues = getBuildEnv(bundleConfig.env || [], exportCondition)
+  const inlineDefinedValues = getDefinedInlineVariables(
+    bundleConfig.env || [],
+    exportCondition,
+  )
 
   const { useTypeScript } = buildContext
   const { runtime, target: jscTarget, minify: shouldMinify } = bundleConfig
@@ -257,7 +264,7 @@ async function buildInputConfig(
           preserveDirectives(),
           prependDirectives(),
           replace({
-            values: envValues,
+            values: inlineDefinedValues,
             preventAssignment: true,
           }),
           nodeResolve({

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -924,6 +924,15 @@ const testCases: {
       expect(await existsFile(join(dir, './dist/index.d.ts'))).toBe(true)
     },
   },
+  {
+    name: 'edge-variable',
+    async expected(dir) {
+      assertFilesContent(dir, {
+        './dist/index.js': /typeof EdgeRuntime/,
+        './dist/index.edge.js': /typeof "edge-runtime"/,
+      })
+    },
+  },
 ]
 
 async function runBundle(

--- a/test/integration/edge-variable/package.json
+++ b/test/integration/edge-variable/package.json
@@ -1,0 +1,7 @@
+{
+  "type": "module",
+  "exports": {
+    "edge-light": "./dist/index.edge.js",
+    "import": "./dist/index.js"
+  }
+}

--- a/test/integration/edge-variable/src/index.js
+++ b/test/integration/edge-variable/src/index.js
@@ -1,0 +1,1 @@
+export const variable = typeof EdgeRuntime


### PR DESCRIPTION
Resolves #410 

Replace `EdgeRuntime` global variable to `"edge-runtime"` string in `.edge-light` build