### PR TITLE
Rewrite esm-shim plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   "license": "MIT",
   "dependencies": {
     "@rollup/plugin-commonjs": "^25.0.7",
-    "@rollup/plugin-esm-shim": "^0.1.5",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-replace": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@swc/helpers": "^0.5.3",
     "arg": "^5.0.2",
     "clean-css": "^5.3.3",
+    "magic-string": "^0.30.6",
     "pretty-bytes": "^5.6.0",
     "rimraf": "^5.0.5",
     "rollup": "^4.9.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ dependencies:
   clean-css:
     specifier: ^5.3.3
     version: 5.3.3
+  magic-string:
+    specifier: ^0.30.6
+    version: 0.30.6
   pretty-bytes:
     specifier: ^5.6.0
     version: 5.6.0
@@ -1065,7 +1068,7 @@ packages:
       estree-walker: 2.0.2
       glob: 8.1.0
       is-reference: 1.2.1
-      magic-string: 0.30.3
+      magic-string: 0.30.6
       rollup: 4.9.4
     dev: false
 
@@ -1078,7 +1081,7 @@ packages:
       rollup:
         optional: true
     dependencies:
-      magic-string: 0.30.3
+      magic-string: 0.30.6
       rollup: 4.9.4
     dev: false
 
@@ -1123,7 +1126,7 @@ packages:
         optional: true
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@4.9.4)
-      magic-string: 0.30.3
+      magic-string: 0.30.6
       rollup: 4.9.4
     dev: false
 
@@ -2858,15 +2861,8 @@ packages:
       yallist: 4.0.0
     dev: true
 
-  /magic-string@0.30.3:
-    resolution: {integrity: sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==}
-    engines: {node: '>=12'}
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.15
-    dev: false
-
-  /magic-string@0.30.5:
-    resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
+  /magic-string@0.30.6:
+    resolution: {integrity: sha512-n62qCLbPjNjyo+owKtveQxZFZTBm+Ms6YoGD23Wew6Vw337PElFNifQpknPruVRQV57kVShPnLGo9vWxVhpPvA==}
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
@@ -3188,7 +3184,7 @@ packages:
       rollup: ^3.29.4 || ^4
       typescript: ^4.5 || ^5.0
     dependencies:
-      magic-string: 0.30.5
+      magic-string: 0.30.6
       rollup: 4.9.4
       typescript: 5.3.2
     optionalDependencies:
@@ -3215,7 +3211,7 @@ packages:
     peerDependencies:
       rollup: ^2.0.0 || ^3.0.0 || ^4.0.0
     dependencies:
-      magic-string: 0.30.5
+      magic-string: 0.30.6
       rollup: 4.9.4
     dev: false
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ dependencies:
   '@rollup/plugin-commonjs':
     specifier: ^25.0.7
     version: 25.0.7(rollup@4.9.4)
-  '@rollup/plugin-esm-shim':
-    specifier: ^0.1.5
-    version: 0.1.5(rollup@4.9.4)
   '@rollup/plugin-json':
     specifier: ^6.1.0
     version: 6.1.0(rollup@4.9.4)
@@ -1068,19 +1065,6 @@ packages:
       estree-walker: 2.0.2
       glob: 8.1.0
       is-reference: 1.2.1
