### PR TITLE
fix: special shouldnt override default condition

### DIFF
--- a/src/entries.ts
+++ b/src/entries.ts
@@ -113,6 +113,22 @@ export async function collectEntriesFromParsedExports(
         matchedExportType === entryExportPathType ||
         (!hasSpecialEntry && matchedExportType !== 'default')
       ) {
+        // When we dealing with special export conditions, we need to make sure
+        // the outputs won't override the default export output paths.
+        // e.g. We have './index' -> { default: 'index.js', development: 'index.development.js' };
+        // When we generate './index.react-server' -> { 'react-server': 'index.react-server.js' },
+        // Normalize the entryExportPath to './index' first and check if it already exists with output paths.
+        const normalizedEntryExportPath = stripSpecialCondition(entryExportPath)
+        if (
+          // The entry already exists, e.g. normalize './index.react-server' to './index'
+          entries[normalizedEntryExportPath] &&
+          // Is special export condition
+          entryExportPathType !== 'default' &&
+          // The extracted special condition is not the current loop one.
+          entryExportPathType !== matchedExportType
+        ) {
+          continue
+        }
         const exportMap = entries[entryExportPath].export
         exportMap[outputComposedExportType] = outputPath
       }

--- a/test/integration/dev-prod-special-convention/index.test.ts
+++ b/test/integration/dev-prod-special-convention/index.test.ts
@@ -1,0 +1,23 @@
+import { createIntegrationTest, assertFilesContent } from '../utils'
+
+describe('integration dev-prod-special-convention', () => {
+  it('should work with dev prod and special optimize conditions', async () => {
+    await createIntegrationTest(
+      {
+        directory: __dirname,
+      },
+      async ({ distDir }) => {
+        await assertFilesContent(distDir, {
+          'index.react-server.mjs': 'index.react-server',
+          'index.development.js': /'index.default'/,
+          'index.development.mjs': /'index.default'/,
+          'index.production.js': /'index.default'/,
+          'index.production.mjs': /'index.default'/,
+          // In jest the NODE_ENV is set to test
+          'index.js': /'index.default'/,
+          'index.mjs': /'index.default'/,
+        })
+      },
+    )
+  })
+})

--- a/test/integration/dev-prod-special-convention/package.json
+++ b/test/integration/dev-prod-special-convention/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "dev-prod-special-convention",
+  "exports": {
+    ".": {
+      "react-server": "./dist/index.react-server.mjs",
+      "import": {
+        "production": "./dist/index.production.mjs",
+        "development": "./dist/index.development.mjs",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "production": "./dist/index.production.js",
+        "development": "./dist/index.development.js",
+        "default": "./dist/index.js"
+      },
+      "default": "./dist/index.js"
+    }
+  }
+}

--- a/test/integration/dev-prod-special-convention/src/index.react-server.ts
+++ b/test/integration/dev-prod-special-convention/src/index.react-server.ts
@@ -1,0 +1,1 @@
+export const value = 'index.react-server'

--- a/test/integration/dev-prod-special-convention/src/index.ts
+++ b/test/integration/dev-prod-special-convention/src/index.ts
@@ -1,0 +1,1 @@
+export const value = 'index.default'


### PR DESCRIPTION
When the existing default condition will generate the output, don't override the condition

Fixes #541 