### PR TITLE
fix: avoid using dirent.path and add node 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        node-version: [18, 20]
+        node-version: [16, 18, 20]
 
     name: Node ${{ matrix.node-version }}
     steps:

--- a/src/entries.ts
+++ b/src/entries.ts
@@ -265,7 +265,7 @@ export async function collectSourceEntriesByExportPath(
       })
       for (const binDirent of binDirentList) {
         if (binDirent.isFile()) {
-          const binFileAbsolutePath = path.join(binDirent.path, binDirent.name)
+          const binFileAbsolutePath = path.join(absoluteDirPath, binDirent.name)
           if (fs.existsSync(binFileAbsolutePath)) {
             bins.set(normalizeExportPath(originalSubpath), binFileAbsolutePath)
           }
@@ -335,7 +335,7 @@ export async function collectSourceEntriesByExportPath(
         continue
       }
 
-      const sourceFileAbsolutePath = path.join(dirent.path, dirent.name)
+      const sourceFileAbsolutePath = path.join(dirPath, dirent.name)
 
       if (isBinaryPath) {
         bins.set(originalSubpath, sourceFileAbsolutePath)
@@ -450,7 +450,7 @@ export async function collectSourceEntries(sourceFolderPath: string) {
   if (binDirent) {
     if (binDirent.isDirectory()) {
       const binDirentList = await fsp.readdir(
-        path.join(binDirent.path, binDirent.name),
+        path.join(sourceFolderPath, binDirent.name),
         {
           withFileTypes: true,
         },


### PR DESCRIPTION
`dirent.path` is `deprecated` and also not supported in node 16

https://github.com/emilkowalski/vaul/actions/runs/8509833761/job/23306167226?pr=315