### PR TITLE
fix: `prepare` append EOL to `package.json`

### DIFF
--- a/src/prepare/index.ts
+++ b/src/prepare/index.ts
@@ -260,6 +260,6 @@ export async function prepare(cwd: string): Promise<void> {
     }
   }
 
-  await fsp.writeFile(pkgJsonPath, JSON.stringify(pkgJson, null, 2))
+  await fsp.writeFile(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + '\n')
   logger.info('Configured `exports` in package.json')
 }


### PR DESCRIPTION
Currently, `bunchee prepare` writes to the `package.json` file without an EOL, this usually causes issues. The PR makes `bunchee prepare` to include EOL.

All tests passed locally.

<img width="1086" alt="image" src="https://github.com/user-attachments/assets/712f8863-7080-485f-a464-8f40f866e45a" />
