### PR TITLE
feat: handle dynamic require in ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,8 @@
       "node_modules"
     ],
     "moduleNameMapper": {
-      "bunchee": "<rootDir>/src/index.ts"
+      "^bunchee$": "<rootDir>/src/index.ts",
+      "^testing-utils$": "<rootDir>/test/integration/utils.ts"
     },
     "transform": {
       "^.+\\.(t|j)sx?$": [

--- a/src/rollup/input.ts
+++ b/src/rollup/input.ts
@@ -248,6 +248,10 @@ export async function buildInputConfig(
           }),
           commonjs({
             exclude: bundleConfig.external || null,
+            // Deal with mixed ESM and CJS modules, such as calling require() in ESM.
+            // For relative paths, the module will be bundled;
+            // For external libraries, the module will not be bundled.
+            transformMixedEsModules: true,
           }),
         ]
   ).filter(isNotNull<Plugin>)

--- a/test/integration/dynamic-require/dynamic-require.test.ts
+++ b/test/integration/dynamic-require/dynamic-require.test.ts
@@ -1,5 +1,5 @@
 import fs from 'fs'
-import { createIntegrationTest, getFileNamesFromDirectory } from 'testing-utils'
+import { createIntegrationTest, getFileNamesFromDirectory } from '../utils'
 
 describe('integration - dynamic-require', () => {
   it('should work', async () => {

--- a/test/integration/dynamic-require/dynamic-require.test.ts
+++ b/test/integration/dynamic-require/dynamic-require.test.ts
@@ -1,0 +1,36 @@
+import fs from 'fs'
+import { createIntegrationTest, getFileNamesFromDirectory } from 'testing-utils'
+
+describe('integration - dynamic-require', () => {
+  it('should work', async () => {
+    await createIntegrationTest(
+      {
+        directory: __dirname,
+      },
+      async ({ distDir }) => {
+        expect(await getFileNamesFromDirectory(distDir)).toEqual([
+          'foo.cjs',
+          'foo.js',
+          'index.cjs',
+          'index.js',
+        ])
+        // TODO: add helper of read content of dist file
+
+        // For require calls to the relative path, the value should be bundled
+        expect(fs.readFileSync(`${distDir}/index.cjs`, 'utf-8')).toContain(
+          `return 'being-required'`,
+        )
+        expect(fs.readFileSync(`${distDir}/index.js`, 'utf-8')).toContain(
+          `return 'being-required'`,
+        )
+        // For require calls to the external library, the value should not be bundled
+        expect(fs.readFileSync(`${distDir}/foo.cjs`, 'utf-8')).not.toContain(
+          `external-lib-value`,
+        )
+        expect(fs.readFileSync(`${distDir}/foo.js`, 'utf-8')).not.toContain(
+          `external-lib-value`,
+        )
+      },
+    )
+  })
+})

--- a/test/integration/dynamic-require/node_modules/external-lib/index.js
+++ b/test/integration/dynamic-require/node_modules/external-lib/index.js
@@ -1,0 +1,7 @@
+const ExternalLib = {
+  method() {
+    return 'external-lib-value';
+  }
+}
+
+export default ExternalLib

--- a/test/integration/dynamic-require/node_modules/external-lib/package.json
+++ b/test/integration/dynamic-require/node_modules/external-lib/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "external-lib",
+  "type": "module",
+  "main": "./index.js"
+}

--- a/test/integration/dynamic-require/package.json
+++ b/test/integration/dynamic-require/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "dynamic-require",
+  "main": "./dist/index.js",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "default": "./dist/index.cjs"
+    },
+    "./foo": {
+      "import": "./dist/foo.js",
+      "default": "./dist/foo.cjs"
+    }
+  },
+  "dependencies": {
+    "external-lib": "*"
+  }
+}

--- a/test/integration/dynamic-require/src/foo.js
+++ b/test/integration/dynamic-require/src/foo.js
@@ -1,0 +1,5 @@
+import externalLib from 'external-lib'
+
+export function foo() {
+  return externalLib.method()
+}

--- a/test/integration/dynamic-require/src/index.js
+++ b/test/integration/dynamic-require/src/index.js
@@ -1,0 +1,3 @@
+export function index() {
+  require('./required-module').method()
+}

--- a/test/integration/dynamic-require/src/required-module.js
+++ b/test/integration/dynamic-require/src/required-module.js
@@ -1,0 +1,3 @@
+export function method() {
+  return 'being-required'
+}

