### PR TITLE
fix: regex expression of circular dependency

### DIFF
--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -278,7 +278,7 @@ async function buildInputConfig(
       // If the circular dependency warning is from node_modules, ignore it
       if (
         code === 'CIRCULAR_DEPENDENCY' &&
-        /Circular dependency: node_modules/.test(warning.message)
+        /Circular dependency:(\s|\S)*node_modules/.test(warning.message)
       ) {
         return
       }


### PR DESCRIPTION
## Issue

If a project is one of a monorepo, navigate to the project and run it maybe print the `Circular dependency` warnings.

```bash
Circular dependency: ../../node_modules/.pnpm/culori@4.0.1/node_modules/culori/src/parse.js -> ../../node_modules/.pnpm/culori@4.0.1/node_modules/culori/src/modes.js -> ../../node_modules/.pnpm/culori@4.0.1/node_modules/culori/src/converter.js -> ../../node_modules/.pnpm/culori@4.0.1/node_modules/culori/src/_prepare.js -> ../../node_modules/.pnpm/culori@4.0.1/node_modules/culori/src/parse.js
```

## Solution

Update the `Circular dependency` regex expression.