### PR TITLE
feat(dts): support bundle dts

### DIFF
--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -67,6 +67,7 @@ function parseCliArgs(argv: string[]) {
       '--no-clean': Boolean,
       '--prepare': Boolean,
       '--tsconfig': String,
+      '--dts-bundle': Boolean,
 
       '-h': '--help',
       '-v': '--version',
@@ -90,6 +91,7 @@ function parseCliArgs(argv: string[]) {
     sourcemap: !!args['--sourcemap'],
     cwd: args['--cwd'],
     dts: args['--no-dts'] ? false : undefined,
+    dtsBundle: args['--dts-bundle'],
     help: args['--help'],
     version: args['--version'],
     runtime: args['--runtime'],
@@ -118,6 +120,7 @@ async function run(args: CliArgs) {
     target,
     runtime,
     dts,
+    dtsBundle,
     env,
     clean,
     tsconfig,
@@ -125,7 +128,7 @@ async function run(args: CliArgs) {
   const cwd = args.cwd || process.cwd()
   const file = args.file ? path.resolve(cwd, args.file) : undefined
   const bundleConfig: BundleConfig = {
-    dts,
+    dts: dts !== false && { respectExternal: dtsBundle ? true : undefined },
     file,
     format,
     cwd,

--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -69,6 +69,7 @@ const swcMinifyOptions = {
 async function createDtsPlugin(
   tsCompilerOptions: BuildContext['tsOptions']['tsCompilerOptions'],
   tsConfigPath: string | undefined,
+  respectExternal: boolean | undefined,
   cwd: string,
 ) {
   const enableIncrementalWithoutBuildInfo =
@@ -114,6 +115,7 @@ async function createDtsPlugin(
   ).default({
     tsconfig: tsConfigPath,
     compilerOptions: overrideResolvedTsOptions,
+    respectExternal,
   })
 
   return dtsPlugin
@@ -262,6 +264,7 @@ async function buildInputConfig(
     const dtsPlugin = await memoizeDtsPluginByKey(uniqueProcessId)(
       tsCompilerOptions,
       tsConfigPath,
+      bundleConfig.dts && bundleConfig.dts.respectExternal,
       cwd,
     )
     typesPlugins.push(dtsPlugin)

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,7 +38,7 @@ type BundleConfig = {
   sourcemap?: boolean
   external?: string[] | null
   env?: string[]
-  dts?: boolean
+  dts?: { respectExternal?: boolean } | false
   runtime?: string
   pkg?: PackageMetadata
   clean?: boolean
@@ -93,6 +93,7 @@ type CliArgs = {
   env?: string
   external?: string
   dts?: false
+  dtsBundle?: boolean
   runtime?: string
   prepare?: boolean
   clean?: boolean

--- a/test/cli/dts-bundle/base.ts
+++ b/test/cli/dts-bundle/base.ts
@@ -1,0 +1,5 @@
+import { ParserConfig } from '@swc/types'
+
+export const createParser = (options: ParserConfig) => {
+  // noop
+}

--- a/test/cli/dts-bundle/index.test.ts
+++ b/test/cli/dts-bundle/index.test.ts
@@ -1,0 +1,71 @@
+import fs from 'fs'
+import fsp from 'fs/promises'
+import { join } from 'path'
+import { createCliTest } from '../utils'
+import { deleteFile } from '../../testing-utils'
+
+describe('cli', () => {
+  const dir = __dirname
+  beforeAll(async () => {
+    await fsp.writeFile(
+      join(dir, './package.json'),
+      '{ "name": "prepare-ts-with-pkg-json", "devDependencies": { "@swc/types": "*" } }',
+    )
+  })
+  afterAll(async () => {
+    await deleteFile(join(dir, './package.json'))
+  })
+
+  it(`cli dts-bundle option should work properly`, async () => {
+    await createCliTest(
+      {
+        directory: __dirname,
+        args: ['./base.ts', '-o', 'dist/base.js', '--dts-bundle'],
+      },
+      ({ code, distFile }) => {
+        const typeFile = distFile.replace('.js', '.d.ts')
+        expect(fs.existsSync(typeFile)).toBe(true)
+        expect(fs.readFileSync(typeFile, 'utf-8')).toContain(
+          'type ParserConfig =',
+        )
+        expect(code).toBe(0)
+      },
+    )
+  })
+  it(`cli dts-bundle option should not bundle dts without dts-bundle`, async () => {
+    await createCliTest(
+      {
+        directory: __dirname,
+        args: ['./base.ts', '-o', 'dist/base.js'],
+      },
+      ({ code, distFile }) => {
+        const typeFile = distFile.replace('.js', '.d.ts')
+        expect(fs.existsSync(typeFile)).toBe(true)
+        expect(fs.readFileSync(typeFile, 'utf-8')).toContain(
+          "from '@swc/types';",
+        )
+        expect(code).toBe(0)
+      },
+    )
+  })
+  it(`cli dts-bundle option should not bundle dts from dependencies`, async () => {
+    await fsp.writeFile(
+      join(dir, './package.json'),
+      '{ "name": "prepare-ts-with-pkg-json", "dependencies": { "@swc/types": "*" } }',
+    )
+    await createCliTest(
+      {
+        directory: __dirname,
+        args: ['./base.ts', '-o', 'dist/base.js'],
+      },
+      ({ code, distFile }) => {
+        const typeFile = distFile.replace('.js', '.d.ts')
+        expect(fs.existsSync(typeFile)).toBe(true)
+        expect(fs.readFileSync(typeFile, 'utf-8')).toContain(
+          "from '@swc/types';",
+        )
+        expect(code).toBe(0)
+      },
+    )
+  })
+})


### PR DESCRIPTION
Fix #560 

Added a CLI flag `--dts-bundle` that will enable `rollup-plugin-dts`'s `respectExternal` option.