--- a/test/integration/esm-shims/index.test.ts
+++ b/test/integration/esm-shims/index.test.ts
@@ -1,4 +1,8 @@
-import { createIntegrationTest, assertFilesContent } from '../utils'
+import {
+  createIntegrationTest,
+  assertFilesContent,
+  getFileContents,
+} from '../utils'
 
 describe('integration esm-shims', () => {
   it('should work with ESM shims', async () => {
@@ -15,7 +19,6 @@ describe('integration esm-shims', () => {
           'const __dirname = __node_cjsPath.dirname(__filename)'
 
         await assertFilesContent(distDir, {
-          'require.mjs': requirePolyfill,
           'filename.mjs': filenamePolyfill,
           'dirname.mjs': dirnamePolyfill,
           'custom-require.mjs': (code) => !code.includes(requirePolyfill),
@@ -24,6 +27,11 @@ describe('integration esm-shims', () => {
           'dirname.js': /__dirname/,
           'custom-require.js': (code) => !code.includes(requirePolyfill),
         })
+
+        const contents = await getFileContents(distDir, ['require.mjs'])
+        expect(contents['require.mjs']).not.toContain(requirePolyfill)
+        expect(contents['require.mjs']).toContain('function getRequireModule')
+        expect(contents['require.mjs']).toContain('import.meta.url')
       },
     )
   })

--- a/test/integration/unspecified-types-paths/index.test.ts
+++ b/test/integration/unspecified-types-paths/index.test.ts
@@ -1,7 +1,10 @@
-import fs from 'fs'
-import { assertFilesContent, createIntegrationTest } from '../utils'
+import {
+  assertFilesContent,
+  createIntegrationTest,
+  getFileNamesFromDirectory,
+} from '../utils'
 
-describe('integration tsconfig-override', () => {
+describe('integration - tsconfig-override', () => {
   it('should not generate js types paths if not specified', async () => {
     await createIntegrationTest(
       {
@@ -12,8 +15,11 @@ describe('integration tsconfig-override', () => {
           './dist/subpath/nested.js': 'subpath/nested',
           './dist/subpath/nested.cjs': 'subpath/nested',
         })
-        const subpathTypes = await import(`${dir}/dist/index.js`)
-        expect(fs.existsSync(subpathTypes)).toBe(false)
+        // No types files should be generated
+        expect(await getFileNamesFromDirectory(dir)).toEqual([
+          'dist/subpath/nested.cjs',
+          'dist/subpath/nested.js',
+        ])
       },
     )
   })

--- a/test/integration/utils.ts
+++ b/test/integration/utils.ts
@@ -9,8 +9,6 @@ function normalizePath(filePath: string) {
   return filePath.replace(/\\/g, '/')
 }
 
-export * from '../testing-utils'
-
 type IntegrationTestOptions = {
   args?: string[]
   options?: { env?: NodeJS.ProcessEnv }

--- a/test/integration/utils.ts
+++ b/test/integration/utils.ts
@@ -8,6 +8,7 @@ import {
 function normalizePath(filePath: string) {
   return filePath.replace(/\\/g, '/')
 }
+export * from '../testing-utils'
 
 type IntegrationTestOptions = {
   args?: string[]

--- a/test/testing-utils.ts
+++ b/test/testing-utils.ts
@@ -37,6 +37,17 @@ export function assertContainFiles(dir: string, filePaths: string[]) {
 
 type FunctionCondition = (content: string) => Boolean
 
+export async function getFileContents(dir: string, filePaths?: string[]) {
+  const results: Record<string, string> = {}
+  const files = filePaths || (await fsp.readdir(dir))
+  for (const file of files) {
+    const fullPath = path.resolve(dir, file)
+    const content = await fsp.readFile(fullPath, { encoding: 'utf-8' })
+    results[file] = content
+  }
+  return results
+}
+
 export async function assertFilesContent(
   dir: string,
   conditionMap: Record<string, RegExp | string | FunctionCondition>,

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -5,15 +5,20 @@
     "target": "ESNext",
     "strict": false,
     "jsx": "preserve",
-    "baseUrl": ".",
+    "baseUrl": "..",
     "paths": {
-      "bunchee": ["../src/index.ts"],
-      "testing-utils": ["./integration/utils.ts"]
+      "bunchee": ["./src/index.ts"]
     }
   },
   "include": [
-    "../src/**/*.test.ts",
-    "../src/**/*.test.tsx"
+    "./test/**/*.test.ts",
+    "./test**/*.test.tsx",
+    // TODO: group those internal utils
+    "./test/utils/*",
+    "./test/testing-utils.ts",
+    "./test/integration/utils.ts",
+    "./src/**/*.test.ts",
+    "./src/**/*.test.tsx"
   ],
   "references": [{ "path": "../tsconfig.json" }]
 }

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "target": "ESNext",
     "strict": false,
+    "jsx": "preserve",
     "baseUrl": ".",
     "paths": {
       "bunchee": ["../src/index.ts"],
@@ -11,8 +12,6 @@
     }
   },
   "include": [
-    "**/*.ts",
-    "**/*.tsx",
     "../src/**/*.test.ts",
     "../src/**/*.test.tsx"
   ],

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -4,15 +4,15 @@
     "module": "ESNext",
     "target": "ESNext",
     "strict": false,
-    "baseUrl": "..",
+    "baseUrl": ".",
     "paths": {
-      "bunchee": ["./src/index.ts"],
-      "testing-utils": ["./test/integration/utils.ts"]
+      "bunchee": ["../src/index.ts"],
+      "testing-utils": ["./integration/utils.ts"]
     }
   },
   "include": [
-    "**/*.test.ts",
-    "**/*.test.tsx",
+    "**/*.ts",
+    "**/*.tsx",
     "../src/**/*.test.ts",
     "../src/**/*.test.tsx"
   ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
   },
   "references": [{ "path": "./test/tsconfig.json" }],
   "include": ["src", "*.d.ts", "**/*.json"],
-  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }


### PR DESCRIPTION
Turn on the commonjs plugin transform flag to handle `require()` in the source code. Include the module when needed and this will avoid the esm-shim issue 


Resolves #626 
Fixes #468