### PR TITLE
fix: index-index nested output and logging

### DIFF
--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -197,6 +197,7 @@ async function run(args: CliArgs) {
     if (watch) {
       logWatcherBuildTime(assetJobs, spinner)
     } else {
+      stopSpinner()
       if (assetJobs.length === 0) {
         logger.warn(
           'The "src" directory does not contain any entry files. ' +

--- a/src/entries.ts
+++ b/src/entries.ts
@@ -338,7 +338,6 @@ export async function collectSourceEntriesByExportPath(
           const exportType = getExportTypeFromExportPath(exportPath)
           sourceFilesMap[exportType] = indexAbsoluteFile
           exportsEntries.set(exportPath, sourceFilesMap)
-          break
         }
       }
     }

--- a/test/integration/entry-index-index/index.test.ts
+++ b/test/integration/entry-index-index/index.test.ts
@@ -8,10 +8,12 @@ describe('integration entry-index-index', () => {
       },
       async ({ distDir }) => {
         await assertFilesContent(distDir, {
-          'index.js': /'index'/,
+          'default.js': /'index'/,
           'react-server.js': /\'react-server\'/,
         })
       },
     )
   })
 })
+
+// TODO: fix output log

--- a/test/integration/entry-index-index/index.test.ts
+++ b/test/integration/entry-index-index/index.test.ts
@@ -6,14 +6,15 @@ describe('integration entry-index-index', () => {
       {
         directory: __dirname,
       },
-      async ({ distDir }) => {
+      async ({ distDir, stdout }) => {
         await assertFilesContent(distDir, {
           'default.js': /'index'/,
           'react-server.js': /\'react-server\'/,
         })
+
+        expect(stdout).toContain('dist/react-server.js')
+        expect(stdout).toContain('dist/default.js')
       },
     )
   })
 })
-
-// TODO: fix output log

--- a/test/integration/entry-index-index/package.json
+++ b/test/integration/entry-index-index/package.json
@@ -2,6 +2,6 @@
   "name": "entry-index-index",
   "exports": {
     "react-server": "./dist/react-server.js",
-    "default": "./dist/index.js"
+    "default": "./dist/default.js"
   }
 }


### PR DESCRIPTION
* If it's index/index, build should still work
* logging was omitted in build by spinner