### PR TITLE
disable removing output in watch mode

### DIFF
--- a/src/rollup-job.ts
+++ b/src/rollup-job.ts
@@ -35,9 +35,12 @@ export async function createAssetRollupJobs(
     : []
   const allConfigs = assetsConfigs.concat(typesConfigs)
 
-  for (const config of allConfigs) {
-    if (options.clean && !isFromCli) {
-      await removeOutputDir(config.output, buildContext.cwd)
+  // When it's production build (non watch mode), we need to remove the output directory
+  if (!options.watch) {
+    for (const config of allConfigs) {
+      if (options.clean && !isFromCli) {
+        await removeOutputDir(config.output, buildContext.cwd)
+      }
     }
   }
 


### PR DESCRIPTION
bunchee removes all files before recreating them, which causes a lot of temporary errors about missing files. This could potentially break hmr during the build of a large monorepo. Since the types files can be missing in the middle of the process