### PR TITLE
fix memoize util causing cache mismatch

### DIFF
--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -33,12 +33,8 @@ import {
   getExportFileTypePath,
   ExportOutput,
 } from './exports'
-import {
-  isESModulePackage,
-  isNotNull,
-  filePathWithoutExtension,
-  memoizeByKey,
-} from './utils'
+import { isESModulePackage, isNotNull, filePathWithoutExtension } from './utils'
+import { memoizeByKey } from './lib/memoize'
 import {
   availableESExtensionsRegex,
   nodeResolveExtensions,

--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -243,8 +243,7 @@ async function buildInputConfig(
     // Each process should be unique
     // Each package build should be unique
     // Composing above factors into a unique cache key to retrieve the memoized dts plugin with tsconfigs
-    const uniqueProcessId =
-      'dts-plugin:' + process.pid + tsConfigPath + (buildContext.pkg.name || '')
+    const uniqueProcessId = 'dts-plugin:' + process.pid + tsConfigPath
     const dtsPlugin = await memoizeDtsPluginByKey(uniqueProcessId)(
       tsCompilerOptions,
       tsConfigPath,

--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -244,7 +244,7 @@ async function buildInputConfig(
     // Each package build should be unique
     // Composing above factors into a unique cache key to retrieve the memoized dts plugin with tsconfigs
     const uniqueProcessId =
-      'dts-plugin:' + process.pid + (buildContext.pkg.name || '')
+      'dts-plugin:' + process.pid + tsConfigPath + (buildContext.pkg.name || '')
     const dtsPlugin = await memoizeDtsPluginByKey(uniqueProcessId)(
       tsCompilerOptions,
       tsConfigPath,

--- a/src/lib/memoize.ts
+++ b/src/lib/memoize.ts
@@ -1,0 +1,28 @@
+type CacheKeyResolver = string | ((...args: any[]) => string)
+
+const memoize = <T extends (...args: any[]) => any>(
+  fn: T,
+  cacheKey?: CacheKeyResolver, // if you need specify a cache key
+  cacheArg?: Map<string, ReturnType<T>>,
+) => {
+  const cache: Map<string, ReturnType<T>> = cacheArg || new Map()
+  return ((...args: Parameters<T>) => {
+    const key = cacheKey
+      ? typeof cacheKey === 'function'
+        ? cacheKey(...args)
+        : cacheKey
+      : JSON.stringify({ args })
+    const existing = cache.get(key)
+    if (existing !== undefined) {
+      return existing
+    }
+    const result = fn(...args)
+    cache.set(key, result)
+    return result
+  }) as T
+}
+
+export const memoizeByKey = <T extends (...args: any[]) => any>(fn: T) => {
+  const cache = new Map<string, ReturnType<T>>()
+  return (cacheKey?: CacheKeyResolver) => memoize(fn, cacheKey, cache)
+}

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -3,7 +3,8 @@ import { resolve, dirname } from 'path'
 import { promises as fsp } from 'fs'
 import { Module } from 'module'
 import pc from 'picocolors'
-import { exit, fileExists, memoize } from './utils'
+import { exit, fileExists } from './utils'
+import { memoizeByKey } from './lib/memoize'
 import { DEFAULT_TS_CONFIG } from './constants'
 import { logger } from './logger'
 
@@ -57,7 +58,9 @@ function resolveTsConfigHandler(
   }
 }
 
-export const resolveTsConfig = memoize(resolveTsConfigHandler)
+export const resolveTsConfig = memoizeByKey(resolveTsConfigHandler)(
+  'tsconfig.json' + process.pid,
+)
 
 export async function convertCompilerOptions(cwd: string, json: any) {
   // Use the original ts handler to avoid memory leak

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -58,9 +58,7 @@ function resolveTsConfigHandler(
   }
 }
 
-export const resolveTsConfig = memoizeByKey(resolveTsConfigHandler)(
-  'tsconfig.json' + process.pid,
-)
+export const resolveTsConfig = memoizeByKey(resolveTsConfigHandler)()
 
 export async function convertCompilerOptions(cwd: string, json: any) {
   // Use the original ts handler to avoid memory leak

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -178,34 +178,6 @@ export const baseNameWithoutExtension = (filename: string): string =>
 export const isTestFile = (filename: string): boolean =>
   /\.(test|spec)$/.test(baseNameWithoutExtension(filename))
 
-type CacheKeyResolver = string | ((...args: any[]) => string)
-
-export const memoize = <T extends (...args: any[]) => any>(
-  fn: T,
-  cacheKey?: CacheKeyResolver, // if you need specify a cache key
-) => {
-  const cache = new Map<string, ReturnType<T>>()
-  return ((...args: Parameters<T>) => {
-    const key = cacheKey
-      ? typeof cacheKey === 'function'
-        ? cacheKey(...args)
-        : cacheKey
-      : JSON.stringify({ args })
-    const existing = cache.get(key)
-    if (existing !== undefined) {
-      return existing
-    }
-    const result = fn(...args)
-    cache.set(key, result)
-    return result
-  }) as T
-}
-
-export const memoizeByKey =
-  <T extends (...args: any[]) => any>(fn: T) =>
-  (cacheKey: CacheKeyResolver) =>
-    memoize(fn, cacheKey)
-
 export function joinRelativePath(...segments: string[]) {
   let result = path.join(...segments)
   // If the first segment starts with '.', ensure the result does too.

--- a/test/unit/memoize.test.ts
+++ b/test/unit/memoize.test.ts
@@ -1,0 +1,22 @@
+import { memoizeByKey } from '../../src/lib/memoize'
+
+describe('memoize', () => {
+  it('should memoize the function by default based on arg', () => {
+    const fn = jest.fn((a: number, b: number) => a + b)
+    const memoized = memoizeByKey(fn)()
+    expect(memoized(1, 2)).toBe(3)
+    expect(memoized(1, 2)).toBe(3)
+    expect(fn).toBeCalledTimes(1)
+    expect(memoized(1, 5)).toBe(6)
+    expect(fn).toBeCalledTimes(2)
+  })
+
+  it('should memoize based on the string key resolver', () => {
+    const fn = jest.fn((a: number, b: number) => a + b)
+    const memoized = memoizeByKey(fn)('key')
+    expect(memoized(1, 2)).toBe(3)
+    expect(memoized(1, 2)).toBe(3)
+    expect(memoized(1, 5)).toBe(3) // still cache since the key is the same
+    expect(fn).toBeCalledTimes(1)
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["./src", "./*.ts", "./*.d.ts"],
+  "include": ["./src", "./*.ts", "./*.d.ts", "test/unit/memoize.test.ts"],
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "./dist",


### PR DESCRIPTION
Fixes cache mismatching caused in #493 

The cache was re-created very time, now we give memoizeByKey a scoped cache that it won't recreate.