### PR TITLE
Fix: types generation for missing types case

### DIFF
--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -1,5 +1,5 @@
 import type { RollupWatcher } from 'rollup'
-import type { BundleConfig } from './types'
+import type { BundleConfig, BundleJobOptions } from './types'
 import fsp from 'fs/promises'
 import fs from 'fs'
 import { resolve } from 'path'
@@ -157,7 +157,7 @@ async function bundle(
   }
 
   const generateTypes = hasTsConfig && options.dts !== false
-  const rollupJobsOptions = { isFromCli, generateTypes }
+  const rollupJobsOptions: BundleJobOptions = { isFromCli, generateTypes }
 
   const assetJobs = await createAssetRollupJobs(
     options,

--- a/src/rollup-job.ts
+++ b/src/rollup-job.ts
@@ -8,24 +8,30 @@ import {
 } from 'rollup'
 
 import { buildEntryConfig } from './build-config'
-import { BuildContext, BuncheeRollupConfig, BundleConfig } from './types'
+import {
+  BuildContext,
+  BuncheeRollupConfig,
+  BundleConfig,
+  BundleJobOptions,
+} from './types'
 import { removeOutputDir } from './utils'
 import { logger } from './logger'
 
 export async function createAssetRollupJobs(
   options: BundleConfig,
   buildContext: BuildContext,
-  {
-    isFromCli,
-    generateTypes,
-  }: {
-    isFromCli: boolean
-    generateTypes: boolean
-  },
+  bundleJobOptions: BundleJobOptions,
 ) {
-  const assetsConfigs = await buildEntryConfig(options, buildContext, false)
+  const { isFromCli, generateTypes } = bundleJobOptions
+  const assetsConfigs = await buildEntryConfig(options, buildContext, {
+    dts: false,
+    isFromCli,
+  })
   const typesConfigs = generateTypes
-    ? await buildEntryConfig(options, buildContext, true)
+    ? await buildEntryConfig(options, buildContext, {
+        dts: true,
+        isFromCli,
+      })
     : []
   const allConfigs = assetsConfigs.concat(typesConfigs)
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,6 +109,16 @@ type BuildContext = {
   }
 }
 
+type BundleJobOptions = {
+  isFromCli: boolean
+  generateTypes: boolean
+}
+
+type bundleEntryOptions = {
+  dts: boolean
+  isFromCli: boolean
+}
+
 export type {
   ExportPaths,
   ExportType,
@@ -123,4 +133,6 @@ export type {
   ParsedExportCondition,
   Entries,
   BuildContext,
+  BundleJobOptions,
+  bundleEntryOptions,
 }

--- a/test/integration/unspecified-types-paths/index.test.ts
+++ b/test/integration/unspecified-types-paths/index.test.ts
@@ -1,0 +1,20 @@
+import fs from 'fs'
+import { assertFilesContent, createIntegrationTest } from '../utils'
+
+describe('integration tsconfig-override', () => {
+  it('should not generate js types paths if not specified', async () => {
+    await createIntegrationTest(
+      {
+        directory: __dirname,
+      },
+      async ({ dir }) => {
+        assertFilesContent(dir, {
+          './dist/subpath/nested.js': 'subpath/nested',
+          './dist/subpath/nested.cjs': 'subpath/nested',
+        })
+        const subpathTypes = await import(`${dir}/dist/index.js`)
+        expect(fs.existsSync(subpathTypes)).toBe(false)
+      },
+    )
+  })
+})

--- a/test/integration/unspecified-types-paths/package.json
+++ b/test/integration/unspecified-types-paths/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "undefined-types-paths",
+  "type": "module",
+  "exports": {
+    "./subpath/nested": {
+      "import": "./dist/subpath/nested.js",
+      "require": "./dist/subpath/nested.cjs"
+    }
+  }
+}

--- a/test/integration/unspecified-types-paths/src/subpath/nested.ts
+++ b/test/integration/unspecified-types-paths/src/subpath/nested.ts
@@ -1,0 +1,1 @@
+export const value = 'subpath/nested'


### PR DESCRIPTION
When there's no types specified in exports, bunchee should not generate a type file

Reported by @dferber90 