### PR TITLE
feat: support raw query to load file as raw content

### DIFF
--- a/src/plugins/raw-plugin.ts
+++ b/src/plugins/raw-plugin.ts
@@ -1,5 +1,6 @@
 import { type FilterPattern, createFilter } from '@rollup/pluginutils'
 import type { Plugin } from 'rollup'
+import { readFileSync } from 'fs'
 
 export function rawContent({ exclude }: { exclude: FilterPattern }): Plugin {
   const filter = createFilter(['**/*.data', '**/*.txt'], exclude)
@@ -7,8 +8,39 @@ export function rawContent({ exclude }: { exclude: FilterPattern }): Plugin {
   return {
     name: 'string',
 
+    resolveId(id, importer) {
+      // Handle ?raw query parameter
+      if (id.includes('?raw')) {
+        const cleanId = id.split('?')[0]
+        // Resolve the actual file path
+        if (importer) {
+          const path = require('path')
+          return path.resolve(path.dirname(importer), cleanId) + '?raw'
+        }
+        return cleanId + '?raw'
+      }
+      return null
+    },
+
+    load(id) {
+      // Handle ?raw query parameter - read the actual file without the query
+      if (id.includes('?raw')) {
+        const cleanId = id.split('?')[0]
+        try {
+          return readFileSync(cleanId, 'utf-8')
+        } catch (error) {
+          this.error(`Failed to read file: ${cleanId}`)
+        }
+      }
+      return null
+    },
+
     transform(code, id) {
-      if (filter(id)) {
+      // Check if the file has ?raw query parameter
+      const isRawQuery = id.includes('?raw')
+      const cleanId = isRawQuery ? id.split('?')[0] : id
+
+      if (filter(cleanId) || isRawQuery) {
         return {
           code: `const data = ${JSON.stringify(code)};\nexport default data;`,
           map: null,

--- a/test/integration/raw-data/index.test.ts
+++ b/test/integration/raw-data/index.test.ts
@@ -1,16 +1,21 @@
 import { describe, expect, it } from 'vitest'
-import { existsSync } from 'fs'
-import { assertFilesContent, createJob } from '../../testing-utils'
-import { join } from 'path'
+import { createJob, getFileContents } from '../../testing-utils'
 
 describe('integration - raw-data', () => {
   const { distDir } = createJob({ directory: __dirname })
 
   it('should generate proper assets', async () => {
-    const distFile = join(distDir, 'index.js')
-    expect(existsSync(distFile)).toBe(true)
-    await assertFilesContent(distDir, {
-      'index.js': '"thisismydata"',
-    })
+    const contents = await getFileContents(distDir)
+    expect(contents['index.js']).toMatchInlineSnapshot(`
+      "const data$2 = "thisismydata";
+
+      const data$1 = "# Test File\\n\\nThis is a test markdown file for the \`?raw\` query parameter feature. ";
+
+      const data = data$2;
+      const rawMarkdown = data$1;
+
+      export { data, rawMarkdown };
+      "
+    `)
   })
 })

--- a/test/integration/raw-data/package.json
+++ b/test/integration/raw-data/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "raw-data",
   "type": "module",
   "exports": "./dist/index.js"
 }

--- a/test/integration/raw-data/src/index.js
+++ b/test/integration/raw-data/src/index.js
@@ -1,3 +1,5 @@
 import content from './content.txt'
+import markdownContent from './readme.md?raw'
 
 export const data = content
+export const rawMarkdown = markdownContent

--- a/test/integration/raw-data/src/readme.md
+++ b/test/integration/raw-data/src/readme.md
@@ -1,0 +1,3 @@
+# Test File
+
+This is a test markdown file for the `?raw` query parameter feature. 


### PR DESCRIPTION
You can use `?raw` source query to load any file as raw content

```
import markdownContent from './readme.md?raw'

export const rawMarkdown = markdownContent
```

Resolves #688
