### PR TITLE
feat: error on duplicated entries

### DIFF
--- a/src/entries.ts
+++ b/src/entries.ts
@@ -5,8 +5,8 @@ import { glob } from 'glob'
 import { getExportTypeFromFile, type ParsedExportsInfo } from './exports'
 import { PackageMetadata, type Entries, ExportPaths } from './types'
 import { logger } from './logger'
+import { baseNameWithoutExtension, validateEntryFiles } from './util/file-path'
 import {
-  baseNameWithoutExtension,
   getSourcePathFromExportPath,
   isBinExportPath,
   isESModulePackage,
@@ -287,7 +287,7 @@ export async function collectSourceEntriesByExportPath(
   const dirPath = path.join(sourceFolderPath, dirName)
 
   // Match <name>{,/index}.{<ext>,<runtime>.<ext>}
-  const globalPatterns = [
+  const entryFilesPatterns = [
     `${baseName}.{${[...availableExtensions].join(',')}}`,
     `${baseName}.{${[...runtimeExportConventions].join(',')}}.{${[
       ...availableExtensions,
@@ -298,13 +298,15 @@ export async function collectSourceEntriesByExportPath(
     ].join(',')}}`,
   ]
 
-  const files = await glob(globalPatterns, {
+  const entryFiles = await glob(entryFilesPatterns, {
     cwd: dirPath,
     nodir: true,
     ignore: PRIVATE_GLOB_PATTERN,
   })
 
-  for (const file of files) {
+  validateEntryFiles(entryFiles)
+
+  for (const file of entryFiles) {
     const ext = path.extname(file).slice(1)
     if (!availableExtensions.has(ext) || isTestFile(file)) continue
 

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -7,12 +7,12 @@ import type {
   ParsedExportCondition,
 } from './types'
 import {
-  baseNameWithoutExtension,
   getMainFieldExportType,
   isESModulePackage,
   joinRelativePath,
   normalizePath,
 } from './utils'
+import { baseNameWithoutExtension } from './util/file-path'
 import {
   BINARY_TAG,
   dtsExtensionsMap,

--- a/src/util/file-path.test.ts
+++ b/src/util/file-path.test.ts
@@ -36,12 +36,21 @@ describe('baseNameWithoutExtension', () => {
 describe('validateEntryFiles', () => {
   it('should throw error if there are multiple files with the same base name', () => {
     expect(() =>
-      validateEntryFiles(['index.js', 'index.ts', 'index.mjs']),
+      validateEntryFiles(['index.js', 'index/index.ts']),
     ).toThrowError('Conflicted entry files found for entries: .')
   })
-  it('should not throw error if there are no multiple files with the same base name', () => {
+  it.only('should throw error if the normalized base names are same', () => {
     expect(() => validateEntryFiles(['foo/index.jsx', 'foo.ts'])).toThrowError(
       'Conflicted entry files found for entries: ./foo',
     )
+  })
+  it('should not throw error if there are no multiple files with the same base name', () => {
+    expect(() =>
+      validateEntryFiles([
+        'index.development.js',
+        'index.ts',
+        'index.react-server.mjs',
+      ]),
+    ).not.toThrow()
   })
 })

--- a/src/util/file-path.test.ts
+++ b/src/util/file-path.test.ts
@@ -1,0 +1,47 @@
+import {
+  getPathWithoutExtension,
+  baseNameWithoutExtension,
+  validateEntryFiles,
+} from './file-path'
+
+describe('getFirstBaseName', () => {
+  it('should return first part base name without extension of file path', () => {
+    expect(getPathWithoutExtension('index.js')).toBe('index')
+    expect(getPathWithoutExtension('index.d.ts')).toBe('index')
+    expect(getPathWithoutExtension('index')).toBe('index')
+    // give few segments nested file path
+    expect(getPathWithoutExtension('./foo/nested/index.js')).toBe(
+      './foo/nested',
+    )
+    expect(getPathWithoutExtension('./foo/nested/index.d.ts')).toBe(
+      './foo/nested',
+    )
+    expect(getPathWithoutExtension('./foo.jsx')).toBe('./foo')
+  })
+})
+
+describe('baseNameWithoutExtension', () => {
+  it('should return full base name without last extension of file path', () => {
+    // give few segments nested file path
+    expect(baseNameWithoutExtension('dist/foo/nested/index.js')).toBe('index')
+    expect(
+      baseNameWithoutExtension('dist/foo/nested/index.development.ts'),
+    ).toBe('index.development')
+    expect(
+      baseNameWithoutExtension('dist/foo/nested/index.react-server.js'),
+    ).toBe('index.react-server')
+  })
+})
+
+describe('validateEntryFiles', () => {
+  it('should throw error if there are multiple files with the same base name', () => {
+    expect(() =>
+      validateEntryFiles(['index.js', 'index.ts', 'index.mjs']),
+    ).toThrowError('Conflicted entry files found for entries: .')
+  })
+  it('should not throw error if there are no multiple files with the same base name', () => {
+    expect(() => validateEntryFiles(['foo/index.jsx', 'foo.ts'])).toThrowError(
+      'Conflicted entry files found for entries: ./foo',
+    )
+  })
+})

--- a/src/util/file-path.ts
+++ b/src/util/file-path.ts
@@ -20,31 +20,34 @@ export const baseNameWithoutExtension = (filePath: string): string => {
 }
 
 export function validateEntryFiles(entryFiles: string[]) {
-  const baseNames = new Set<string>()
-  const duplicateBaseNames = new Set<string>()
+  const fileBasePaths = new Set<string>()
+  const duplicatePaths = new Set<string>()
 
-  for (const file of entryFiles) {
+  for (const filePath of entryFiles) {
     // Check if there are multiple files with the same base name
-    // e.g. index.js, index.ts, index.mjs
-    // e.g. <name>.ext and <name>./index.ext
-    let baseName = getPathWithoutExtension(file)
-    const indexSuffix = '/index'
-    if (baseName.endsWith(indexSuffix)) {
-      baseName = baseName.slice(0, -indexSuffix.length)
-    }
+    const filePathWithoutExt = filePath
+      .slice(0, -path.extname(filePath).length)
+      .replace(/\\/g, '/')
+    const segments = filePathWithoutExt.split('/')
+    const lastSegment = segments.pop() || ''
 
-    if (baseNames.has(baseName)) {
-      duplicateBaseNames.add(
+    if (lastSegment !== 'index' && lastSegment !== '') {
+      segments.push(lastSegment)
+    }
+    const fileBasePath = segments.join('/')
+
+    if (fileBasePaths.has(fileBasePath)) {
+      duplicatePaths.add(
         // Add a dot if the base name is empty, 'foo' -> './foo', '' -> '.'
-        '.' + (baseName !== '' ? '/' : '') + baseName,
+        './' + filePath.replace(/\\/g, '/'),
       )
     }
-    baseNames.add(baseName)
+    fileBasePaths.add(fileBasePath)
   }
 
-  if (duplicateBaseNames.size > 0) {
+  if (duplicatePaths.size > 0) {
     throw new Error(
-      `Conflicted entry files found for entries: ${[...duplicateBaseNames].join(
+      `Conflicted entry files found for entries: ${[...duplicatePaths].join(
         ', ',
       )}`,
     )

--- a/src/util/file-path.ts
+++ b/src/util/file-path.ts
@@ -1,0 +1,52 @@
+import path from 'path'
+
+// Example: ./src/util/foo.ts -> ./src/util/foo
+// Example: ./src/util/foo/index.ts -> ./src/util/foo
+// Example: ./src/util/foo.d.ts -> ./src/util/foo
+export const getPathWithoutExtension = (filePath: string): string => {
+  const pathWithoutExtension = filePath
+    // Remove the file extension first
+    .replace(/(\.\w+)+$/, '')
+    // Remove '/index' if it exists at the end of the path
+    .replace(/\/index$/, '')
+
+  return pathWithoutExtension
+}
+
+// Example: ./src/util/foo.development.ts -> foo.development
+// Example: ./src/util/foo.react-server.ts -> foo.react-server
+export const baseNameWithoutExtension = (filePath: string): string => {
+  return path.basename(filePath, path.extname(filePath))
+}
+
+export function validateEntryFiles(entryFiles: string[]) {
+  const baseNames = new Set<string>()
+  const duplicateBaseNames = new Set<string>()
+
+  for (const file of entryFiles) {
+    // Check if there are multiple files with the same base name
+    // e.g. index.js, index.ts, index.mjs
+    // e.g. <name>.ext and <name>./index.ext
+    let baseName = getPathWithoutExtension(file)
+    const indexSuffix = '/index'
+    if (baseName.endsWith(indexSuffix)) {
+      baseName = baseName.slice(0, -indexSuffix.length)
+    }
+
+    if (baseNames.has(baseName)) {
+      duplicateBaseNames.add(
+        // Add a dot if the base name is empty, 'foo' -> './foo', '' -> '.'
+        '.' + (baseName !== '' ? '/' : '') + baseName,
+      )
+    }
+    baseNames.add(baseName)
+  }
+
+  if (duplicateBaseNames.size > 0) {
+    throw new Error(
+      `Conflicted entry files found for entries: ${[...duplicateBaseNames].join(
+        ', ',
+      )}`,
+    )
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,6 +13,7 @@ import {
 import { logger } from './logger'
 import { type OutputOptions } from 'rollup'
 import { posixRelativify } from './lib/format'
+import { baseNameWithoutExtension } from './util/file-path'
 
 export function exit(err: string | Error) {
   logger.error(err)
@@ -174,10 +175,6 @@ export const getMainFieldExportType = (pkg: PackageMetadata) => {
       : 'require'
   return mainExportType
 }
-
-// TODO: add unit test
-export const baseNameWithoutExtension = (filename: string): string =>
-  path.basename(filename, path.extname(filename))
 
 export const isTestFile = (filename: string): boolean =>
   /\.(test|spec)$/.test(baseNameWithoutExtension(filename))

--- a/test/integration/conflicted-entry/conflicted-entry.test.ts
+++ b/test/integration/conflicted-entry/conflicted-entry.test.ts
@@ -1,0 +1,17 @@
+import { createIntegrationTest } from '../utils'
+
+describe('integration - conflicted-entry', () => {
+  it('should error on conflicted entries', async () => {
+    await createIntegrationTest(
+      {
+        directory: __dirname,
+      },
+      async ({ code, stderr }) => {
+        expect(code).toBe(1)
+        expect(stderr).toContain(
+          'Conflicted entry files found for entries: ./foo',
+        )
+      },
+    )
+  })
+})

--- a/test/integration/conflicted-entry/package.json
+++ b/test/integration/conflicted-entry/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "conflicted-entry",
+  "exports": {
+    "./foo": "./dist/foo.js"
+  }
+}

--- a/test/integration/conflicted-entry/src/foo.ts
+++ b/test/integration/conflicted-entry/src/foo.ts
@@ -1,0 +1,1 @@
+export class Foo {}

--- a/test/integration/conflicted-entry/src/foo/index.jsx
+++ b/test/integration/conflicted-entry/src/foo/index.jsx
@@ -1,0 +1,1 @@
+export class Foo {}

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -8,5 +8,5 @@
       "bunchee": ["./src/index.ts"]
     }
   },
-  "include": ["./**/*.test.ts"]
+  "include": ["./**/*.test.ts", "../src/**/*.test.ts"]
 }


### PR DESCRIPTION
If there's duplicated entry like `foo/index.js` and `foo.js` we can error in build `Conflicted entry files found for entries: ./foo'`

Closes #593 