### PR TITLE
Fix bunchee command execution in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ mkdir src && touch ./src/index.ts
 
 ```sh
 # Use bunchee to prepare package.json configuration
-npx bunchee --prepare
+npm exec bunchee --prepare
 # "If you're using other package manager such as pnpm"
 # pnpm bunchee --prepare
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ mkdir src && touch ./src/index.ts
 
 ```sh
 # Use bunchee to prepare package.json configuration
-npm bunchee --prepare
+npx bunchee --prepare
 # "If you're using other package manager such as pnpm"
 # pnpm bunchee --prepare
 


### PR DESCRIPTION
Executing with npm results in 
```shell
npm bunchee --prepare

Unknown command: "bunchee"

To see a list of supported npm commands, run:
  npm help
```