### PR TITLE
fix: require detection of esm-shims plugin

### DIFF
--- a/src/plugins/esm-shim.ts
+++ b/src/plugins/esm-shim.ts
@@ -5,7 +5,8 @@ import MagicString from 'magic-string'
 
 const FILENAME_REGEX = /__filename/
 const DIRNAME_REGEX = /__dirname/
-const GLOBAL_REQUIRE_REGEX = /require(\.resolve)?\(/
+// not char, or space before require(.resolve)?(
+const GLOBAL_REQUIRE_REGEX = /[\W\s]require(\.resolve)?\(/
 
 const PolyfillComment = '/** rollup-private-do-not-use-esm-shim-polyfill */'
 const createESMShim = ({

--- a/test/integration/esm-shims/index.test.ts
+++ b/test/integration/esm-shims/index.test.ts
@@ -18,9 +18,11 @@ describe('integration esm-shims', () => {
           'require.mjs': requirePolyfill,
           'filename.mjs': filenamePolyfill,
           'dirname.mjs': dirnamePolyfill,
+          'custom-require.mjs': (code) => !code.includes(requirePolyfill),
           'require.js': /require\(/,
           'filename.js': /__filename/,
           'dirname.js': /__dirname/,
+          'custom-require.js': (code) => !code.includes(requirePolyfill),
         })
       },
     )

--- a/test/integration/esm-shims/package.json
+++ b/test/integration/esm-shims/package.json
@@ -11,6 +11,10 @@
     "./filename": {
       "import": "./dist/filename.mjs",
       "require": "./dist/filename.js"
+    },
+    "./custom-require": {
+      "import": "./dist/custom-require.mjs",
+      "require": "./dist/custom-require.js"
     }
   }
 }

--- a/test/integration/esm-shims/src/custom-require.js
+++ b/test/integration/esm-shims/src/custom-require.js
@@ -1,0 +1,11 @@
+const __getOwnPropNames = Object.getOwnPropertyNames
+var __commonJS = (cb, mod) =>
+  function __require() {
+    return (
+      mod ||
+        (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod),
+      mod.exports
+    )
+  }
+
+export const a = 1


### PR DESCRIPTION
If it's customized require calls, it should need the global nodejs polyfill for esm-shim

Fixes #564 