-      magic-string: 0.30.6
-      rollup: 4.9.4
-    dev: false
-
-  /@rollup/plugin-esm-shim@0.1.5(rollup@4.9.4):
-    resolution: {integrity: sha512-xnIjDm/0EbqAw0/rR1UE7eAo9db0ftGPqT8RUCFtkFxtCuspbbmj+wutoyxm32jBytyO3SgkxSG17OR893fV7A==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^2.0.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-    dependencies:
       magic-string: 0.30.6
       rollup: 4.9.4
     dev: false

--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -17,7 +17,7 @@ import type {
 } from 'rollup'
 import { convertCompilerOptions, type TypescriptOptions } from './typescript'
 
-import path, { resolve, dirname, join, basename, format } from 'path'
+import path, { resolve, dirname, join, basename } from 'path'
 import { wasm } from '@rollup/plugin-wasm'
 import { swc } from 'rollup-plugin-swc3'
 import commonjs from '@rollup/plugin-commonjs'

--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -17,7 +17,7 @@ import type {
 } from 'rollup'
 import { convertCompilerOptions, type TypescriptOptions } from './typescript'
 
-import path, { resolve, dirname, join, basename } from 'path'
+import path, { resolve, dirname, join, basename, format } from 'path'
 import { wasm } from '@rollup/plugin-wasm'
 import { swc } from 'rollup-plugin-swc3'
 import commonjs from '@rollup/plugin-commonjs'
@@ -269,6 +269,7 @@ async function buildInputConfig(
             preferBuiltins: runtime === 'node',
             extensions: nodeResolveExtensions,
           }),
