### PR TITLE
feat: allow overrding tsconfig path

### DIFF
--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -32,6 +32,7 @@ Options:
   --sourcemap            enable sourcemap generation, default: false
   --dts                  determine if need to generate types, default: undefined
   --no-dts               do not generate types, default: undefined
+  --tsconfig             path to tsconfig file, default: tsconfig.json
 `
 
 function help() {
@@ -67,6 +68,7 @@ function parseCliArgs(argv: string[]) {
       '--no-external': Boolean,
       '--no-clean': Boolean,
       '--prepare': Boolean,
+      '--tsconfig': String,
 
       '-h': '--help',
       '-v': '--version',
@@ -98,6 +100,7 @@ function parseCliArgs(argv: string[]) {
     clean: !args['--no-clean'],
     env: args['--env'],
     prepare: !!args['--prepare'],
+    tsconfig: args['--tsconfig'],
   }
   return parsedArgs
 }
@@ -114,6 +117,7 @@ async function run(args: CliArgs) {
     dts,
     env,
     clean,
+    tsconfig,
   } = args
   const cwd = args.cwd || process.cwd()
   const file = args.file ? path.resolve(cwd, args.file) : undefined
@@ -130,6 +134,7 @@ async function run(args: CliArgs) {
     sourcemap: sourcemap === false ? false : true,
     env: env?.split(',') || [],
     clean,
+    tsconfig,
   }
   if (args.version) {
     return logger.log(version)

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -69,7 +69,7 @@ async function bundle(
   const inputFile = cliEntryPath
   const isFromCli = Boolean(cliEntryPath)
 
-  let tsConfig = resolveTsConfig(cwd)
+  let tsConfig = resolveTsConfig(cwd, options.tsconfig)
   let hasTsConfig = Boolean(tsConfig?.tsConfigPath)
   const defaultTsOptions: TypescriptOptions = {
     tsConfigPath: tsConfig?.tsConfigPath,

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,7 @@ type BundleConfig = {
   runtime?: string
   pkg?: PackageMetadata
   clean?: boolean
+  tsconfig?: string
 }
 
 type PackageMetadata = {
@@ -80,6 +81,7 @@ type CliArgs = {
   runtime?: string
   prepare?: boolean
   clean?: boolean
+  tsconfig?: string
 }
 
 type BundleOptions = BundleConfig

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -32,10 +32,13 @@ function resolveTypescriptHandler(cwd: string): typeof import('typescript') {
 }
 const resolveTypescript = memoize(resolveTypescriptHandler)
 
-function resolveTsConfigHandler(cwd: string): null | TypescriptOptions {
+function resolveTsConfigHandler(
+  cwd: string,
+  tsconfig = 'tsconfig.json',
+): null | TypescriptOptions {
   let tsCompilerOptions: CompilerOptions = {}
   let tsConfigPath: string | undefined
-  tsConfigPath = resolve(cwd, 'tsconfig.json')
+  tsConfigPath = resolve(cwd, tsconfig)
   if (fileExists(tsConfigPath)) {
     const ts = resolveTypescript(cwd)
     const basePath = tsConfigPath ? dirname(tsConfigPath) : cwd

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -485,6 +485,15 @@ const testCases: {
       expect(await existsFile(join(dir, './dist/index.d.ts'))).toBe(true)
     },
   },
+  {
+    name: 'tsconfig-override',
+    dir: 'tsconfig-override',
+    args: ['--tsconfig', 'tsconfig.build.json'],
+    async expected(dir) {
+      expect(await existsFile(join(dir, './dist/index.js'))).toBe(true)
+      expect(await existsFile(join(dir, './dist/index.d.ts'))).toBe(true)
+    },
+  },
 ]
 
 async function runBundle(

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -485,20 +485,6 @@ const testCases: {
       expect(await existsFile(join(dir, './dist/index.d.ts'))).toBe(true)
     },
   },
-  {
-    name: 'tsconfig-override',
-    dir: 'tsconfig-override',
-    args: ['--tsconfig', 'tsconfig.build.json'],
-    async expected(dir) {
-      expect(await existsFile(join(dir, './dist/index.js'))).toBe(true)
-      expect(await existsFile(join(dir, './dist/index.d.ts'))).toBe(true)
-
-      // Should not reference using local path since `tsconfig.build.json` doesn't have
-      // path overrides
-      const content = await fsp.readFile(join(dir, './dist/index.js'), 'utf-8')
-      expect(content).toContain("export { bundle } from 'bunchee';")
-    },
-  },
 ]
 
 async function runBundle(

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -492,6 +492,11 @@ const testCases: {
     async expected(dir) {
       expect(await existsFile(join(dir, './dist/index.js'))).toBe(true)
       expect(await existsFile(join(dir, './dist/index.d.ts'))).toBe(true)
+
+      // Should not reference using local path since `tsconfig.build.json` doesn't have
+      // path overrides
+      const content = await fsp.readFile(join(dir, './dist/index.js'), 'utf-8')
+      expect(content).toContain("export { bundle } from 'bunchee';")
     },
   },
 ]

--- a/test/integration/tsconfig-override/index.test.ts
+++ b/test/integration/tsconfig-override/index.test.ts
@@ -3,7 +3,7 @@ import { join } from 'path'
 import { createIntegrationTest } from '../utils'
 
 describe('integration tsconfig-override', () => {
-  it('should use esnext output in build without override', async () => {
+  it('should use es5 output in build without override', async () => {
     await createIntegrationTest(
       {
         directory: __dirname,
@@ -13,11 +13,12 @@ describe('integration tsconfig-override', () => {
           join(dir, './dist/index.js'),
           'utf-8',
         )
-        expect(content).toContain("var index = (()=>'index');")
+        expect(content).toContain('function A')
+        expect(content).not.toContain('class A')
       },
     )
   })
-  it('should use es5 output in build', async () => {
+  it('should use es8 output in build', async () => {
     await createIntegrationTest(
       {
         directory: __dirname,
@@ -28,7 +29,8 @@ describe('integration tsconfig-override', () => {
           join(dir, './dist/index.js'),
           'utf-8',
         )
-        expect(content).toContain('export { index as default };')
+        expect(content).not.toContain('function A')
+        expect(content).toContain('class A')
       },
     )
   })

--- a/test/integration/tsconfig-override/index.test.ts
+++ b/test/integration/tsconfig-override/index.test.ts
@@ -1,0 +1,36 @@
+import * as fsp from 'fs/promises'
+import { join } from 'path'
+import { createIntegrationTest } from '../utils'
+
+describe('integration tsconfig-override', () => {
+  const dir = __dirname
+  it('should use esnext output in build without override', async () => {
+    await createIntegrationTest(
+      {
+        directory: __dirname,
+      },
+      async ({ dir }) => {
+        const content = await fsp.readFile(
+          join(dir, './dist/index.js'),
+          'utf-8',
+        )
+        expect(content).toContain('export { index as default };')
+      },
+    )
+  })
+  it('should use es5 output in build', async () => {
+    await createIntegrationTest(
+      {
+        directory: __dirname,
+        args: ['--tsconfig', 'tsconfig.build.json'],
+      },
+      async ({ dir }) => {
+        const content = await fsp.readFile(
+          join(dir, './dist/index.js'),
+          'utf-8',
+        )
+        expect(content).toContain("var index = (()=>'index');")
+      },
+    )
+  })
+})

--- a/test/integration/tsconfig-override/index.test.ts
+++ b/test/integration/tsconfig-override/index.test.ts
@@ -3,30 +3,6 @@ import { join } from 'path'
 import { createIntegrationTest } from '../utils'
 
 describe('integration tsconfig-override', () => {
-  beforeAll(async () => {
-    await fsp.writeFile(
-      join(__dirname, './package.json'),
-      JSON.stringify({
-        name: 'tsconfig-override',
-        type: 'module',
-        exports: {
-          '.': {
-            default: './dist/index.js',
-            types: './dist/index.d.ts',
-          },
-        },
-      }),
-    )
-    await fsp.writeFile(
-      join(__dirname, './tsconfig.json'),
-      JSON.stringify({ compilerOptions: { target: 'esnext' } }),
-    )
-    await fsp.writeFile(
-      join(__dirname, './tsconfig.build.json'),
-      JSON.stringify({ compilerOptions: { target: 'es5' } }),
-    )
-  })
-
   it('should use esnext output in build without override', async () => {
     await createIntegrationTest(
       {

--- a/test/integration/tsconfig-override/index.test.ts
+++ b/test/integration/tsconfig-override/index.test.ts
@@ -3,7 +3,30 @@ import { join } from 'path'
 import { createIntegrationTest } from '../utils'
 
 describe('integration tsconfig-override', () => {
-  const dir = __dirname
+  beforeAll(async () => {
+    await fsp.writeFile(
+      join(__dirname, './package.json'),
+      JSON.stringify({
+        name: 'tsconfig-override',
+        type: 'module',
+        exports: {
+          '.': {
+            default: './dist/index.js',
+            types: './dist/index.d.ts',
+          },
+        },
+      }),
+    )
+    await fsp.writeFile(
+      join(__dirname, './tsconfig.json'),
+      JSON.stringify({ compilerOptions: { target: 'esnext' } }),
+    )
+    await fsp.writeFile(
+      join(__dirname, './tsconfig.build.json'),
+      JSON.stringify({ compilerOptions: { target: 'es5' } }),
+    )
+  })
+
   it('should use esnext output in build without override', async () => {
     await createIntegrationTest(
       {
@@ -14,7 +37,7 @@ describe('integration tsconfig-override', () => {
           join(dir, './dist/index.js'),
           'utf-8',
         )
-        expect(content).toContain('export { index as default };')
+        expect(content).toContain("var index = (()=>'index');")
       },
     )
   })
@@ -29,7 +52,7 @@ describe('integration tsconfig-override', () => {
           join(dir, './dist/index.js'),
           'utf-8',
         )
-        expect(content).toContain("var index = (()=>'index');")
+        expect(content).toContain('export { index as default };')
       },
     )
   })

--- a/test/integration/tsconfig-override/package.json
+++ b/test/integration/tsconfig-override/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "tsconfig-override",
+  "type": "module",
+  "exports": {
+    ".": {
+      "default": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  }
+}

--- a/test/integration/tsconfig-override/package.json
+++ b/test/integration/tsconfig-override/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "tsconfig-override",
+  "types": "./dist/index.d.ts",
+  "exports": "./dist/index.js"
+}

--- a/test/integration/tsconfig-override/package.json
+++ b/test/integration/tsconfig-override/package.json
@@ -1,9 +1,0 @@
-{
-  "name": "tsconfig-override",
-  "type": "module",
-  "types": "./dist/index.d.ts",
-  "exports": "./dist/index.js",
-  "peerDependencies": {
-    "bunchee": "*"
-  }
-}

--- a/test/integration/tsconfig-override/package.json
+++ b/test/integration/tsconfig-override/package.json
@@ -1,5 +1,9 @@
 {
   "name": "tsconfig-override",
+  "type": "module",
   "types": "./dist/index.d.ts",
-  "exports": "./dist/index.js"
+  "exports": "./dist/index.js",
+  "peerDependencies": {
+    "bunchee": "*"
+  }
 }

--- a/test/integration/tsconfig-override/src/index.ts
+++ b/test/integration/tsconfig-override/src/index.ts
@@ -1,0 +1,1 @@
+export default () => 'index'

--- a/test/integration/tsconfig-override/src/index.ts
+++ b/test/integration/tsconfig-override/src/index.ts
@@ -1,1 +1,1 @@
-export default () => 'index'
+export default class A {}

--- a/test/integration/tsconfig-override/src/index.ts
+++ b/test/integration/tsconfig-override/src/index.ts
@@ -1,3 +1,4 @@
+// CMD+Click on "bunchee" goes to `src/index.ts`, but built output should go to `dist/index.d.ts`
 export { bundle } from 'bunchee'
 
 export default () => 'index'

--- a/test/integration/tsconfig-override/src/index.ts
+++ b/test/integration/tsconfig-override/src/index.ts
@@ -1,1 +1,3 @@
+export { bundle } from 'bunchee'
+
 export default () => 'index'

--- a/test/integration/tsconfig-override/src/index.ts
+++ b/test/integration/tsconfig-override/src/index.ts
@@ -1,4 +1,1 @@
-// CMD+Click on "bunchee" goes to `src/index.ts`, but built output should go to `dist/index.d.ts`
-export { bundle } from 'bunchee'
-
 export default () => 'index'

--- a/test/integration/tsconfig-override/tsconfig.build.json
+++ b/test/integration/tsconfig-override/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler"
+  }
+}

--- a/test/integration/tsconfig-override/tsconfig.build.json
+++ b/test/integration/tsconfig-override/tsconfig.build.json
@@ -1,0 +1,1 @@
+{ "compilerOptions": { "target": "es5" } }

--- a/test/integration/tsconfig-override/tsconfig.build.json
+++ b/test/integration/tsconfig-override/tsconfig.build.json
@@ -1,5 +1,0 @@
-{
-  "compilerOptions": {
-    "target": "ESNext"
-  }
-}

--- a/test/integration/tsconfig-override/tsconfig.build.json
+++ b/test/integration/tsconfig-override/tsconfig.build.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "module": "ESNext",
-    "moduleResolution": "bundler"
+    "target": "ESNext"
   }
 }

--- a/test/integration/tsconfig-override/tsconfig.build.json
+++ b/test/integration/tsconfig-override/tsconfig.build.json
@@ -1,1 +1,1 @@
-{ "compilerOptions": { "target": "es5" } }
+{ "compilerOptions": { "target": "es2018" } }

--- a/test/integration/tsconfig-override/tsconfig.json
+++ b/test/integration/tsconfig-override/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler"
+  }
+}

--- a/test/integration/tsconfig-override/tsconfig.json
+++ b/test/integration/tsconfig-override/tsconfig.json
@@ -1,0 +1,1 @@
+{ "compilerOptions": { "target": "esnext" } }

--- a/test/integration/tsconfig-override/tsconfig.json
+++ b/test/integration/tsconfig-override/tsconfig.json
@@ -1,5 +1,0 @@
-{
-  "compilerOptions": {
-    "target": "ES5"
-  }
-}

--- a/test/integration/tsconfig-override/tsconfig.json
+++ b/test/integration/tsconfig-override/tsconfig.json
@@ -1,8 +1,5 @@
 {
-  "extends": "./tsconfig.build.json",
   "compilerOptions": {
-    "paths": {
-      "bunchee": ["../../../src"]
-    }
+    "target": "ES5"
   }
 }

--- a/test/integration/tsconfig-override/tsconfig.json
+++ b/test/integration/tsconfig-override/tsconfig.json
@@ -1,1 +1,1 @@
-{ "compilerOptions": { "target": "esnext" } }
+{ "compilerOptions": { "target": "es5" } }

--- a/test/integration/tsconfig-override/tsconfig.json
+++ b/test/integration/tsconfig-override/tsconfig.json
@@ -1,6 +1,8 @@
 {
+  "extends": "./tsconfig.build.json",
   "compilerOptions": {
-    "module": "ESNext",
-    "moduleResolution": "bundler"
+    "paths": {
+      "bunchee": ["../../../src"]
+    }
   }
 }


### PR DESCRIPTION
Allows using a custom path for tsconfig during build. Useful if you for example have one tsconfig for editor experience and a different one for build

(ref https://github.com/pingdotgg/uploadthing/tree/main/packages/uploadthing - base tsconfig has path overrides to resolve source code types during dev, but we don't want the built output to use those paths)
![CleanShot 2024-03-13 at 17 15 13@2x](https://github.com/huozhi/bunchee/assets/51714798/d34d37d3-2da5-4dc9-90dd-88b4298dc515)
