### PR TITLE
fix: prepend plugin sourcemap

### DIFF
--- a/src/plugins/prepend-directives.ts
+++ b/src/plugins/prepend-directives.ts
@@ -14,7 +14,6 @@ export function prependDirectives(): Plugin {
           if (firstDirective) {
             const directive = firstDirective.value
             const directiveCode = `'${directive}';`
-            // return directiveCode + '\n' + code
             const magicString = new MagicString(code)
             magicString.prepend(directiveCode + '\n')
             return {

--- a/src/plugins/prepend-directives.ts
+++ b/src/plugins/prepend-directives.ts
@@ -3,7 +3,7 @@ import MagicString from 'magic-string'
 
 export function prependDirectives(): Plugin {
   return {
-    name: 'prependDirective',
+    name: 'prepend-directive',
     transform: {
       order: 'post',
       handler(code, id) {

--- a/src/plugins/prepend-directives.ts
+++ b/src/plugins/prepend-directives.ts
@@ -1,4 +1,5 @@
 import type { Plugin } from 'rollup'
+import MagicString from 'magic-string'
 
 export function prependDirectives(): Plugin {
   return {
@@ -13,7 +14,13 @@ export function prependDirectives(): Plugin {
           if (firstDirective) {
             const directive = firstDirective.value
             const directiveCode = `'${directive}';`
-            return directiveCode + '\n' + code
+            // return directiveCode + '\n' + code
+            const magicString = new MagicString(code)
+            magicString.prepend(directiveCode + '\n')
+            return {
+              code: magicString.toString(),
+              map: magicString.generateMap({ hires: true }),
+            }
           }
         }
         return null


### PR DESCRIPTION
Fix the error when build with `--sourcemap`
```
[plugin prependDirective] Sourcemap is likely to be incorrect: a plugin (prependDirective) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help
```