### PR TITLE
fix: enable rollup default tree-shaking

### DIFF
--- a/src/rollup/input.ts
+++ b/src/rollup/input.ts
@@ -258,7 +258,7 @@ export async function buildInputConfig(
       return externals.some((name) => id === name || id.startsWith(name + '/'))
     },
     plugins,
-    treeshake: true,
+    treeshake: 'recommended',
     onwarn(warning, warn) {
       const code = warning.code || ''
       // Some may not have types, like CLI binary

--- a/src/rollup/input.ts
+++ b/src/rollup/input.ts
@@ -258,9 +258,7 @@ export async function buildInputConfig(
       return externals.some((name) => id === name || id.startsWith(name + '/'))
     },
     plugins,
-    treeshake: {
-      propertyReadSideEffects: false,
-    },
+    treeshake: true,
     onwarn(warning, warn) {
       const code = warning.code || ''
       // Some may not have types, like CLI binary

--- a/test/compile/treeshake/__snapshot__/treeshake.js.snapshot
+++ b/test/compile/treeshake/__snapshot__/treeshake.js.snapshot
@@ -1,0 +1,7 @@
+class Foo {
+    getFoo() {
+        return 'foo';
+    }
+}
+
+export { Foo };

--- a/test/compile/treeshake/__snapshot__/treeshake.min.js.snapshot
+++ b/test/compile/treeshake/__snapshot__/treeshake.min.js.snapshot
@@ -1,0 +1,1 @@
+class o{getFoo(){return"foo"}}export{o as Foo};

--- a/test/compile/treeshake/input.js
+++ b/test/compile/treeshake/input.js
@@ -1,0 +1,14 @@
+class Foo {
+  getFoo() {
+    return 'foo'
+  }
+}
+
+// This will be removed by treeshaking
+class Bar {
+  getBar() {
+    return 'bar'
+  }
+}
+
+export { Foo }


### PR DESCRIPTION
The treeshake option is not merged with default preset, it's using the explicit configured option unless you speicify a preset. 
We know enable the tree-shaking with "recommended" preset


According to the doc: `"recommended" should work well for most usage patterns. Some semantic issues may be swallowed, though (treeshake.unknownGlobalSideEffects: false, treeshake.correctVarValueBeforeDeclaration: false)`