### PR TITLE
refactor: modify migrated integration test format to be a guide for the upcoming works

### DIFF
--- a/test/integration/basic-jsx/index.test.ts
+++ b/test/integration/basic-jsx/index.test.ts
@@ -1,7 +1,7 @@
 import { createIntegrationTest, assertContainFiles } from '../utils'
 
 describe('integration basic-jsx', () => {
-  it('should work on basic JSX format', async () => {
+  it('should work with basic JSX format', async () => {
     await createIntegrationTest(
       {
         directory: __dirname,

--- a/test/integration/basic-jsx/index.test.ts
+++ b/test/integration/basic-jsx/index.test.ts
@@ -1,7 +1,7 @@
 import { createIntegrationTest, assertContainFiles } from '../utils'
 
-describe('integration', () => {
-  test(`basic-jsx`, async () => {
+describe('integration basic-jsx', () => {
+  it('should work on basic JSX format', async () => {
     await createIntegrationTest(
       {
         directory: __dirname,

--- a/test/integration/bin/cts/fixtures/.gitignore
+++ b/test/integration/bin/cts/fixtures/.gitignore
@@ -1,0 +1,1 @@
+tsconfig.json

--- a/test/integration/bin/cts/index.test.ts
+++ b/test/integration/bin/cts/index.test.ts
@@ -1,9 +1,5 @@
 import { readFile } from 'fs/promises'
-import { createIntegrationTest, deleteFile, existsFile } from '../../utils'
-
-afterEach(async () => {
-  await deleteFile(`${__dirname}/fixtures/tsconfig.json`)
-})
+import { createIntegrationTest, existsFile } from '../../utils'
 
 describe('integration bin/cts', () => {
   it('should work with bin as .cts extension', async () => {

--- a/test/integration/bin/cts/index.test.ts
+++ b/test/integration/bin/cts/index.test.ts
@@ -5,8 +5,8 @@ afterEach(async () => {
   await deleteFile(`${__dirname}/fixtures/tsconfig.json`)
 })
 
-describe('integration', () => {
-  test(`bin/cts`, async () => {
+describe('integration bin/cts', () => {
+  it('should work with bin as .cts extension', async () => {
     await createIntegrationTest(
       {
         directory: __dirname,

--- a/test/integration/bin/multi-path/fixtures/.gitignore
+++ b/test/integration/bin/multi-path/fixtures/.gitignore
@@ -1,0 +1,1 @@
+tsconfig.json

--- a/test/integration/bin/multi-path/index.test.ts
+++ b/test/integration/bin/multi-path/index.test.ts
@@ -1,9 +1,5 @@
 import { readFile } from 'fs/promises'
-import { createIntegrationTest, existsFile, deleteFile } from '../../utils'
-
-afterEach(async () => {
-  await deleteFile(`${__dirname}/fixtures/tsconfig.json`)
-})
+import { createIntegrationTest, existsFile } from '../../utils'
 
 describe('integration bin/multi-path', () => {
   it('should work with bin as multi path', async () => {

--- a/test/integration/bin/multi-path/index.test.ts
+++ b/test/integration/bin/multi-path/index.test.ts
@@ -5,8 +5,8 @@ afterEach(async () => {
   await deleteFile(`${__dirname}/fixtures/tsconfig.json`)
 })
 
-describe('integration', () => {
-  test(`bin/multi-path`, async () => {
+describe('integration bin/multi-path', () => {
+  it('should work with bin as multi path', async () => {
     await createIntegrationTest(
       {
         directory: __dirname,

--- a/test/integration/bin/single-path/fixtures/.gitignore
+++ b/test/integration/bin/single-path/fixtures/.gitignore
@@ -1,0 +1,1 @@
+tsconfig.json

--- a/test/integration/bin/single-path/index.test.ts
+++ b/test/integration/bin/single-path/index.test.ts
@@ -1,13 +1,5 @@
 import { readFile } from 'fs/promises'
-import {
-  createIntegrationTest,
-  assertContainFiles,
-  deleteFile,
-} from '../../utils'
-
-afterEach(async () => {
-  await deleteFile(`${__dirname}/fixtures/tsconfig.json`)
-})
+import { createIntegrationTest, assertContainFiles } from '../../utils'
 
 describe('integration bin/single-path', () => {
   it('should work with bin as single path', async () => {

--- a/test/integration/bin/single-path/index.test.ts
+++ b/test/integration/bin/single-path/index.test.ts
@@ -9,8 +9,8 @@ afterEach(async () => {
   await deleteFile(`${__dirname}/fixtures/tsconfig.json`)
 })
 
-describe('integration', () => {
-  test(`bin/single-path`, async () => {
+describe('integration bin/single-path', () => {
+  it('should work with bin as single path', async () => {
     await createIntegrationTest(
       {
         directory: __dirname,

--- a/test/integration/cjs-pkg-esm-main-field/index.test.ts
+++ b/test/integration/cjs-pkg-esm-main-field/index.test.ts
@@ -1,7 +1,7 @@
 import { createIntegrationTest } from '../utils'
 
-describe('integration', () => {
-  test(`cjs-pkg-esm-main-field`, async () => {
+describe('integration cjs-pkg-esm-main-field', () => {
+  it('should warn if main field with .mjs extension in CJS package', async () => {
     await createIntegrationTest(
       {
         directory: __dirname,

--- a/test/integration/default-node-mjs/index.test.ts
+++ b/test/integration/default-node-mjs/index.test.ts
@@ -2,7 +2,7 @@ import { readFile } from 'fs/promises'
 import { createIntegrationTest, existsFile } from '../utils'
 
 describe('integration default-node-mjs', () => {
-  it('should work on default .node.mjs convention', async () => {
+  it('should work with .mjs extension', async () => {
     await createIntegrationTest(
       {
         directory: __dirname,

--- a/test/integration/default-node-mjs/index.test.ts
+++ b/test/integration/default-node-mjs/index.test.ts
@@ -1,8 +1,8 @@
 import { readFile } from 'fs/promises'
 import { createIntegrationTest, existsFile } from '../utils'
 
-describe('integration', () => {
-  test(`default-node-mjs`, async () => {
+describe('integration default-node-mjs', () => {
+  it('should work on default .node.mjs convention', async () => {
     await createIntegrationTest(
       {
         directory: __dirname,

--- a/test/integration/dev-prod-convention/fixtures/.gitignore
+++ b/test/integration/dev-prod-convention/fixtures/.gitignore
@@ -1,0 +1,1 @@
+tsconfig.json

--- a/test/integration/dev-prod-convention/index.test.ts
+++ b/test/integration/dev-prod-convention/index.test.ts
@@ -1,7 +1,7 @@
 import { createIntegrationTest, assertFilesContent } from '../utils'
 
 describe('integration dev-prod-convention', () => {
-  it('should work on environment conventions', async () => {
+  it('should work on optimize conventions dev and prod', async () => {
     await createIntegrationTest(
       {
         directory: __dirname,

--- a/test/integration/dev-prod-convention/index.test.ts
+++ b/test/integration/dev-prod-convention/index.test.ts
@@ -4,8 +4,8 @@ afterEach(async () => {
   await deleteFile(`${__dirname}/fixtures/tsconfig.json`)
 })
 
-describe('integration', () => {
-  test(`dev-prod-convention`, async () => {
+describe('integration dev-prod-convention', () => {
+  it('should work on environment conventions', async () => {
     await createIntegrationTest(
       {
         directory: __dirname,

--- a/test/integration/dev-prod-convention/index.test.ts
+++ b/test/integration/dev-prod-convention/index.test.ts
@@ -1,8 +1,4 @@
-import { createIntegrationTest, assertFilesContent, deleteFile } from '../utils'
-
-afterEach(async () => {
-  await deleteFile(`${__dirname}/fixtures/tsconfig.json`)
-})
+import { createIntegrationTest, assertFilesContent } from '../utils'
 
 describe('integration dev-prod-convention', () => {
   it('should work on environment conventions', async () => {

--- a/test/integration/duplicate-entry/index.test.ts
+++ b/test/integration/duplicate-entry/index.test.ts
@@ -1,7 +1,7 @@
 import { createIntegrationTest, assertContainFiles } from '../utils'
 
-describe('integration', () => {
-  test(`duplicate-entry`, async () => {
+describe('integration duplicate-entry', () => {
+  it('should deduplicate entries', async () => {
     await createIntegrationTest(
       {
         directory: __dirname,

--- a/test/integration/edge-variable/index.test.ts
+++ b/test/integration/edge-variable/index.test.ts
@@ -1,7 +1,7 @@
 import { createIntegrationTest, assertFilesContent } from '../utils'
 
-describe('integration', () => {
-  test(`edge-variable`, async () => {
+describe('integration edge-variable', () => {
+  it('should work on .edge convention', async () => {
     await createIntegrationTest(
       {
         directory: __dirname,

--- a/test/integration/edge-variable/index.test.ts
+++ b/test/integration/edge-variable/index.test.ts
@@ -1,7 +1,7 @@
 import { createIntegrationTest, assertFilesContent } from '../utils'
 
 describe('integration edge-variable', () => {
-  it('should work on .edge convention', async () => {
+  it('should work with edge export condition', async () => {
     await createIntegrationTest(
       {
         directory: __dirname,

--- a/test/integration/entry-index-index/index.test.ts
+++ b/test/integration/entry-index-index/index.test.ts
@@ -1,7 +1,7 @@
 import { createIntegrationTest, assertFilesContent } from '../utils'
 
-describe('integration', () => {
-  test(`entry-index-index`, async () => {
+describe('integration entry-index-index', () => {
+  it('should work on index file inside index directory', async () => {
     await createIntegrationTest(
       {
         directory: __dirname,

--- a/test/integration/entry-index-index/index.test.ts
+++ b/test/integration/entry-index-index/index.test.ts
@@ -1,7 +1,7 @@
 import { createIntegrationTest, assertFilesContent } from '../utils'
 
 describe('integration entry-index-index', () => {
-  it('should work on index file inside index directory', async () => {
+  it('should work with index file inside index directory', async () => {
     await createIntegrationTest(
       {
         directory: __dirname,

--- a/test/integration/esm-pkg-cjs-main-field/index.test.ts
+++ b/test/integration/esm-pkg-cjs-main-field/index.test.ts
@@ -1,7 +1,7 @@
 import { createIntegrationTest, assertContainFiles } from '../utils'
 
-describe('integration', () => {
-  test(`esm-pkg-cjs-main-field`, async () => {
+describe('integration esm-pkg-cjs-main-field', () => {
+  it('should work on ESM package, main field as CJS ', async () => {
     await createIntegrationTest(
       {
         directory: __dirname,

--- a/test/integration/esm-pkg-cjs-main-field/index.test.ts
+++ b/test/integration/esm-pkg-cjs-main-field/index.test.ts
@@ -1,7 +1,7 @@
 import { createIntegrationTest, assertContainFiles } from '../utils'
 
 describe('integration esm-pkg-cjs-main-field', () => {
-  it('should work on ESM package, main field as CJS ', async () => {
+  it('should work with ESM package with CJS main field ', async () => {
     await createIntegrationTest(
       {
         directory: __dirname,

--- a/test/integration/esm-shims/index.test.ts
+++ b/test/integration/esm-shims/index.test.ts
@@ -1,7 +1,7 @@
 import { createIntegrationTest, assertFilesContent } from '../utils'
 
-describe('integration', () => {
-  test(`esm-shims`, async () => {
+describe('integration esm-shims', () => {
+  it('should work on ESM shims', async () => {
     await createIntegrationTest(
       {
         directory: __dirname,

--- a/test/integration/esm-shims/index.test.ts
+++ b/test/integration/esm-shims/index.test.ts
@@ -1,7 +1,7 @@
 import { createIntegrationTest, assertFilesContent } from '../utils'
 
 describe('integration esm-shims', () => {
-  it('should work on ESM shims', async () => {
+  it('should work with ESM shims', async () => {
     await createIntegrationTest(
       {
         directory: __dirname,

--- a/test/integration/externals/index.test.ts
+++ b/test/integration/externals/index.test.ts
@@ -2,7 +2,7 @@ import { readFile } from 'fs/promises'
 import { createIntegrationTest } from '../utils'
 
 describe('integration externals', () => {
-  it('should work on externals', async () => {
+  it('should handle externals', async () => {
     await createIntegrationTest(
       {
         directory: __dirname,

--- a/test/integration/externals/index.test.ts
+++ b/test/integration/externals/index.test.ts
@@ -1,8 +1,8 @@
 import { readFile } from 'fs/promises'
 import { createIntegrationTest } from '../utils'
 
-describe('integration', () => {
-  test(`externals`, async () => {
+describe('integration externals', () => {
+  it('should work on externals', async () => {
     await createIntegrationTest(
       {
         directory: __dirname,

--- a/test/integration/invalid-exports-cjs/index.test.ts
+++ b/test/integration/invalid-exports-cjs/index.test.ts
@@ -1,7 +1,7 @@
 import { createIntegrationTest } from '../utils'
 
-describe('integration', () => {
-  test(`invalid-exports-cjs`, async () => {
+describe('integration invalid-exports-cjs', () => {
+  it('should warn on invalid exports as CJS', async () => {
     await createIntegrationTest(
       {
         directory: __dirname,

--- a/test/integration/invalid-exports-esm/index.test.ts
+++ b/test/integration/invalid-exports-esm/index.test.ts
@@ -1,7 +1,7 @@
 import { createIntegrationTest } from '../utils'
 
-describe('integration', () => {
-  test(`invalid-exports-esm`, async () => {
+describe('integration invalid-exports-esm', () => {
+  it('should warn on invalid exports as ESM', async () => {
     await createIntegrationTest(
       {
         directory: __dirname,

--- a/test/integration/js-only/index.test.ts
+++ b/test/integration/js-only/index.test.ts
@@ -1,7 +1,7 @@
 import { createIntegrationTest, existsFile } from '../utils'
 
-describe('integration', () => {
-  test(`js-only`, async () => {
+describe('integration js-only', () => {
+  it('should work on JS only', async () => {
     await createIntegrationTest(
       {
         directory: __dirname,

--- a/test/integration/js-only/index.test.ts
+++ b/test/integration/js-only/index.test.ts
@@ -1,7 +1,7 @@
 import { createIntegrationTest, existsFile } from '../utils'
 
 describe('integration js-only', () => {
-  it('should work on JS only', async () => {
+  it('should work with js only project', async () => {
     await createIntegrationTest(
       {
         directory: __dirname,


### PR DESCRIPTION
As stated in https://github.com/huozhi/bunchee/pull/455#discussion_r1493786108 and https://github.com/huozhi/bunchee/pull/455#discussion_r1493786266, this PR modifies the migrated integration tests for later works.

Extends PR #455
Extends Issue #449