### PR TITLE
Fix shared chunk type file extension

### DIFF
--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -482,8 +482,11 @@ async function buildOutputConfigs(
       entryFiles,
     ),
     chunkFileNames() {
-      const ext =
-        format === 'cjs' && outputFileExtension === '.cjs' ? 'cjs' : 'js'
+      const ext = dts
+        ? 'd.ts'
+        : format === 'cjs' && outputFileExtension === '.cjs'
+        ? 'cjs'
+        : 'js'
       return '[name]-[hash].' + ext
     },
     // By default in rollup, when creating multiple chunks, transitive imports of entry chunks

--- a/test/integration/shared-module-ts/index.test.ts
+++ b/test/integration/shared-module-ts/index.test.ts
@@ -12,12 +12,12 @@ describe('integration shared-module-ts', () => {
         const files = await fsp.readdir(distDir)
         const sharedUtilModuleFile = files.find((file) =>
           /util-shared-\w+\.d\.ts/.test(file),
-        )
+        )!
         const appContextSharedFile = files.find((file) =>
           /app-context-shared-\w+\.d\.ts/.test(file),
-        )
+        )!
 
-        const indexType = files.find((file) => file === 'index.d.ts')
+        const indexType = files.find((file) => file === 'index.d.ts')!
         const indexFileContent = readFileSync(
           path.join(distDir, indexType),
           'utf-8',

--- a/test/integration/shared-module-ts/index.test.ts
+++ b/test/integration/shared-module-ts/index.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync, promises as fsp } from 'fs'
+import { createIntegrationTest } from '../utils'
+import path from 'path'
+
+describe('integration shared-module-ts', () => {
+  it('should contain correct type file path of shared chunks', async () => {
+    await createIntegrationTest(
+      {
+        directory: __dirname,
+      },
+      async ({ distDir }) => {
+        const files = await fsp.readdir(distDir)
+        const sharedUtilModuleFile = files.find((file) =>
+          /util-shared-\w+\.d\.ts/.test(file),
+        )
+        const appContextSharedFile = files.find((file) =>
+          /app-context-shared-\w+\.d\.ts/.test(file),
+        )
+
+        const indexType = files.find((file) => file === 'index.d.ts')
+        const indexFileContent = readFileSync(
+          path.join(distDir, indexType),
+          'utf-8',
+        )
+
+        expect(indexFileContent).toContain(
+          sharedUtilModuleFile.replace('.d.ts', '.js'),
+        )
+        expect(indexFileContent).toContain(
+          appContextSharedFile.replace('.d.ts', '.js'),
+        )
+      },
+    )
+  })
+})

--- a/test/integration/shared-module-ts/package.json
+++ b/test/integration/shared-module-ts/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "shared-module",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "react-server": "./dist/index.react-server.js",
+      "import": "./dist/index.js",
+      "default": "./dist/index.cjs"
+    },
+    "./another": {
+      "types": "./dist/another.d.ts",
+      "import": "./dist/another.js",
+      "default": "./dist/another.cjs"
+    }
+  },
+  "dependencies": {
+    "react": "*"
+  }
+}

--- a/test/integration/shared-module-ts/src/another.ts
+++ b/test/integration/shared-module-ts/src/another.ts
@@ -1,0 +1,1 @@
+export { sharedApi as anotherSharedApi } from './lib/util.shared-runtime'

--- a/test/integration/shared-module-ts/src/index.react-server.ts
+++ b/test/integration/shared-module-ts/src/index.react-server.ts
@@ -1,0 +1,1 @@
+export { AppContext } from './lib/app-context.shared-runtime'

--- a/test/integration/shared-module-ts/src/index.ts
+++ b/test/integration/shared-module-ts/src/index.ts
@@ -1,0 +1,3 @@
+export const index = 'index'
+export { sharedApi } from './lib/util.shared-runtime'
+export { AppContext } from './lib/app-context.shared-runtime'

--- a/test/integration/shared-module-ts/src/lib/app-context.shared-runtime.ts
+++ b/test/integration/shared-module-ts/src/lib/app-context.shared-runtime.ts
@@ -1,0 +1,5 @@
+'use client'
+
+import React from 'react'
+
+export const AppContext = React.createContext(null)

--- a/test/integration/shared-module-ts/src/lib/util.shared-runtime.ts
+++ b/test/integration/shared-module-ts/src/lib/util.shared-runtime.ts
@@ -1,0 +1,3 @@
+export function sharedApi() {
+  return 'common:shared'
+}


### PR DESCRIPTION
When it's running dts job, change the extension of `chunkFileNames` to `d.ts`

Fixes #547 