### PR TITLE
chore: replace `tsx` with swc

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "clean": "rm -rf ./dist",
     "typecheck": "tsc --noEmit && tsc -p test/tsconfig.json --noEmit",
     "prepublishOnly": "pnpm clean && pnpm build && chmod +x ./dist/bin/cli.js && pnpm test",
-    "build": "tsx ./src/bin/index.ts --runtime node",
+    "build": "SWC_NODE_IGNORE_DYNAMIC=true node -r @swc-node/register ./src/bin/index.ts --runtime node",
     "format": "prettier --write .",
     "prepare": "husky install"
   },
@@ -79,6 +79,7 @@
   },
   "devDependencies": {
     "@huozhi/testing-package": "1.0.0",
+    "@swc-node/register": "^1.9.0",
     "@swc/jest": "^0.2.31",
     "@swc/types": "^0.1.5",
     "@types/clean-css": "^4.2.11",
@@ -91,7 +92,6 @@
     "picocolors": "^1.0.0",
     "prettier": "^3.0.0",
     "react": "^18.2.0",
-    "tsx": "^4.6.2",
     "typescript": "^5.3.2"
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,9 @@ devDependencies:
   '@huozhi/testing-package':
     specifier: 1.0.0
     version: 1.0.0
+  '@swc-node/register':
+    specifier: ^1.9.0
+    version: 1.9.0(@swc/core@1.3.106)(@swc/types@0.1.5)(typescript@5.3.2)
   '@swc/jest':
     specifier: ^0.2.31
     version: 0.2.31(@swc/core@1.3.106)
@@ -100,9 +103,6 @@ devDependencies:
   react:
     specifier: ^18.2.0
     version: 18.2.0
-  tsx:
-    specifier: ^4.6.2
-    version: 4.6.2
   typescript:
     specifier: ^5.3.2
     version: 5.3.2
@@ -525,204 +525,6 @@ packages:
   /@bcoe/v8-coverage@0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
-
-  /@esbuild/android-arm64@0.18.20:
-    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/android-arm@0.18.20:
-    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/android-x64@0.18.20:
-    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/darwin-arm64@0.18.20:
-    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/darwin-x64@0.18.20:
-    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/freebsd-arm64@0.18.20:
-    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/freebsd-x64@0.18.20:
-    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-arm64@0.18.20:
-    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-arm@0.18.20:
-    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-ia32@0.18.20:
-    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-loong64@0.18.20:
-    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-mips64el@0.18.20:
-    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-ppc64@0.18.20:
-    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-riscv64@0.18.20:
-    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-s390x@0.18.20:
-    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-x64@0.18.20:
-    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/netbsd-x64@0.18.20:
-    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/openbsd-x64@0.18.20:
-    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/sunos-x64@0.18.20:
-    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/win32-arm64@0.18.20:
-    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/win32-ia32@0.18.20:
-    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/win32-x64@0.18.20:
-    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
 
   /@fastify/deepmerge@1.3.0:
     resolution: {integrity: sha512-J8TOSBq3SoZbDhM9+R/u77hP93gz/rajSA+K2kGyijPpORPWUXHUpTaleoj+92As0S9uPRP7Oi8IqMf0u+ro6A==}
@@ -1264,6 +1066,43 @@ packages:
     resolution: {integrity: sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==}
     dependencies:
       '@sinonjs/commons': 1.8.3
+    dev: true
+
+  /@swc-node/core@1.13.0(@swc/core@1.3.106)(@swc/types@0.1.5):
+    resolution: {integrity: sha512-lFPD4nmy4ifAOVMChFjwlpXN5KQXvegqeyuzz1KQz42q1lf+cL3Qux1/GteGuZjh8HC+Rj1RdNrHpE/MCfJSTw==}
+    engines: {node: '>= 10'}
+    peerDependencies:
+      '@swc/core': '>= 1.3'
+      '@swc/types': '>= 0.1'
+    dependencies:
+      '@swc/core': 1.3.106(@swc/helpers@0.5.3)
+      '@swc/types': 0.1.5
+    dev: true
+
+  /@swc-node/register@1.9.0(@swc/core@1.3.106)(@swc/types@0.1.5)(typescript@5.3.2):
+    resolution: {integrity: sha512-i0iYInD4q5v3xQC6bKvs0QtfUxu197CU5qKALmpxEqTYs7sIhQ7KFLe3kP+eAR4gRkJTvAgjQgrokXLN2jZrOw==}
+    peerDependencies:
+      '@swc/core': '>= 1.3'
+      typescript: '>= 4.3'
+    dependencies:
+      '@swc-node/core': 1.13.0(@swc/core@1.3.106)(@swc/types@0.1.5)
+      '@swc-node/sourcemap-support': 0.5.0
+      '@swc/core': 1.3.106(@swc/helpers@0.5.3)
+      colorette: 2.0.20
+      debug: 4.3.4
+      pirates: 4.0.6
+      tslib: 2.6.2
+      typescript: 5.3.2
+    transitivePeerDependencies:
+      - '@swc/types'
+      - supports-color
+    dev: true
+
+  /@swc-node/sourcemap-support@0.5.0:
+    resolution: {integrity: sha512-fbhjL5G0YvFoWwNhWleuBUfotiX+USiA9oJqu9STFw+Hb0Cgnddn+HVS/K5fI45mn92e8V+cHD2jgFjk4w2T9Q==}
+    dependencies:
+      source-map-support: 0.5.21
+      tslib: 2.6.2
     dev: true
 
   /@swc/core-darwin-arm64@1.3.106:
@@ -1913,36 +1752,6 @@ packages:
       is-arrayish: 0.2.1
     dev: true
 
-  /esbuild@0.18.20:
-    resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
-    engines: {node: '>=12'}
-    hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      '@esbuild/android-arm': 0.18.20
-      '@esbuild/android-arm64': 0.18.20
-      '@esbuild/android-x64': 0.18.20
-      '@esbuild/darwin-arm64': 0.18.20
-      '@esbuild/darwin-x64': 0.18.20
-      '@esbuild/freebsd-arm64': 0.18.20
-      '@esbuild/freebsd-x64': 0.18.20
-      '@esbuild/linux-arm': 0.18.20
-      '@esbuild/linux-arm64': 0.18.20
-      '@esbuild/linux-ia32': 0.18.20
-      '@esbuild/linux-loong64': 0.18.20
-      '@esbuild/linux-mips64el': 0.18.20
-      '@esbuild/linux-ppc64': 0.18.20
-      '@esbuild/linux-riscv64': 0.18.20
-      '@esbuild/linux-s390x': 0.18.20
-      '@esbuild/linux-x64': 0.18.20
-      '@esbuild/netbsd-x64': 0.18.20
-      '@esbuild/openbsd-x64': 0.18.20
-      '@esbuild/sunos-x64': 0.18.20
-      '@esbuild/win32-arm64': 0.18.20
-      '@esbuild/win32-ia32': 0.18.20
-      '@esbuild/win32-x64': 0.18.20
-    dev: true
-
   /escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
     engines: {node: '>=6'}
@@ -2084,6 +1893,7 @@ packages:
     resolution: {integrity: sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==}
     dependencies:
       resolve-pkg-maps: 1.0.0
+    dev: false
 
   /glob@10.3.10:
     resolution: {integrity: sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==}
@@ -3057,6 +2867,11 @@ packages:
     engines: {node: '>= 6'}
     dev: true
 
+  /pirates@4.0.6:
+    resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
+    engines: {node: '>= 6'}
+    dev: true
+
   /pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
@@ -3122,6 +2937,7 @@ packages:
 
   /resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+    dev: false
 
   /resolve.exports@1.1.0:
     resolution: {integrity: sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==}
@@ -3301,6 +3117,13 @@ packages:
       source-map: 0.6.1
     dev: true
 
+  /source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+    dev: true
+
   /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
@@ -3449,17 +3272,6 @@ packages:
 
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
-
-  /tsx@4.6.2:
-    resolution: {integrity: sha512-QPpBdJo+ZDtqZgAnq86iY/PD2KYCUPSUGIunHdGwyII99GKH+f3z3FZ8XNFLSGQIA4I365ui8wnQpl8OKLqcsg==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
-    dependencies:
-      esbuild: 0.18.20
-      get-tsconfig: 4.7.2
-    optionalDependencies:
-      fsevents: 2.3.3
-    dev: true
 
   /type-detect@4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}

--- a/test/cli/output-in-watch/index.test.ts
+++ b/test/cli/output-in-watch/index.test.ts
@@ -8,12 +8,12 @@ describe('cli', () => {
         args: ['hello.js', '-w', '-o', 'dist/hello.bundle.js'],
         abortTimeout: 3000,
       },
-      ({ code, stdout }) => {
+      ({ signal, stdout }) => {
         const watchOutputRegex = /Build in \d+(.\d{2})ms/
         expect(stdout.includes('Watching project')).toBe(true)
         expect(watchOutputRegex.test(stdout)).toBe(true)
         expect(stdout.includes('Exports')).toBe(false)
-        expect(code).toBe(143) // SIGTERM exit code
+        expect(signal).toBe('SIGTERM') // SIGTERM exit code
       },
     )
   })

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1,6 +1,6 @@
 import fsp from 'fs/promises'
 import { execSync, fork } from 'child_process'
