### PR TITLE
fix: support more special fields of target runtime

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,10 +16,28 @@ export const nodeResolveExtensions = [
   '.node',
   '.jsx',
 ]
+// You can find the list of runtime keys here:
+//  https://runtime-keys.proposal.wintercg.org/
 export const runtimeExportConventions = new Set([
+  'azion',
+  'lagon',
+  'moddable',
+  'netlify',
+  'electron',
+  'fastly',
+  'kiesel',
+  'wasmer',
   'react-server',
+  'edge-routine',
   'react-native',
   'edge-light',
+  'node',
+  'deno',
+  'bun',
+  'workerd',
+  // This is not official, but it's used in the vite
+  //  Refs: https://vitejs.dev/config/shared-options#resolve-conditions
+  'browser',
 ])
 export const optimizeConventions = new Set(['development', 'production'])
 export const specialExportConventions = new Set([

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,8 +27,8 @@ export const runtimeExportConventions = new Set([
   'deno',
   'bun',
   'workerd',
-  // This is not official, but it's used in the vite
-  // x-ref: https://vitejs.dev/config/shared-options#resolve-conditions
+
+  // Browser only
   'browser',
 ])
 export const optimizeConventions = new Set(['development', 'production'])

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,18 +17,10 @@ export const nodeResolveExtensions = [
   '.jsx',
 ]
 // You can find the list of runtime keys here:
-//  https://runtime-keys.proposal.wintercg.org/
+// https://runtime-keys.proposal.wintercg.org/
 export const runtimeExportConventions = new Set([
-  'azion',
-  'lagon',
-  'moddable',
-  'netlify',
   'electron',
-  'fastly',
-  'kiesel',
-  'wasmer',
   'react-server',
-  'edge-routine',
   'react-native',
   'edge-light',
   'node',
@@ -36,7 +28,7 @@ export const runtimeExportConventions = new Set([
   'bun',
   'workerd',
   // This is not official, but it's used in the vite
-  //  Refs: https://vitejs.dev/config/shared-options#resolve-conditions
+  // x-ref: https://vitejs.dev/config/shared-options#resolve-conditions
   'browser',
 ])
 export const optimizeConventions = new Set(['development', 'production'])

--- a/test/integration/ts-exports-multiple-conditions/index.test.ts
+++ b/test/integration/ts-exports-multiple-conditions/index.test.ts
@@ -1,0 +1,42 @@
+import {
+  assertContainFiles,
+  createIntegrationTest,
+  assertFilesContent,
+} from '../utils'
+
+describe('integration - ts-exports-multiple-conditions', () => {
+  it('should generate proper assets', async () => {
+    await createIntegrationTest(
+      {
+        directory: __dirname,
+      },
+      async ({ distDir }) => {
+        const distFiles = [
+          // entry files
+          'index.js',
+          'index.cjs',
+          'index.browser.js',
+          'index.workerd.js',
+          'index.edge-light.js',
+          // types
+          'index.d.cts',
+          'index.d.ts',
+          'index.browser.d.ts',
+          'index.workerd.d.ts',
+          'index.edge-light.d.ts',
+        ]
+        assertContainFiles(distDir, distFiles)
+        await assertFilesContent(distDir, {
+          'index.js': (code) => code.includes("const runtime = 'node'"),
+          'index.cjs': (code) => code.includes("const runtime = 'node'"),
+          'index.browser.js': (code) =>
+            code.includes("const runtime = 'browser'"),
+          'index.workerd.js': (code) =>
+            code.includes("const runtime = 'workerd'"),
+          'index.edge-light.js': (code) =>
+            code.includes("const runtime = 'edge-light'"),
+        })
+      },
+    )
+  })
+})

--- a/test/integration/ts-exports-multiple-conditions/package.json
+++ b/test/integration/ts-exports-multiple-conditions/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "ts-exports-multiple-conditions",
+  "type": "module",
+  "types": "dist/index.d.ts",
+  "module": "dist/index.js",
+  "main": "dist/index.cjs",
+  "exports": {
+    ".": {
+      "node": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "default": "./dist/index.cjs"
+      },
+      "workerd": {
+        "types": "./dist/index.workerd.d.ts",
+        "default": "./dist/index.workerd.js"
+      },
+      "edge-light": {
+        "types": "./dist/index.edge-light.d.ts",
+        "default": "./dist/index.edge-light.js"
+      },
+      "browser": {
+        "types": "./dist/index.browser.d.ts",
+        "default": "./dist/index.browser.js"
+      },
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  }
+}

--- a/test/integration/ts-exports-multiple-conditions/src/index.browser.ts
+++ b/test/integration/ts-exports-multiple-conditions/src/index.browser.ts
@@ -1,0 +1,1 @@
+export const runtime = 'browser'

--- a/test/integration/ts-exports-multiple-conditions/src/index.edge-light.ts
+++ b/test/integration/ts-exports-multiple-conditions/src/index.edge-light.ts
@@ -1,0 +1,1 @@
+export const runtime = 'edge-light'

--- a/test/integration/ts-exports-multiple-conditions/src/index.ts
+++ b/test/integration/ts-exports-multiple-conditions/src/index.ts
@@ -1,0 +1,1 @@
+export const runtime = 'node'

--- a/test/integration/ts-exports-multiple-conditions/src/index.workerd.ts
+++ b/test/integration/ts-exports-multiple-conditions/src/index.workerd.ts
@@ -1,0 +1,1 @@
+export const runtime = 'workerd'


### PR DESCRIPTION
Support more popular common runtime like `workerd`, `bun`, `deno` and `browser`