### PR TITLE
fix: cjs .d.ts types resolving

### DIFF
--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -187,8 +187,10 @@ async function buildInputConfig(
 
   // common plugins for both dts and ts assets that need to be processed
 
+  // If it's a .d.ts file under non-ESM package or .d.cts file, use cjs types alias.
   const aliasFormat = dts
-    ? bundleConfig.file?.endsWith('.d.cts')
+    ? bundleConfig.file?.endsWith('.d.cts') ||
+      (bundleConfig.file?.endsWith('.d.ts') && !isESModulePackage(pkg.type))
       ? 'cjs'
       : 'esm'
     : bundleConfig.format

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -148,7 +148,6 @@ const testCases: {
   },
   {
     name: 'multi-entries',
-    args: [],
     async expected(dir, { stdout }) {
       const contentsRegex = {
         './dist/index.js': /'index'/,
@@ -157,9 +156,10 @@ const testCases: {
         './dist/server/edge.mjs': /'server.edge-light'/,
         './dist/server/react-server.mjs': /'server.react-server'/,
         // types
-        './dist/server/index.d.ts': `export { Client } from '../client/index.mjs';\nexport { Shared } from '../shared/index.mjs';`,
+        './dist/server/index.d.ts': `export { Client } from '../client/index.cjs';\nexport { Shared } from '../shared/index.cjs';`,
         './dist/client/index.d.mts': `export { Shared } from '../shared/index.mjs'`,
         './dist/client/index.d.cts': `export { Shared } from '../shared/index.cjs'`,
+        './dist/client/index.d.ts': `export { Shared } from '../shared/index.cjs'`,
       }
 
       await assertFilesContent(dir, contentsRegex)

--- a/test/testing-utils.ts
+++ b/test/testing-utils.ts
@@ -38,16 +38,12 @@ export async function assertFilesContent(
   dir: string,
   contentsRegex: Record<string, RegExp | string>,
 ) {
-  const distFiles = Object.keys(contentsRegex)
-  for (const relativeFile of distFiles) {
-    const file = path.join(dir, relativeFile)
-    expect({
-      [file]: (await existsFile(file)) ? 'existed' : 'missing',
-    }).toMatchObject({ [file]: 'existed' })
-  }
-
   const promises = Object.entries(contentsRegex).map(async ([file, regex]) => {
-    const content = await fsp.readFile(path.join(dir, file), {
+    const filePath = path.join(dir, file)
+    expect({
+      [filePath]: (await existsFile(filePath)) ? 'existed' : 'missing',
+    }).toMatchObject({ [filePath]: 'existed' })
+    const content = await fsp.readFile(filePath, {
       encoding: 'utf-8',
     })
     if (regex instanceof RegExp) {


### PR DESCRIPTION
`d.ts` should resolve cjs files when the package.json "type" is cjs type