### PR TITLE
Fix ts pkg import json

### DIFF
--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -194,6 +194,7 @@ async function buildInputConfig(
     : bundleConfig.format
 
   const commonPlugins = [
+    json(),
     sizePlugin,
     aliasEntries({
       entry,
@@ -281,7 +282,6 @@ async function buildInputConfig(
           commonjs({
             exclude: bundleConfig.external || null,
           }),
-          json(),
         ]
   ).filter(isNotNull<Plugin>)
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -80,6 +80,15 @@ const testCases: {
     },
   },
   {
+    name: 'ts-import-json',
+    async expected(dir) {
+      assertFilesContent(dir, {
+        './dist/index.js': /"0.0.1"/,
+        './dist/index.d.ts': /declare const version: string/,
+      })
+    },
+  },
+  {
     name: 'no-ts-require-for-js',
     args: ['index.js', '-o', './dist/index.js'],
     async expected(dir) {

--- a/test/integration/ts-import-json/package.json
+++ b/test/integration/ts-import-json/package.json
@@ -1,0 +1,5 @@
+{
+  "version": "0.0.1",
+  "type": "module",
+  "exports": "./dist/index.js"
+}

--- a/test/integration/ts-import-json/src/index.ts
+++ b/test/integration/ts-import-json/src/index.ts
@@ -1,0 +1,3 @@
+import pkgJson from '../package.json'
+
+export const version = pkgJson.version

--- a/test/integration/ts-import-json/tsconfig.json
+++ b/test/integration/ts-import-json/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler"
+  }
+}


### PR DESCRIPTION
When user import json module in ts module, types generation breaks. Cause we need to let ts generation also be able to resolve json file