### PR TITLE
Fix conditional export bundle mapping

### DIFF
--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -233,10 +233,12 @@ async function buildInputConfig(
       : 'esm'
     : bundleConfig.format
 
+  const currentConditionNames = Object.keys(exportCondition.export)[0]
   const aliasPlugin = aliasEntries({
     entry,
     entries,
     format: aliasFormat,
+    conditionNames: new Set(currentConditionNames.split('.')),
     dts,
     cwd,
   })

--- a/src/entries.ts
+++ b/src/entries.ts
@@ -238,6 +238,20 @@ function getExportTypeFromExportTypesArray(types: string[]): string {
   return exportType
 }
 
+export function getSpecialExportTypeFromConditionNames(
+  conditionNames: Set<string>,
+): string {
+  let exportType = 'default'
+  conditionNames.forEach((value) => {
+    if (specialExportConventions.has(value)) {
+      exportType = value
+    } else if (value === 'import' || value === 'require' || value === 'types') {
+      // exportType = value
+    }
+  })
+  return exportType
+}
+
 // ./index -> .
 // ./index.development -> .
 // ./index.react-server -> .

--- a/test/integration/dev-prod-convention-reexport/index.test.ts
+++ b/test/integration/dev-prod-convention-reexport/index.test.ts
@@ -1,0 +1,22 @@
+import { createIntegrationTest, assertFilesContent } from '../utils'
+
+describe('integration dev-prod-convention-reexport', () => {
+  it('should work with dev and prod optimize conditions', async () => {
+    await createIntegrationTest(
+      {
+        directory: __dirname,
+      },
+      async ({ distDir }) => {
+        await assertFilesContent(distDir, {
+          // index export
+          'index.dev.js': /core.dev.js/,
+          'index.dev.mjs': /core.dev.mjs/,
+          'index.prod.js': /core.prod.js/,
+          'index.prod.mjs': /core.prod.mjs/,
+          'index.js': /core.js/,
+          'index.mjs': /core.mjs/,
+        })
+      },
+    )
+  })
+})

--- a/test/integration/dev-prod-convention-reexport/package.json
+++ b/test/integration/dev-prod-convention-reexport/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "dev-prod-nested-convention",
+  "exports": {
+    ".": {
+      "import": {
+        "development": "./dist/index.dev.mjs",
+        "production": "./dist/index.prod.mjs",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "production": "./dist/index.prod.js",
+        "development": "./dist/index.dev.js",
+        "default": "./dist/index.js"
+      }
+    },
+    "./core": {
+      "import": {
+        "development": "./dist/core.dev.mjs",
+        "production": "./dist/core.prod.mjs",
+        "default": "./dist/core.mjs"
+      },
+      "require": {
+        "production": "./dist/core.prod.js",
+        "development": "./dist/core.dev.js",
+        "default": "./dist/core.js"
+      }
+    }
+  }
+}

--- a/test/integration/dev-prod-convention-reexport/src/core.ts
+++ b/test/integration/dev-prod-convention-reexport/src/core.ts
@@ -1,0 +1,2 @@
+export const value = 'core.cond'
+export const env = process.env.NODE_ENV

--- a/test/integration/dev-prod-convention-reexport/src/index.ts
+++ b/test/integration/dev-prod-convention-reexport/src/index.ts
@@ -1,0 +1,2 @@
+export * from './core'
+export const value = 'index'


### PR DESCRIPTION
### Problem

`development` condition is declared first, then it's always get picked

### Fix

We should pass down the current condition names of entry to alias plugin, to let it decide which condition shall we alias.

- If there's special condition matched in other exports, prefer those ones;
- If there's no special condition matched, fallback to default if there's no other conditon (import/require) based on bundle type (cjs or esm);


Fixes #548 