### PR TITLE
fix: algorithm for determine the end of build in watch mode

### DIFF
--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -242,11 +242,12 @@ function logWatcherBuildTime(result: RollupWatcher[]) {
 
   result.map((watcher) => {
     function start() {
-      if (startTime === 0) startTime = performance.now()
+      if (watcherCounter === 0) startTime = performance.now()
+      watcherCounter++
     }
     function end() {
-      watcherCounter++
-      if (watcherCounter === result.length) {
+      watcherCounter--
+      if (watcherCounter === 0) {
         logger.info(`Build in ${(performance.now() - startTime).toFixed(2)}ms`)
       }
     }


### PR DESCRIPTION
if we print `console.log(startTime, watcherCount)` in `end` function, it looks like:

```bash
❯ bunchee -w
Watching project /Users/nnecec/Github/bunchee...
523.054045021534 1
523.054045021534 2
523.054045021534 3
523.054045021534 4
✓ Build in 3250.67ms
523.054045021534 5
523.054045021534 6
523.054045021534 7
523.054045021534 8
523.054045021534 9
523.054045021534 10
```


`logWatcherBuildTime` will be executed only once at the beginning. So we need reset `startTime` and `watcherCount` in the `start` function.

Also, if we modify a file, it may not trigger a rebuild of all the entry files, so the `watcherCount` maybe not equal to `result.length`.