### PR TITLE
feat: generate relative imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "typecheck": "tsc --noEmit && tsc -p test/tsconfig.json --noEmit",
     "prepublishOnly": "pnpm clean && pnpm build && chmod +x ./dist/bin/cli.js && pnpm test:ci",
     "tsx": "node -r @swc-node/register",
+    "ts-bunchee": "pnpm tsx ./src/bin/index.ts",
+    "build-dir": "pnpm ts-bunchee --cwd",
     "build": "node -r @swc-node/register ./src/bin/index.ts --runtime node",
     "format": "prettier --write .",
     "prepare": "husky"

--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -236,7 +236,6 @@ async function buildInputConfig(
   const aliasPlugin = aliasEntries({
     entry,
     entries,
-    entriesAlias: pluginContext.entriesAlias,
     format: aliasFormat,
     dts,
     cwd,

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -4,7 +4,6 @@ import fsp from 'fs/promises'
 import fs from 'fs'
 import { resolve } from 'path'
 import { performance } from 'perf_hooks'
-import { getReversedAlias } from './build-config'
 import {
   createOutputState,
   logOutputState,
@@ -142,7 +141,6 @@ async function bundle(
   }
 
   const sizeCollector = createOutputState({ entries })
-  const entriesAlias = getReversedAlias({ entries, name: pkg.name })
   const buildContext: BuildContext = {
     entries,
     pkg,
@@ -152,7 +150,6 @@ async function bundle(
     pluginContext: {
       outputState: sizeCollector,
       moduleDirectiveLayerMap: new Map(),
-      entriesAlias,
     },
   }
 

--- a/src/plugins/alias-plugin.ts
+++ b/src/plugins/alias-plugin.ts
@@ -8,46 +8,40 @@ import { relativify } from '../lib/format'
 // For a resolved file, if it's one of the entries,
 // aliases it as export path, such as <absolute file> -> <pkg>/<export path>
 export function aliasEntries({
-  entry,
+  entry: sourceFilePath,
   entries,
-  entriesAlias,
   format,
   dts,
   cwd,
 }: {
   entry: string
   entries: Entries
-  entriesAlias: Record<string, string>
   format: OutputOptions['format']
   dts: boolean
   cwd: string
 }): Plugin {
-  const entryAliasWithoutSelf = {
-    ...entriesAlias,
-    [entry]: null,
-  }
   const pathToRelativeDistMap = new Map<string, string>()
   for (const [, exportCondition] of Object.entries(entries)) {
     const exportDistMaps = exportCondition.export
+    const exportMapEntries = Object.entries(exportDistMaps)
 
-    if (dts) {
-      // Search types + [format] condition from entries map
-      // e.g. import.types, require.types
-      const typeCond = Object.entries(exportDistMaps).find(
-        ([composedKey, cond]) => {
-          const typesSet = new Set(composedKey.split('.'))
-          const formatCond = format === 'cjs' ? 'require' : 'import'
-          const isMatchedCond =
-            typesSet.has(formatCond) ||
-            (!typesSet.has('import') && !typesSet.has('require'))
+    const matchedBundlePath = exportMapEntries.find(([composedKey, cond]) => {
+      const hasCondition = cond != null
+      const conditionNames = new Set(composedKey.split('.'))
+      const formatCond = format === 'cjs' ? 'require' : 'import'
+      const isTypesCondName = conditionNames.has('types')
 
-          return typesSet.has('types') && isMatchedCond && cond != null
-        },
-      )?.[1]
-
-      if (typeCond) {
-        pathToRelativeDistMap.set(exportCondition.source, typeCond)
+      if (dts) {
+        return isTypesCondName && hasCondition
+      } else {
+        const isMatchedFormat = conditionNames.has(formatCond)
+        return isMatchedFormat && !isTypesCondName && hasCondition
       }
+    })?.[1]
+
+    if (matchedBundlePath) {
+      if (!pathToRelativeDistMap.has(exportCondition.source))
+        pathToRelativeDistMap.set(exportCondition.source, matchedBundlePath)
     }
   }
 
@@ -58,28 +52,26 @@ export function aliasEntries({
         const resolved = await this.resolve(source, importer, options)
 
         if (resolved != null) {
-          if (dts) {
-            // For types, generate relative path to the other type files,
-            // this will be compatible for the node10 ts module resolution.
-            const resolvedDist = pathToRelativeDistMap.get(resolved.id)
-            const entryDist = pathToRelativeDistMap.get(entry)
-            if (resolved.id !== entry && entryDist && resolvedDist) {
-              const absoluteEntryDist = path.resolve(cwd, entryDist)
-              const absoluteResolvedDist = path.resolve(cwd, resolvedDist)
+          // For types, generate relative path to the other type files,
+          // this will be compatible for the node10 ts module resolution.
+          const srcBundlePath = pathToRelativeDistMap.get(sourceFilePath)
+          // Resolved module bundle path
+          const importBundlePath = pathToRelativeDistMap.get(resolved.id)
+          // console.log('pathToRelativeDistMap', 'entry', basename( sourceFilePath), 'entryDist', relativeBundlePath, 'resolved.id', resolved.id)
+          if (
+            resolved.id !== sourceFilePath &&
+            srcBundlePath &&
+            importBundlePath
+          ) {
+            const absoluteBundlePath = path.resolve(cwd, srcBundlePath)
+            const absoluteImportBundlePath = path.resolve(cwd, importBundlePath)
 
-              const filePathBase = path.relative(
-                path.dirname(absoluteEntryDist),
-                absoluteResolvedDist,
-              )!
-              const relativePath = relativify(filePathBase)
-              return { id: relativePath, external: true }
-            }
-          } else {
-            const aliasedId = entryAliasWithoutSelf[resolved.id]
-
-            if (aliasedId != null) {
-              return { id: aliasedId }
-            }
+            const filePathBase = path.relative(
+              path.dirname(absoluteBundlePath),
+              absoluteImportBundlePath,
+            )!
+            const relativePath = relativify(filePathBase)
+            return { id: relativePath, external: true }
           }
         }
         return null

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,7 +105,6 @@ type BuildContext = {
   pluginContext: {
     outputState: OutputState
     moduleDirectiveLayerMap: Map<string, Set<[string, string]>>
-    entriesAlias: Record<string, string>
   }
 }
 

--- a/test/integration/multi-entries/package.json
+++ b/test/integration/multi-entries/package.json
@@ -12,6 +12,7 @@
       "import": "./dist/client/index.mjs"
     },
     "./shared": {
+      "types": "./dist/shared/index.d.ts",
       "import": "./dist/shared/index.mjs",
       "require": "./dist/shared/index.cjs",
       "edge-light": "./dist/shared/edge-light.mjs"

--- a/test/integration/multi-exports-ts/index.test.ts
+++ b/test/integration/multi-exports-ts/index.test.ts
@@ -6,9 +6,9 @@ describe('integration multi-exports', () => {
   })
   it('should work with multi exports condition', async () => {
     await assertFilesContent(dir, {
-      './dist/cjs/index.js': `var foo = require('multi-exports-ts/foo')`,
+      './dist/cjs/index.js': `= require('../../foo/cjs/index.js')`,
       './dist/cjs/index.d.cts': `import { Foo } from '../../foo/cjs/index.cjs'`,
-      './dist/es/index.mjs': `import { foo } from 'multi-exports-ts/foo'`,
+      './dist/es/index.mjs': `import { foo } from '../../foo/es/index.mjs'`,
       './dist/es/index.d.mts': `import { Foo } from '../../foo/es/index.mjs'`,
       './foo/cjs/index.js': `exports.foo = foo`,
       './foo/cjs/index.d.cts': `export { type Foo, foo }`,

--- a/test/integration/pkg-exports-ts-rsc/index.test.ts
+++ b/test/integration/pkg-exports-ts-rsc/index.test.ts
@@ -12,7 +12,7 @@ describe('integration pkg-exports-ts-rsc', () => {
           './react-server.mjs': /'react-server'/,
           './react-native.js': /'react-native'/,
           './index.d.ts': /declare const shared = true/,
-          './api.mjs': /\'pkg-export-ts-rsc\'/,
+          './api.mjs': `'./index.mjs'`,
         })
       },
     )

--- a/test/integration/shared-entry/index.test.ts
+++ b/test/integration/shared-entry/index.test.ts
@@ -22,7 +22,7 @@ describe('integration shared-entry', () => {
           join(dir, './dist/index.mjs'),
           'utf-8',
         )
-        expect(indexEsm).toContain('shared-entry/shared')
+        expect(indexEsm).toContain(`'./shared.mjs'`)
         expect(indexEsm).toContain('index-export')
         expect(indexEsm).not.toMatch(/['"]\.\/shared['"]/)
         expect(indexEsm).not.toContain('shared-export')
@@ -32,7 +32,7 @@ describe('integration shared-entry', () => {
           join(dir, './dist/index.js'),
           'utf-8',
         )
-        expect(indexCjs).toContain('shared-entry/shared')
+        expect(indexCjs).toContain(`require('./shared.js')`)
         expect(indexCjs).toContain('index-export')
         expect(indexCjs).not.toMatch(/['"]\.\/shared['"]/)
 


### PR DESCRIPTION
This will PR generates the relative paths relationship for the JS bundles. 

For instance, for the 2 exports which one is relying on the other one, and `./foo` is dependent on `./`, project name is "my-lib":
```
- src/
  |- index.ts
  |- foo.ts
```

Bunchee will output the below structure and use `"<project name>/<export path>"` as dependency for each bundle to import the other export bundles. e.g. foo.js will import from `"my-lib"` as it's the `./` export.
```
- dist/
  |- index.js
  |- foo.js
```

This output is not ideal cause it might resolve the 2nd module resolving. And some bundler might error (e.g. vite).

After this PR, the output the relative path for all imports and there's no extra module resolving. And we did some smart resolution which also based on the output format, to make sure CJS is only requiring other CJS bundles and ESM can resolve other ESM bundles.

Resolves #511