-import { resolve, join, extname } from 'path'
+import path, { resolve, join, extname } from 'path'
 import {
   stripANSIColor,
   existsFile,
@@ -492,15 +492,15 @@ async function runBundle(
   args_: string[],
 ): Promise<{ code: number | null; stdout: string; stderr: string }> {
   const assetPath = process.env.POST_BUILD
-    ? '/../dist/bin/cli.js'
-    : '/../src/bin/index.ts'
+    ? '../dist/bin/cli.js'
+    : '../src/bin/index.ts'
 
   const args = (args_ || []).concat(['--cwd', dir])
-  const ps = fork(
-    `${require.resolve('tsx/cli')}`,
-    [__dirname + assetPath].concat(args),
-    { stdio: 'pipe' },
-  )
+
+  const ps = fork(path.resolve(__dirname, assetPath), args, {
+    stdio: 'pipe',
+    env: { SWC_NODE_IGNORE_DYNAMIC: 'true' },
+  })
   let stderr = '',
     stdout = ''
   ps.stdout?.on('data', (chunk) => (stdout += chunk.toString()))

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1,5 +1,5 @@
 import fsp from 'fs/promises'
-import { execSync, fork } from 'child_process'
+import { execSync, spawn } from 'child_process'
 import path, { resolve, join, extname } from 'path'
 import {
   stripANSIColor,
@@ -497,10 +497,13 @@ async function runBundle(
 
   const args = (args_ || []).concat(['--cwd', dir])
 
-  const ps = fork(path.resolve(__dirname, assetPath), args, {
-    stdio: 'pipe',
-    env: { SWC_NODE_IGNORE_DYNAMIC: 'true' },
-  })
+  const ps = spawn(
+    process.execPath,
+    ['-r', '@swc-node/register', path.resolve(__dirname, assetPath)].concat(
+      args,
+    ),
+    { stdio: 'pipe', env: { SWC_NODE_IGNORE_DYNAMIC: 'true', ...process.env } },
+  )
   let stderr = '',
     stdout = ''
   ps.stdout?.on('data', (chunk) => (stdout += chunk.toString()))

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1,5 +1,5 @@
 import fsp from 'fs/promises'
-import { execSync, spawn } from 'child_process'
+import { execSync, fork } from 'child_process'
 import path, { resolve, join, extname } from 'path'
 import {
   stripANSIColor,
@@ -349,14 +349,14 @@ const testCases: {
     args: [],
     async expected(dir, { stdout }) {
       /*
-      output:
-
-      Exports          File                        Size
-      cli (bin)        dist/cli.js                 103 B
-      .                dist/index.js               42 B
-      . (react-server) dist/index.react-server.js  55 B
-      ./foo            dist/foo.js                 103 B
-      */
+        output:
+  
+        Exports          File                        Size
+        cli (bin)        dist/cli.js                 103 B
+        .                dist/index.js               42 B
+        . (react-server) dist/index.react-server.js  55 B
+        ./foo            dist/foo.js                 103 B
+        */
 
       const lines = stripANSIColor(stdout).split('\n')
       const [tableHeads, ...restLines] = lines
@@ -417,11 +417,11 @@ const testCases: {
     args: [],
     async expected(dir, { stdout, stderr }) {
       /*
-      output:
-
-      Exports File          Size
-      .       dist/index.js 30 B
-      */
+        output:
+  
+        Exports File          Size
+        .       dist/index.js 30 B
+        */
       const [tableHeads, indexLine] = stripANSIColor(stdout).split('\n')
       expect(tableHeads).toContain('Exports')
       expect(tableHeads).toContain('File')
@@ -497,13 +497,11 @@ async function runBundle(
 
   const args = (args_ || []).concat(['--cwd', dir])
 
-  const ps = spawn(
-    process.execPath,
-    ['-r', '@swc-node/register', path.resolve(__dirname, assetPath)].concat(
-      args,
-    ),
-    { stdio: 'pipe', env: { SWC_NODE_IGNORE_DYNAMIC: 'true', ...process.env } },
-  )
+  const ps = fork(path.resolve(__dirname, assetPath), args, {
+    execArgv: ['-r', '@swc-node/register'],
+    stdio: 'pipe',
+    env: { SWC_NODE_IGNORE_DYNAMIC: 'true', ...process.env },
+  })
   let stderr = '',
     stdout = ''
   ps.stdout?.on('data', (chunk) => (stdout += chunk.toString()))

--- a/test/testing-utils.ts
+++ b/test/testing-utils.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import fsp from 'fs/promises'
 import path from 'path'
 import * as debug from './utils/debug'
-import { fork } from 'child_process'
+import { spawn } from 'child_process'
 
 export function stripANSIColor(str: string) {
   return str.replace(
@@ -153,13 +153,16 @@ export async function executeBunchee(
     ? '../dist/bin/cli.js'
     : '../src/bin/index.ts'
 
-  const ps = fork(path.resolve(__dirname, assetPath), args, {
-    stdio: 'pipe',
-    env: {
-      ...options.env,
-      SWC_NODE_IGNORE_DYNAMIC: 'true',
+  const ps = spawn(
+    process.execPath,
+    ['-r', '@swc-node/register', path.resolve(__dirname, assetPath)].concat(
+      args,
+    ),
+    {
+      stdio: 'pipe',
+      env: { SWC_NODE_IGNORE_DYNAMIC: 'true', ...options.env, ...process.env },
     },
-  })
+  )
   let stderr = ''
   let stdout = ''
   ps.stdout?.on('data', (chunk) => (stdout += chunk.toString()))

--- a/test/testing-utils.ts
+++ b/test/testing-utils.ts
@@ -137,7 +137,8 @@ export async function createTest<T>(
 }
 
 export type ExcuteBuncheeResult = {
-  code: number
+  code: number | null
+  signal: NodeJS.Signals | null
   stdout: string
   stderr: string
 }
@@ -169,11 +170,13 @@ export async function executeBunchee(
     }, processOptions.abortTimeout)
   }
 
-  const code = (await new Promise((resolve) => {
-    ps.on('close', resolve)
-  })) as number
+  const [code, signal] = await new Promise<
+    [number | null, NodeJS.Signals | null]
+  >((resolve) => {
+    ps.on('close', (code, signal) => resolve([code, signal]))
+  })
   if (stdout) console.log(stdout)
   if (stderr) console.error(stderr)
 
-  return { code, stdout, stderr }
+  return { code, stdout, stderr, signal }
 }

--- a/test/testing-utils.ts
+++ b/test/testing-utils.ts
@@ -150,17 +150,16 @@ export async function executeBunchee(
   debug.log(`Command: bunchee ${args.join(' ')}`)
 
   const assetPath = process.env.POST_BUILD
-    ? '/../dist/bin/cli.js'
-    : '/../src/bin/index.ts'
+    ? '../dist/bin/cli.js'
+    : '../src/bin/index.ts'
 
-  const ps = fork(
-    `${require.resolve('tsx/cli')}`,
-    [__dirname + assetPath].concat(args),
-    {
-      stdio: 'pipe',
-      env: options.env,
+  const ps = fork(path.resolve(__dirname, assetPath), args, {
+    stdio: 'pipe',
+    env: {
+      ...options.env,
+      SWC_NODE_IGNORE_DYNAMIC: 'true',
     },
-  )
+  })
   let stderr = ''
   let stdout = ''
   ps.stdout?.on('data', (chunk) => (stdout += chunk.toString()))

--- a/test/testing-utils.ts
+++ b/test/testing-utils.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import fsp from 'fs/promises'
 import path from 'path'
 import * as debug from './utils/debug'
-import { spawn } from 'child_process'
+import { fork } from 'child_process'
 
 export function stripANSIColor(str: string) {
   return str.replace(
@@ -153,16 +153,11 @@ export async function executeBunchee(
     ? '../dist/bin/cli.js'
     : '../src/bin/index.ts'
 
-  const ps = spawn(
-    process.execPath,
-    ['-r', '@swc-node/register', path.resolve(__dirname, assetPath)].concat(
-      args,
-    ),
-    {
-      stdio: 'pipe',
-      env: { SWC_NODE_IGNORE_DYNAMIC: 'true', ...options.env, ...process.env },
-    },
-  )
+  const ps = fork(path.resolve(__dirname, assetPath), args, {
+    execArgv: ['-r', '@swc-node/register'],
+    stdio: 'pipe',
+    env: { SWC_NODE_IGNORE_DYNAMIC: 'true', ...options.env, ...process.env },
+  })
   let stderr = ''
   let stdout = ''
   ps.stdout?.on('data', (chunk) => (stdout += chunk.toString()))


### PR DESCRIPTION
The PR replaces `tsx` with `@swc-node/register`.

`bunchee` already prefers swc, it doesn't make sense to use esbuild as the build script loader.  Let's switch it to swc.