### PR TITLE
feat: support mark any underscore module as private

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -82,3 +82,5 @@ export const DEFAULT_TS_CONFIG = {
 }
 
 export const BINARY_TAG = '$binary'
+
+export const PRIVATE_GLOB_PATTERN = '**/_*/**'

--- a/src/prepare/prepare-entries.ts
+++ b/src/prepare/prepare-entries.ts
@@ -1,6 +1,10 @@
 import { existsSync } from 'fs'
 import { glob } from 'glob'
-import { BINARY_TAG, availableExtensions } from '../constants'
+import {
+  BINARY_TAG,
+  PRIVATE_GLOB_PATTERN,
+  availableExtensions,
+} from '../constants'
 
 import { collectSourceEntriesByExportPath } from '../entries'
 import { normalizePath, sourceFilenameToExportFullPath } from '../utils'
@@ -24,13 +28,13 @@ export async function collectSourceEntries(sourceFolderPath: string) {
   const binMatches = await glob(binPattern, {
     cwd: sourceFolderPath,
     nodir: true,
-    ignore: '**/_*', // ignore private entries
+    ignore: PRIVATE_GLOB_PATTERN, // ignore private entries
   })
 
   const srcMatches = await glob(srcPattern, {
     cwd: sourceFolderPath,
     nodir: true,
-    ignore: '**/_*', // ignore private entries
+    ignore: PRIVATE_GLOB_PATTERN, // ignore private entries
   })
 
   for (const file of binMatches) {

--- a/test/integration/shared-any-module/index.test.ts
+++ b/test/integration/shared-any-module/index.test.ts
@@ -1,0 +1,35 @@
+import {
+  assertFilesContent,
+  createIntegrationTest,
+  getFileNamesFromDirectory,
+} from '../utils'
+
+describe('integration shared-module', () => {
+  it('should split all shared module into different chunks', async () => {
+    await createIntegrationTest(
+      {
+        directory: __dirname,
+      },
+      async ({ distDir, stdout }) => {
+        const jsFiles = await getFileNamesFromDirectory(distDir)
+        expect(jsFiles).toEqual([
+          '_internal/util-a.cjs',
+          '_internal/util-a.js',
+          '_internal/util-b.cjs',
+          '_internal/util-b.js',
+          'export-a.js',
+          'export-b.js',
+          'export-c.js',
+          'private/_nested/util-c.cjs',
+          'private/_nested/util-c.js',
+        ])
+
+        await assertFilesContent(distDir, {
+          'export-a.js': `'./_internal/util-a.js'`,
+          'export-b.js': `'./_internal/util-b.js'`,
+          'export-c.js': `'./private/_nested/util-c.js'`,
+        })
+      },
+    )
+  })
+})

--- a/test/integration/shared-any-module/package.json
+++ b/test/integration/shared-any-module/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "shared-module",
+  "type": "module",
+  "exports": {
+    "./export-a": "./dist/export-a.js",
+    "./export-b": "./dist/export-b.js",
+    "./export-c": "./dist/export-c.js"
+  },
+  "dependencies": {
+    "react": "*"
+  }
+}

--- a/test/integration/shared-any-module/src/_internal/util-a.js
+++ b/test/integration/shared-any-module/src/_internal/util-a.js
@@ -1,0 +1,1 @@
+export const utilA = 'utilA'

--- a/test/integration/shared-any-module/src/_internal/util-b.js
+++ b/test/integration/shared-any-module/src/_internal/util-b.js
@@ -1,0 +1,1 @@
+export const utilB = 'utilB'

--- a/test/integration/shared-any-module/src/export-a.js
+++ b/test/integration/shared-any-module/src/export-a.js
@@ -1,0 +1,6 @@
+import { utilA } from './_internal/util-a'
+import { utilB } from './_internal/util-b'
+
+export const getName = () => {
+  return 'export-a' + utilA + utilB
+}

--- a/test/integration/shared-any-module/src/export-b.js
+++ b/test/integration/shared-any-module/src/export-b.js
@@ -1,0 +1,6 @@
+import { utilB } from './_internal/util-b'
+import { utilC } from './private/_nested/util-c'
+
+export const getName = () => {
+  return 'export-b' + utilB + utilC
+}

--- a/test/integration/shared-any-module/src/export-c.js
+++ b/test/integration/shared-any-module/src/export-c.js
@@ -1,0 +1,6 @@
+import { utilA } from './_internal/util-a'
+import { utilC } from './private/_nested/util-c'
+
+export const getName = () => {
+  return 'export-c' + utilA + utilC
+}

--- a/test/integration/shared-any-module/src/private/_nested/util-c.js
+++ b/test/integration/shared-any-module/src/private/_nested/util-c.js
@@ -1,0 +1,1 @@
+export const utilC = 'utilC'


### PR DESCRIPTION
### What

If I have a lot of internal files that wanted to be share across multiple entries, e.g. `_internal/**` and each entry randomly imports the internal files, we could create some shared chunks for `_internal/**` so that each shared module will have a new chunk.

For example

```
- src
  | - _internal/
    |- util-a
    |- util-b
  | - entry-a
  | - entry-b
```

In the dependency graph, `entry-a` imports `util-a`, and `entry-b` imports `util-b`. we could just create 2 chunks for `_internal/util-a` and `_internal/util-b` instead of asking users to use a barrel file like `_internal/index.ts` or rename everything under `_internal` with a underscore prefix.

Closes #617 