### PR TITLE
Support browserlists from package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,20 @@ Bunchee offers a convenient watch mode for rebuilding your library whenever chan
 #### `target`
 
 If you specify `target` option in `tsconfig.json`, then you don't have to pass it again through CLI.
+To target a range of browsers, you can use the `browserslist` field in `package.json`, bunchee will use it to determine the target browsers for the output bundle.
+
+For example:
+
+```json
+{
+  "browserslist": [
+    "last 1 version",
+    "> 1%",
+    "maintained node versions",
+    "not dead"
+  ]
+}
+```
 
 #### Package lint
 

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -1,4 +1,8 @@
-import type { BundleConfig, BundleJobOptions } from './types'
+import type {
+  BrowserslistConfig,
+  BundleConfig,
+  BundleJobOptions,
+} from './types'
 import fsp from 'fs/promises'
 import fs from 'fs'
 import { resolve } from 'path'
@@ -134,6 +138,11 @@ async function bundle(
     hasTsConfig = true
   }
 
+  let browserslistConfig: BrowserslistConfig | undefined
+  if (options.runtime === 'browser') {
+    browserslistConfig = pkg.browserslist
+  }
+
   const outputState = createOutputState({ entries })
   const buildContext: BuildContext = {
     entries,
@@ -141,6 +150,7 @@ async function bundle(
     cwd,
     tsOptions: defaultTsOptions,
     useTypeScript: hasTsConfig,
+    browserslistConfig,
     pluginContext: {
       outputState,
       moduleDirectiveLayerMap: new Map(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,6 @@ import type { JscTarget } from '@swc/types'
 import type { InputOptions, OutputOptions } from 'rollup'
 import type { OutputState } from './plugins/output-state-plugin'
 import type { TypescriptOptions } from './typescript'
-import type browserslist from 'browserslist'
 
 type PackageType = 'commonjs' | 'module'
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ import type { JscTarget } from '@swc/types'
 import type { InputOptions, OutputOptions } from 'rollup'
 import type { OutputState } from './plugins/output-state-plugin'
 import type { TypescriptOptions } from './typescript'
+import type browserslist from 'browserslist'
 
 type PackageType = 'commonjs' | 'module'
 
@@ -72,6 +73,7 @@ type PackageMetadata = {
   exports?: string | Record<string, ExportCondition>
   types?: string
   typings?: string
+  browserslist?: BrowserslistConfig
 }
 
 type BuncheeRollupConfig = {
@@ -112,12 +114,15 @@ type ExportPaths = Record<string, FullExportCondition>
 
 type Entries = Record<string, ParsedExportCondition>
 
+type BrowserslistConfig = string | string[] | Record<string, string>
+
 type BuildContext = {
   entries: Entries
   pkg: PackageMetadata
   cwd: string
   tsOptions: TypescriptOptions
   useTypeScript: boolean
+  browserslistConfig: BrowserslistConfig | undefined
   pluginContext: {
     outputState: OutputState
     moduleDirectiveLayerMap: Map<string, Set<[string, string]>>
@@ -150,4 +155,5 @@ export type {
   BuildContext,
   BundleJobOptions,
   bundleEntryOptions,
+  BrowserslistConfig,
 }

--- a/test/integration/browserslist/index.test.ts
+++ b/test/integration/browserslist/index.test.ts
@@ -1,0 +1,16 @@
+import { createIntegrationTest, assertFilesContent } from '../utils'
+
+describe('browserslist', () => {
+  it('should work with basic JSX format', async () => {
+    await createIntegrationTest(
+      {
+        directory: __dirname,
+      },
+      ({ distDir }) => {
+        assertFilesContent(distDir, {
+          'index.js': `_class_private_field_loose_key`,
+        })
+      },
+    )
+  })
+})

--- a/test/integration/browserslist/package.json
+++ b/test/integration/browserslist/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "browserslist",
+  "main": "./dist/index.js",
+  "browserslist": [
+    "ie 9"
+  ]
+}

--- a/test/integration/browserslist/src/index.js
+++ b/test/integration/browserslist/src/index.js
@@ -1,0 +1,7 @@
+export class A {
+  static prop = 'A-prop'
+
+  #foo() {
+    return 'foo'
+  }
+}


### PR DESCRIPTION
Closes #587 

Support `browserslist` in package.json.
This doesn't support the rc file cause we don't need to extend the dependency