+          bundleConfig.format === 'esm' && esmShim(),
           wasm(),
           swc({
             include: availableESExtensionsRegex,
@@ -277,7 +278,7 @@ async function buildInputConfig(
             tsconfig: tsConfigPath ?? false,
             ...swcOptions,
           }),
-          esmShim(),
+
           commonjs({
             exclude: bundleConfig.external || null,
           }),

--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -24,8 +24,8 @@ import commonjs from '@rollup/plugin-commonjs'
 import json from '@rollup/plugin-json'
 import { nodeResolve } from '@rollup/plugin-node-resolve'
 import replace from '@rollup/plugin-replace'
-import esmShim from '@rollup/plugin-esm-shim'
 import preserveDirectives from 'rollup-preserve-directives'
+import { esmShim } from './plugins/esm-shim'
 import { inlineCss } from './plugins/inline-css'
 import { rawContent } from './plugins/raw-plugin'
 import { aliasEntries } from './plugins/alias-plugin'
@@ -259,7 +259,6 @@ async function buildInputConfig(
           ...commonPlugins,
           inlineCss({ exclude: /node_modules/ }),
           rawContent({ exclude: /node_modules/ }),
-          esmShim(),
           preserveDirectives(),
           prependDirectives(),
           replace({
@@ -278,6 +277,7 @@ async function buildInputConfig(
             tsconfig: tsConfigPath ?? false,
             ...swcOptions,
           }),
+          esmShim(),
           commonjs({
             exclude: bundleConfig.external || null,
           }),

--- a/src/plugins/esm-shim.ts
+++ b/src/plugins/esm-shim.ts
@@ -1,5 +1,3 @@
-// @ts-expect-error @rollup/plugin-esm-shim has this export but missing in the types
-import { provideCJSSyntax } from '@rollup/plugin-esm-shim'
 import { availableESExtensionsRegex } from '../constants'
 import { Plugin, ProgramNode, AstNode } from 'rollup'
 import { extname } from 'path'

--- a/src/plugins/esm-shim.ts
+++ b/src/plugins/esm-shim.ts
@@ -1,23 +1,122 @@
 // @ts-expect-error @rollup/plugin-esm-shim has this export but missing in the types
 import { provideCJSSyntax } from '@rollup/plugin-esm-shim'
-import { availableExtensions } from '../constants'
-import { Plugin } from 'rollup'
+import { availableESExtensionsRegex } from '../constants'
+import { Plugin, ProgramNode, AstNode } from 'rollup'
 import { extname } from 'path'
+import MagicString from 'magic-string'
+
+const FILENAME_REGEX = /__filename/
+const DIRNAME_REGEX = /__dirname/
+const GLOBAL_REQUIRE_REGEX = /require(\.resolve)?\(/
+
+const PolyfillComment = '/** rollup-private-do-not-use-esm-shim-polyfill */'
+const createESMShim = ({
+  filename,
+  dirname,
+  globalRequire,
+}: {
+  filename: boolean
+  dirname: boolean
+  globalRequire: boolean
+}) => {
+  const useNodeUrl = filename || dirname
+  const useNodePath = dirname
+  const useNodeModule = globalRequire
+  return (
+    `\
+${PolyfillComment}
+${useNodeUrl ? `import __node_cjsUrl from 'node:url'` : ''};
+${useNodePath ? `import __node_cjsPath from 'node:path';` : ''}
+${useNodeModule ? `import __node_cjsModule from 'node:module';` : ''}
+${
+  useNodeUrl
+    ? 'const __filename = __node_cjsUrl.fileURLToPath(import.meta.url);'
+    : ''
+}
+${useNodePath ? 'const __dirname = __node_cjsPath.dirname(__filename);' : ''}
+${
+  useNodeModule
+    ? 'const require = __node_cjsModule.createRequire(import.meta.url);'
+    : ''
+}
+`.trim() + '\n'
+  )
+}
 
 export function esmShim(): Plugin {
   return {
     name: 'esm-shim',
-    renderChunk: {
-      order: 'pre',
-      handler(code, chunk, opts) {
-        const chunkExt = extname(chunk.fileName).slice(1)
-        if (chunk.type === 'chunk' && availableExtensions.has(chunkExt)) {
-          return
+    transform: {
+      order: 'post',
+      handler(code, id) {
+        const ext = extname(id)
+        if (
+          !availableESExtensionsRegex.test(ext) ||
+          code.includes(PolyfillComment)
+        ) {
+          return null
         }
-        if (opts.format === 'es') {
-          return provideCJSSyntax(code)
+
+        let hasFilename = false
+        let hasDirname = false
+        let hasGlobalRequire = false
+        if (FILENAME_REGEX.test(code)) {
+          hasFilename = true
         }
-        return
+        if (DIRNAME_REGEX.test(code)) {
+          hasDirname = true
+        }
+        if (GLOBAL_REQUIRE_REGEX.test(code)) {
+          hasGlobalRequire = true
+        }
+
+        if (!hasFilename && !hasDirname && !hasGlobalRequire) {
+          return null
+        }
+
+        const magicString = new MagicString(code)
+        let ast: null | ProgramNode = null
+        try {
+          // rollup 2 built-in parser doesn't have `allowShebang`, we need to use the sliced code here. Hence the `magicString.toString()`
+          ast = this.parse(magicString.toString(), {
+            allowReturnOutsideFunction: true,
+          })
+        } catch (e) {
+          console.warn(e)
+          return null
+        }
+
+        if (ast.type !== 'Program') {
+          return null
+        }
+
+        let lastImportNode = null
+        for (const node of ast.body) {
+          if (node.type === 'ImportDeclaration') {
+            lastImportNode = node
+            continue
+          }
+        }
+        let end: number = 0
+
+        if (lastImportNode) {
+          end = (lastImportNode as any as AstNode).end
+        } else {
+          end = ast.body.length > 0 ? (ast.body[0] as any as AstNode).end : 0
+        }
+        magicString.appendRight(
+          end,
+          '\n' +
+            createESMShim({
+              filename: hasFilename,
+              dirname: hasDirname,
+              globalRequire: hasGlobalRequire,
+            }),
+        )
+        return {
+          code: magicString.toString(),
+          map: magicString.generateMap({ hires: true }),
+        }
       },
     },
   }

--- a/src/plugins/esm-shim.ts
+++ b/src/plugins/esm-shim.ts
@@ -1,0 +1,24 @@
+// @ts-expect-error @rollup/plugin-esm-shim has this export but missing in the types
+import { provideCJSSyntax } from '@rollup/plugin-esm-shim'
+import { availableExtensions } from '../constants'
+import { Plugin } from 'rollup'
+import { extname } from 'path'
+
+export function esmShim(): Plugin {
+  return {
+    name: 'esm-shim',
+    renderChunk: {
+      order: 'pre',
+      handler(code, chunk, opts) {
+        const chunkExt = extname(chunk.fileName).slice(1)
+        if (chunk.type === 'chunk' && availableExtensions.has(chunkExt)) {
+          return
+        }
+        if (opts.format === 'es') {
+          return provideCJSSyntax(code)
+        }
+        return
+      },
+    },
+  }
+}

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -438,31 +438,22 @@ const testCases: {
   },
   {
     name: 'esm-shims',
-    args: [],
     async expected(dir) {
-      const shimsCode = [
-        'const __filename = cjsUrl.fileURLToPath(import.meta.url)',
-        'const __dirname = cjsPath.dirname(__filename)',
-        'const require = cjsModule.createRequire(import.meta.url)',
-      ]
-      const esmOutput = await fsp.readFile(
-        join(dir, './dist/index.mjs'),
-        'utf-8',
-      )
-      const cjsOutput = await fsp.readFile(
-        join(dir, './dist/index.cjs'),
-        'utf-8',
-      )
-      expect(shimsCode.every((code) => esmOutput.includes(code))).toBe(true)
-      expect(shimsCode.map((code) => cjsOutput.includes(code))).toEqual([
-        false,
-        false,
-        false,
-      ])
-      // for import.meta.url, should use pathToFileURL + URL polyfill
-      expect(cjsOutput).toContain('pathToFileURL')
-      expect(cjsOutput).toContain('new URL')
-      expect(cjsOutput).not.toContain('import.meta.url')
+      const requirePolyfill =
+        'const require = __node_cjsModule.createRequire(import.meta.url)'
+      const filenamePolyfill =
+        'const __filename = __node_cjsUrl.fileURLToPath(import.meta.url)'
+      const dirnamePolyfill =
+        'const __dirname = __node_cjsPath.dirname(__filename)'
+
+      await assertFilesContent(dir, {
+        './dist/require.mjs': requirePolyfill,
+        './dist/filename.mjs': filenamePolyfill,
+        './dist/dirname.mjs': dirnamePolyfill,
+        './dist/require.js': /require\(/,
+        './dist/filename.js': /__filename/,
+        './dist/dirname.js': /__dirname/,
+      })
     },
   },
   {

--- a/test/integration/esm-shims/package.json
+++ b/test/integration/esm-shims/package.json
@@ -1,8 +1,16 @@
 {
   "exports": {
-    ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+    "./require": {
+      "import": "./dist/require.mjs",
+      "require": "./dist/require.js"
+    },
+    "./dirname": {
+      "import": "./dist/dirname.mjs",
+      "require": "./dist/dirname.js"
+    },
+    "./filename": {
+      "import": "./dist/filename.mjs",
+      "require": "./dist/filename.js"
     }
   }
 }

--- a/test/integration/esm-shims/src/dirname.js
+++ b/test/integration/esm-shims/src/dirname.js
@@ -1,0 +1,4 @@
+export function getDirname() {
+  return __dirname
+}
+

--- a/test/integration/esm-shims/src/filename.js
+++ b/test/integration/esm-shims/src/filename.js
@@ -1,0 +1,3 @@
+export function getFilename() {
+  return __filename
+}

--- a/test/integration/esm-shims/src/index.js
+++ b/test/integration/esm-shims/src/index.js
@@ -1,6 +1,0 @@
-export function test() {
-  console.log(__dirname)
-  console.log(__filename)
-  console.log(import.meta.url)
-}
-

--- a/test/integration/esm-shims/src/require.js
+++ b/test/integration/esm-shims/src/require.js
@@ -1,0 +1,7 @@
+export function getRequireModule() {
+  return require('node:fs')
+}
+
+export function esmImport() {
+  return import.meta.url
+}


### PR DESCRIPTION
### What

Drop the `@rollup/plugin-esm-shim` plugin and rewrite one with AST parsing, due to it causes issues by the regex matching and replacing with shims. It cannot optionally inject the shims based on the usage.

### Improvement

The new plugin is using the AST parsing, and based on the cjs API you're using we inject the certain ones of polyfill and replace the usage. If you only use one, we won't insert two polyfills.
It can handle all the import paths, `@rollup/plugin-esm-shim` will break with `@scope` module path, but AST parsing won't have that problem

Resolves #442 