### PR TITLE
limit parallel rollup builds so many entries don't OOM

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -86,6 +86,10 @@ export const DEFAULT_TS_CONFIG = {
 
 export const BINARY_TAG = '$binary'
 
+// How many rollup builds run in parallel. Building every entry at once makes
+// memory scale with entry count, which OOMs on packages with many exports.
+export const DEFAULT_BUILD_CONCURRENCY = 4
+
 export const PRIVATE_GLOB_PATTERN = '**/_*/**'
 export const TESTS_GLOB_PATTERN =
   '**/{__tests__/**,__mocks__/**,*.{test,spec}.*}'

--- a/src/lib/concurrency.test.ts
+++ b/src/lib/concurrency.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import { runWithConcurrency } from './concurrency'
+
+function createTracker() {
+  let running = 0
+  let peak = 0
+  return {
+    get peak() {
+      return peak
+    },
+    task<T>(value: T, delay = 0): () => Promise<T> {
+      return async () => {
+        running++
+        peak = Math.max(peak, running)
+        await new Promise((resolve) => setTimeout(resolve, delay))
+        running--
+        return value
+      }
+    },
+  }
+}
+
+describe('runWithConcurrency', () => {
+  it('should resolve the results in the input order', async () => {
+    const tracker = createTracker()
+    const tasks = [
+      tracker.task('a', 30),
+      tracker.task('b', 10),
+      tracker.task('c', 20),
+      tracker.task('d', 0),
+    ]
+    expect(await runWithConcurrency(tasks, 2)).toEqual(['a', 'b', 'c', 'd'])
+  })
+
+  it('should never run more tasks than the limit at once', async () => {
+    const tracker = createTracker()
+    const tasks = Array.from({ length: 10 }, (_, i) => tracker.task(i, 5))
+    const results = await runWithConcurrency(tasks, 3)
+    expect(results).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    expect(tracker.peak).toBe(3)
+  })
+
+  it('should run everything at once when the limit is not finite', async () => {
+    const tracker = createTracker()
+    const tasks = Array.from({ length: 5 }, (_, i) => tracker.task(i, 5))
+    expect(await runWithConcurrency(tasks, Infinity)).toEqual([0, 1, 2, 3, 4])
+    expect(tracker.peak).toBe(5)
+  })
+
+  it('should run everything at once when the limit is zero or negative', async () => {
+    const zero = createTracker()
+    await runWithConcurrency(
+      Array.from({ length: 4 }, (_, i) => zero.task(i, 5)),
+      0,
+    )
+    expect(zero.peak).toBe(4)
+
+    const negative = createTracker()
+    await runWithConcurrency(
+      Array.from({ length: 4 }, (_, i) => negative.task(i, 5)),
+      -1,
+    )
+    expect(negative.peak).toBe(4)
+  })
+
+  it('should handle an empty task list', async () => {
+    expect(await runWithConcurrency([], 4)).toEqual([])
+  })
+
+  it('should reject when a task rejects', async () => {
+    const tasks = [
+      async () => 'ok',
+      async () => {
+        throw new Error('boom')
+      },
+    ]
+    await expect(runWithConcurrency(tasks, 2)).rejects.toThrow('boom')
+  })
+})

--- a/src/lib/concurrency.ts
+++ b/src/lib/concurrency.ts
@@ -1,0 +1,29 @@
+/**
+ * Run async tasks with a concurrency limit to prevent memory overflow.
+ * Useful for limiting parallel rollup builds, especially DTS generation.
+ */
+export async function runWithConcurrency<T>(
+  tasks: (() => Promise<T>)[],
+  limit: number,
+): Promise<T[]> {
+  if (limit <= 0 || !Number.isFinite(limit)) {
+    limit = Infinity
+  }
+
+  const results: T[] = new Array(tasks.length)
+  let currentIndex = 0
+
+  async function runNext(): Promise<void> {
+    while (currentIndex < tasks.length) {
+      const index = currentIndex++
+      results[index] = await tasks[index]()
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(limit, tasks.length) }, () =>
+    runNext(),
+  )
+
+  await Promise.all(workers)
+  return results
+}

--- a/src/rollup-job.ts
+++ b/src/rollup-job.ts
@@ -16,6 +16,8 @@ import {
 } from './types'
 import { removeOutputDir } from './utils'
 import { normalizeError } from './lib/normalize-error'
+import { runWithConcurrency } from './lib/concurrency'
+import { DEFAULT_BUILD_CONCURRENCY } from './constants'
 
 export async function createAssetRollupJobs(
   options: BundleConfig,
@@ -44,16 +46,30 @@ export async function createAssetRollupJobs(
     }
   }
 
-  const rollupJobs = allConfigs.map((rollupConfig) =>
-    bundleOrWatch(options, rollupConfig),
-  )
-
   try {
-    return await Promise.all(rollupJobs)
+    // Watchers never settle, so pooling them would stall the build. Only the
+    // one-shot build is capped.
+    if (options.watch) {
+      return await Promise.all(
+        allConfigs.map((rollupConfig) => bundleOrWatch(options, rollupConfig)),
+      )
+    }
+
+    return await runWithConcurrency(
+      allConfigs.map(
+        (rollupConfig) => () => bundleOrWatch(options, rollupConfig),
+      ),
+      getBuildConcurrency(),
+    )
   } catch (err: unknown) {
     const error = normalizeError(err)
     throw error
   }
+}
+
+function getBuildConcurrency(): number {
+  const value = Number(process.env.BUNCHEE_CONCURRENCY)
+  return Number.isFinite(value) && value > 0 ? value : DEFAULT_BUILD_CONCURRENCY
 }
 
 async function bundleOrWatch(


### PR DESCRIPTION
## what

caps how many rollup builds run at once instead of firing all of them through one `Promise.all`. defaults to 4, override with `BUNCHEE_CONCURRENCY`. watch mode is left as is, since watchers never settle and pooling them would just deadlock.

## why

i have a component library with 76 entries in `exports`. bunchee does not build it, it dies:

```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```

raising the heap does not help. 4 gb dies, 10 gb dies too. the wall is somewhere around 14 entries. below that it builds fine in about 10 seconds.

stuff i ruled out first so this is not a red herring:

- not dts. it OOMs with `--dts` too, so it is the js bundling and not type generation.
- not one bad entry. i split 27 pattern entries into 14 and 13, both halves build fine, all 27 together OOM.
- not my config. `skipLibCheck` is on and nothing imports back into the package barrel.

the cause is `allConfigs.map(...)` plus `Promise.all` in `rollup-job.ts`. every entry gets its own rollup build and they all run at the same time, so memory scales with entry count.

## note

you already wrote this. commit 5617aa0 adds `runWithConcurrency` with basically this shape, but it is sitting on a branch that is 1 ahead and 55 behind main with no PR, and it is not in 6.12.0. so i rebuilt it off current main and am sending it as a PR. close this if you would rather land your own.

in the meantime we carry a `bun patch` against 6.12.0 to get our build green, but a released fix would obviously be better.
