### PR TITLE
Fix shared chunk extension along with parent chunk

### DIFF
--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -444,6 +444,7 @@ async function buildOutputConfigs(
   const useEsModuleMark = tsCompilerOptions?.esModuleInterop // hasEsmExport(exportPaths, tsCompilerOptions)
   const absoluteOutputFile = resolve(cwd, bundleConfig.file!)
   const outputFileExtension = extname(absoluteOutputFile)
+  const isEsmPkg = isESModulePackage(pkg.type)
   const name = filePathWithoutExtension(absoluteOutputFile)
   const dtsFile = resolve(
     cwd,
@@ -482,10 +483,13 @@ async function buildOutputConfigs(
       entryFiles,
     ),
     chunkFileNames() {
+      const isCjsFormat = format === 'cjs'
       const ext = dts
         ? 'd.ts'
-        : format === 'cjs' && outputFileExtension === '.cjs'
+        : isCjsFormat && isEsmPkg
         ? 'cjs'
+        : !isCjsFormat && !isEsmPkg
+        ? 'mjs'
         : 'js'
       return '[name]-[hash].' + ext
     },

--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -15,7 +15,7 @@ import type {
 } from 'rollup'
 import { convertCompilerOptions } from './typescript'
 
-import path, { resolve, dirname, join, basename, extname } from 'path'
+import path, { resolve, dirname, join, basename } from 'path'
 import { wasm } from '@rollup/plugin-wasm'
 import { swc } from 'rollup-plugin-swc3'
 import commonjs from '@rollup/plugin-commonjs'
@@ -443,7 +443,6 @@ async function buildOutputConfigs(
   // Add esm mark and interop helper if esm export is detected
   const useEsModuleMark = tsCompilerOptions?.esModuleInterop // hasEsmExport(exportPaths, tsCompilerOptions)
   const absoluteOutputFile = resolve(cwd, bundleConfig.file!)
-  const outputFileExtension = extname(absoluteOutputFile)
   const isEsmPkg = isESModulePackage(pkg.type)
   const name = filePathWithoutExtension(absoluteOutputFile)
   const dtsFile = resolve(

--- a/test/compile/use-client/__snapshot__/use-client.js.snapshot
+++ b/test/compile/use-client/__snapshot__/use-client.js.snapshot
@@ -1,5 +1,5 @@
 'use strict';
-import { c as client } from './client-client-Cm06vGwQ.js';
+import { c as client } from './client-client-Cm06vGwQ.mjs';
 
 var input = (()=>{
     return client();

--- a/test/compile/use-client/__snapshot__/use-client.min.js.snapshot
+++ b/test/compile/use-client/__snapshot__/use-client.min.js.snapshot
@@ -1,1 +1,1 @@
-"use strict";import{c as t}from"./client-client-B-RDfYre.js";var e=()=>t();export{e as default};
+"use strict";import{c as t}from"./client-client-B-RDfYre.mjs";var e=()=>t();export{e as default};

--- a/test/integration/shared-module-ts-esm/index.test.ts
+++ b/test/integration/shared-module-ts-esm/index.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync, promises as fsp } from 'fs'
+import { createIntegrationTest } from '../utils'
+import path from 'path'
+
+describe('integration shared-module-ts-esm', () => {
+  it('should contain correct type file path of shared chunks', async () => {
+    await createIntegrationTest(
+      {
+        directory: __dirname,
+      },
+      async ({ distDir }) => {
+        const cjsFiles = await fsp.readdir(path.join(distDir, 'cjs'))
+        const esmFiles = await fsp.readdir(path.join(distDir, 'es'))
+
+        expect(cjsFiles).toEqual(
+          expect.arrayContaining([
+            expect.stringMatching(/util-shared-\w+\.js/),
+          ]),
+        )
+
+        expect(esmFiles).toEqual(
+          expect.arrayContaining([
+            expect.stringMatching(/util-shared-\w+\.mjs/),
+          ]),
+        )
+      },
+    )
+  })
+})

--- a/test/integration/shared-module-ts-esm/index.test.ts
+++ b/test/integration/shared-module-ts-esm/index.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync, promises as fsp } from 'fs'
+import { promises as fsp } from 'fs'
 import { createIntegrationTest } from '../utils'
 import path from 'path'
 

--- a/test/integration/shared-module-ts-esm/package.json
+++ b/test/integration/shared-module-ts-esm/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "shared-module-ts-esm",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/es/index.d.mts",
+        "default": "./dist/es/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
+    }
+  },
+  "dependencies": {
+    "react": "*"
+  }
+}

--- a/test/integration/shared-module-ts-esm/src/index.ts
+++ b/test/integration/shared-module-ts-esm/src/index.ts
@@ -1,0 +1,2 @@
+export const index = 'index'
+export { sharedApi } from './lib/util.shared-runtime'

--- a/test/integration/shared-module-ts-esm/src/lib/util.shared-runtime.ts
+++ b/test/integration/shared-module-ts-esm/src/lib/util.shared-runtime.ts
@@ -1,0 +1,3 @@
+export function sharedApi() {
+  return 'common:shared'
+}

--- a/test/integration/shared-module-ts/package.json
+++ b/test/integration/shared-module-ts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "shared-module",
+  "name": "shared-module-ts",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
When output shared chunk file: 

- if it's ESM package and CJS chunk, use `.cjs` extension
- if it's CJS package and ESM chunk, use `.mjs` extension
- otherwise just use '.js' extension

Fixes #557