### PR TITLE
refactor: replace `ora` with `nanospinner`

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "clean-css": "^5.3.3",
     "fast-glob": "^3.3.3",
     "magic-string": "^0.30.17",
-    "ora": "^8.0.1",
+    "nanospinner": "^1.2.2",
     "picomatch": "^4.0.2",
     "pretty-bytes": "^5.6.0",
     "rollup": "^4.46.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,9 @@ importers:
       magic-string:
         specifier: ^0.30.17
         version: 0.30.17
-      ora:
-        specifier: ^8.0.1
-        version: 8.0.1
+      nanospinner:
+        specifier: ^1.2.2
+        version: 1.2.2
       picomatch:
         specifier: ^4.0.2
         version: 4.0.2
@@ -1054,10 +1054,6 @@ packages:
     resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  cli-spinners@2.9.2:
-    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
-    engines: {node: '>=6'}
-
   cli-truncate@4.0.0:
     resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
     engines: {node: '>=18'}
@@ -1275,10 +1271,6 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
-  is-interactive@2.0.0:
-    resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
-    engines: {node: '>=12'}
-
   is-module@1.0.0:
     resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
 
@@ -1292,14 +1284,6 @@ packages:
   is-stream@3.0.0:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  is-unicode-supported@1.3.0:
-    resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
-    engines: {node: '>=12'}
-
-  is-unicode-supported@2.0.0:
-    resolution: {integrity: sha512-FRdAyx5lusK1iHG0TWpVtk9+1i+GjrzRffhDg4ovQ7mcidMQ6mj+MhKPmvh7Xwyv5gIS06ns49CA7Sqg7lC22Q==}
-    engines: {node: '>=18'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1388,10 +1372,6 @@ packages:
     resolution: {integrity: sha512-ovJXBXkKGfq+CwmKTjluEqFi3p4h8xvkxGQQAQan22YCgef4KZ1mKGjzfGh6PL6AW5Csw0QiQPNuQyH+6Xk3hA==}
     engines: {node: '>=18.0.0'}
 
-  log-symbols@6.0.0:
-    resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
-    engines: {node: '>=18'}
-
   log-update@6.0.0:
     resolution: {integrity: sha512-niTvB4gqvtof056rRIrTZvjNYE4rCUzO6X/X+kYjd7WFxXeJ0NwEFnRxX6ehkvv3jTwrXnNdtAak5XYZuIyPFw==}
     engines: {node: '>=18'}
@@ -1449,6 +1429,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanospinner@1.2.2:
+    resolution: {integrity: sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==}
+
   next@15.4.2-canary.42:
     resolution: {integrity: sha512-mNW8pt4dqNAAXj6hyOThq1b/axFmZh9g7pRo7e+cYBpmUOQRCjAAaq5aLgI+q875UHKiO5556fhmMEF+SINVkA==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
@@ -1481,10 +1464,6 @@ packages:
   onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
-
-  ora@8.0.1:
-    resolution: {integrity: sha512-ANIvzobt1rls2BDny5fWZ3ZVKyD6nscLvfFRpQgfWsythlcsVUC9kL0zq6j2Z5z9wwp1kd7wpsD/T9qNPVLCaQ==}
-    engines: {node: '>=18'}
 
   oxc-resolver@1.12.0:
     resolution: {integrity: sha512-YlaCIArvWNKCWZFRrMjhh2l5jK80eXnpYP+bhRc1J/7cW3TiyEY0ngJo73o/5n8hA3+4yLdTmXLNTQ3Ncz50LQ==}
@@ -1665,10 +1644,6 @@ packages:
 
   std-env@3.8.0:
     resolution: {integrity: sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==}
-
-  stdin-discarder@0.2.2:
-    resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
-    engines: {node: '>=18'}
 
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -2565,8 +2540,6 @@ snapshots:
     dependencies:
       restore-cursor: 4.0.0
 
-  cli-spinners@2.9.2: {}
-
   cli-truncate@4.0.0:
     dependencies:
       slice-ansi: 5.0.0
@@ -2771,8 +2744,6 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
-  is-interactive@2.0.0: {}
-
   is-module@1.0.0: {}
 
   is-number@7.0.0: {}
@@ -2782,10 +2753,6 @@ snapshots:
       '@types/estree': 1.0.8
 
   is-stream@3.0.0: {}
-
-  is-unicode-supported@1.3.0: {}
-
-  is-unicode-supported@2.0.0: {}
 
   isexe@2.0.0: {}
 
@@ -2865,11 +2832,6 @@ snapshots:
       rfdc: 1.3.0
       wrap-ansi: 9.0.0
 
-  log-symbols@6.0.0:
-    dependencies:
-      chalk: 5.3.0
-      is-unicode-supported: 1.3.0
-
   log-update@6.0.0:
     dependencies:
       ansi-escapes: 6.2.1
@@ -2916,6 +2878,10 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanospinner@1.2.2:
+    dependencies:
+      picocolors: 1.1.1
+
   next@15.4.2-canary.42(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       '@next/env': 15.4.2-canary.42
@@ -2950,18 +2916,6 @@ snapshots:
   onetime@6.0.0:
     dependencies:
       mimic-fn: 4.0.0
-
-  ora@8.0.1:
-    dependencies:
-      chalk: 5.3.0
-      cli-cursor: 4.0.0
-      cli-spinners: 2.9.2
-      is-interactive: 2.0.0
-      is-unicode-supported: 2.0.0
-      log-symbols: 6.0.0
-      stdin-discarder: 0.2.2
-      string-width: 7.1.0
-      strip-ansi: 7.1.0
 
   oxc-resolver@1.12.0:
     optionalDependencies:
@@ -3169,8 +3123,6 @@ snapshots:
   stackback@0.0.2: {}
 
   std-env@3.8.0: {}
-
-  stdin-discarder@0.2.2: {}
 
   string-argv@0.3.2: {}
 

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -12,6 +12,7 @@ import { prepare } from '../prepare'
 import { RollupWatcher } from 'rollup'
 import { logOutputState } from '../plugins/output-state-plugin'
 import { normalizeError } from '../lib/normalize-error'
+import { createSpinner } from 'nanospinner'
 
 const helpMessage = `
 Usage: bunchee [options]
@@ -258,18 +259,15 @@ async function run(args: CliArgs) {
   // lint package by default
   await lint(cwd)
 
-  const { default: ora } = await import('ora')
-
-  const oraInstance = process.stdout.isTTY
-    ? ora({
-        text: 'Building...\n\n',
+  const spinnerInstance = process.stdout.isTTY
+    ? createSpinner('Building...\n\n', {
         color: 'green',
       })
     : {
         start: () => {},
         stop: () => {},
         clear: () => {},
-        stopAndPersist: () => {},
+        success: () => {},
         isSpinning: false,
       }
 
@@ -279,19 +277,19 @@ async function run(args: CliArgs) {
   }
 
   function startSpinner() {
-    oraInstance.start()
+    spinnerInstance.start()
   }
 
   function stopSpinner(text?: string) {
-    if (oraInstance.isSpinning) {
-      oraInstance.clear()
+    if (spinnerInstance.isSpinning) {
+      spinnerInstance.clear()
       if (text) {
-        oraInstance.stopAndPersist({
-          symbol: '✔',
+        spinnerInstance.success({
+          mark: '✔',
           text,
         })
       } else {
-        oraInstance.stop()
+        spinnerInstance.stop()
       }
     }
   }


### PR DESCRIPTION
Replace `ora` with `nanospinner`:

- 20 times smaller than `ora`
- tiny with only single dependency
- dual CJS/ESM package (no dynamic import required)
- fulfill bunchee's requirements

---

<img width="1076" height="213" alt="image" src="https://github.com/user-attachments/assets/6a4a0fb6-355a-4654-9fc4-fb1f28b83e54" />

All tests passed locally.

<img width="950" height="292" alt="image" src="https://github.com/user-attachments/assets/e674eb45-6db2-41b5-883f-854b43e2dc90" />

Here is a demo of the final output (you can verify that with `pnpm run build`)