### PR TITLE
fix: js bundle alias of shared module

### DIFF
--- a/src/entries.ts
+++ b/src/entries.ts
@@ -440,19 +440,19 @@ export async function collectSourceEntriesFromExportPaths(
       ],
     ]
     const privateExportInfo: [string, string][] = [
+      ...(isTs ? typesInfos : []),
       [
         posixRelativify(
           posix.join('./dist', exportPath + (isEsmPkg ? '.js' : '.mjs')),
         ),
-        condPart + 'import',
+        condPart + 'import.default',
       ],
       [
         posixRelativify(
           posix.join('./dist', exportPath + (isEsmPkg ? '.cjs' : '.js')),
         ),
-        condPart + 'require',
+        condPart + 'require.default',
       ],
-      ...(isTs ? typesInfos : []),
     ]
 
     const exportsInfo = parsedExportsInfo.get(normalizedExportPath)

--- a/test/integration/shared-module-with-suffix/package.json
+++ b/test/integration/shared-module-with-suffix/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "mixed-export-conditions",
+  "exports": {
+    "./client": {
+      "import": {
+        "default": "./dist/client.mjs"
+      }
+    }
+  }
+}

--- a/test/integration/shared-module-with-suffix/shared-module-with-suffix.test.ts
+++ b/test/integration/shared-module-with-suffix/shared-module-with-suffix.test.ts
@@ -1,0 +1,16 @@
+import { assertFilesContent, createIntegrationTest } from '../utils'
+
+describe('integration - shared-module-with-suffix', () => {
+  it('should alias correctly for the shared module with special suffix', async () => {
+    await createIntegrationTest(
+      {
+        directory: __dirname,
+      },
+      async ({ distDir }) => {
+        assertFilesContent(distDir, {
+          'client.mjs': `./_private/util.browser.mjs`,
+        })
+      },
+    )
+  })
+})

--- a/test/integration/shared-module-with-suffix/src/_private/util.browser.ts
+++ b/test/integration/shared-module-with-suffix/src/_private/util.browser.ts
@@ -1,0 +1,1 @@
+export const util = 'index:browser'

--- a/test/integration/shared-module-with-suffix/src/client/index.ts
+++ b/test/integration/shared-module-with-suffix/src/client/index.ts
@@ -1,0 +1,5 @@
+import { util } from '../_private/util.browser'
+
+export function getClient() {
+  return 'client' + util
+}


### PR DESCRIPTION
The shared module might alias to the import.types or require.types condition instead of js bundle