### PR TITLE
Change prepare option to command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ mkdir src && touch ./src/index.ts
 
 ```sh
 # Use bunchee to prepare package.json configuration
-npm exec bunchee --prepare
+npm exec bunchee prepare
 # "If you're using other package manager such as pnpm"
-# pnpm bunchee --prepare
+# pnpm bunchee prepare
 
 # "Or use with npx"
-# npx bunchee@latest --prepare
+# npx bunchee@latest prepare
 ```
 
 Or you can checkout the following cases to configure your package.json.

--- a/test/integration/prepare-js/index.test.ts
+++ b/test/integration/prepare-js/index.test.ts
@@ -15,7 +15,7 @@ describe('integration prepare-js', () => {
   it('should contain correct files', async () => {
     await createIntegrationTest(
       {
-        args: ['--prepare'],
+        args: ['prepare'],
         directory: __dirname,
       },
       async ({ dir, stdout }) => {

--- a/test/integration/prepare-ts-with-pkg-json/index.test.ts
+++ b/test/integration/prepare-ts-with-pkg-json/index.test.ts
@@ -14,7 +14,7 @@ describe('integration prepare-ts-with-pkg-json', () => {
   it('should contain files', async () => {
     await createIntegrationTest(
       {
-        args: ['--prepare'],
+        args: ['prepare'],
         directory: __dirname,
       },
       async ({ dir }) => {

--- a/test/integration/prepare-ts-with-test-file/index.test.ts
+++ b/test/integration/prepare-ts-with-test-file/index.test.ts
@@ -11,7 +11,7 @@ describe('integration prepare-ts-with-test-file', () => {
   it('should contain files', async () => {
     await createIntegrationTest(
       {
-        args: ['--prepare'],
+        args: ['prepare'],
         directory: __dirname,
       },
       async ({ dir }) => {

--- a/test/integration/prepare-ts/index.test.ts
+++ b/test/integration/prepare-ts/index.test.ts
@@ -16,7 +16,7 @@ describe('integration prepare-ts', () => {
   it('should contain files', async () => {
     await createIntegrationTest(
       {
-        args: ['--prepare'],
+        args: ['prepare'],
         directory: __dirname,
       },
       async ({ dir, stdout }) => {


### PR DESCRIPTION
Since `prepare()` is not building the project itself, more like setup the project. It should be more flexible that could receive more options if possible in the future, thus we separate it to a different command.