### PR TITLE
remove the default behavior of env replacement on node env

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ This convention keeps shared modules private while enabling efficient bundling a
 - External (`--external <dep,>`): Specifying extra external dependencies, by default it is the list of `dependencies` and `peerDependencies` from `package.json`. Values are separate by comma.
 - Target (`--target <target>`): Set ECMAScript target (default: `'es2015'`).
 - Runtime (`--runtime <runtime>`): Set build runtime (default: `'browser'`).
-- Environment (`--env <env,>`): Define environment variables. (default: `NODE_ENV`, separate by comma)
+- Environment (`--env <env,>`): Define environment variables. (default: `[]`, separate by comma)
 - Working Directory (`--cwd <cwd>`): Set current working directory where containing `package.json`.
 - Minify (`-m`): Compress output.
 - Watch (`-w`): Watch for source file changes.

--- a/src/env.ts
+++ b/src/env.ts
@@ -7,9 +7,6 @@ export function getDefinedInlineVariables(
   envs: string[],
   parsedExportCondition: ParsedExportCondition,
 ): Record<string, string> {
-  if (!envs.includes('NODE_ENV')) {
-    envs.push('NODE_ENV')
-  }
   const envVars = envs.reduce((acc: Record<string, string>, key) => {
     const value = process.env[key]
     if (typeof value !== 'undefined') {

--- a/test/integration/dev-prod-convention/index.test.ts
+++ b/test/integration/dev-prod-convention/index.test.ts
@@ -12,9 +12,9 @@ describe('integration dev-prod-convention', () => {
           'index.development.mjs': /= "development"/,
           'index.production.js': /= "production"/,
           'index.production.mjs': /= "production"/,
-          // In jest the NODE_ENV is set to test
-          'index.js': /= "test"/,
-          'index.mjs': /= "test"/,
+          // Do not replace NODE_ENV by default
+          'index.js': /= process.env.NODE_ENV/,
+          'index.mjs': /= process.env.NODE_ENV/,
         })
       },
     )


### PR DESCRIPTION
Replacing `NODE_ENV` by default could result into unexpected behavior when the environment change and it's not easy to opt-out. Remove the default env here to provide easier defaults for users to bundle and still possible to opt-in with set `NODE_ENV`