### PR TITLE
fix: iife invalid name rollup error

### DIFF
--- a/src/rollup/output.ts
+++ b/src/rollup/output.ts
@@ -44,6 +44,7 @@ export async function buildOutputConfigs(
 
   const outputOptions: OutputOptions = {
     name: pkg.name || name,
+    extend: true,
     dir: dts ? typesDir : jsDir,
     format,
     exports: 'named',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -48,12 +48,6 @@ export function fileExists(filePath: string) {
   return fs.existsSync(filePath)
 }
 
-const toCamelCase = (str: string): string => {
-  return str
-    .replace(/[-_]+(.)?/g, (_, c) => (c ? c.toUpperCase() : ''))
-    .replace(/^[A-Z]/, (c) => c.toLowerCase())
-}
-
 // . -> pkg name
 // ./lite -> <pkg name>/lite
 export function getExportPath(
@@ -61,7 +55,7 @@ export function getExportPath(
   cwd: string,
   exportName?: string,
 ) {
-  const name = toCamelCase(pkg.name || path.basename(cwd))
+  const name = pkg.name || path.basename(cwd)
   if (exportName === '.' || !exportName) return name
   return path.join(name, exportName)
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -48,6 +48,12 @@ export function fileExists(filePath: string) {
   return fs.existsSync(filePath)
 }
 
+const toCamelCase = (str: string): string => {
+  return str
+    .replace(/[-_]+(.)?/g, (_, c) => (c ? c.toUpperCase() : ''))
+    .replace(/^[A-Z]/, (c) => c.toLowerCase())
+}
+
 // . -> pkg name
 // ./lite -> <pkg name>/lite
 export function getExportPath(
@@ -55,7 +61,7 @@ export function getExportPath(
   cwd: string,
   exportName?: string,
 ) {
-  const name = pkg.name || path.basename(cwd)
+  const name = toCamelCase(pkg.name || path.basename(cwd))
   if (exportName === '.' || !exportName) return name
   return path.join(name, exportName)
 }


### PR DESCRIPTION
When package name contains `-` it will throw the error from rollup when output with `iife` or `umd`
```
 Error [RollupError]: Given name "bunchee-test" is not a legal JS identifier. If you need this, you can try "output.extend: true".
code: 'ILLEGAL_IDENTIFIER_AS_NAME',
url: 'https://rollupjs.org/configuration-options/#output-extend'
```

Setting extend to `true` to avoid it

```
Whether to extend the global variable defined by the name option in umd or iife formats. When true, the global variable will be defined as (global.name = global.name || {}). When false, the global defined by name will be overwritten like (global.name = {}).
```