### PR TITLE
Fix entries silently dropped in worker builds

### DIFF
--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -199,13 +199,19 @@ async function bundle(
   const useWorkers =
     !options.watch &&
     !options._entryFilter &&
+    // Test-only, not a supported option: the tests build the same package
+    // both ways and diff the output.
+    !process.env.TEST_NO_WORKERS &&
     entryNames.length >= MIN_ENTRIES_FOR_WORKERS
 
   try {
     let assetJobs
     if (useWorkers) {
       // Clean once before fanning out; concurrent workers must not remove
-      // each other's output.
+      // each other's output. Every output directory the rollup configs would
+      // clean is covered: the export conditions hold the js dist files, plus
+      // the `types` condition when it is declared, and the types path derived
+      // from a js path when it is not always lands in the same directory.
       if (options.clean && !isFromCli) {
         for (const entry of Object.values(entries)) {
           for (const distFile of Object.values(entry.export)) {
@@ -213,7 +219,14 @@ async function bundle(
           }
         }
       }
-      const workerStats = await runEntriesInWorkers(cwd, entryNames, options)
+      const workerStats = await runEntriesInWorkers(
+        cwd,
+        // The original CLI entry, before the single-entry fallback above
+        // reassigns it — this is what the entries above were resolved with.
+        inputFile,
+        entryNames,
+        options,
+      )
       for (const stats of workerStats) {
         outputState.mergeSizeStats(stats)
       }

--- a/src/lib/worker-pool.ts
+++ b/src/lib/worker-pool.ts
@@ -1,43 +1,52 @@
 import fs from 'fs'
 import os from 'os'
-import { dirname, join } from 'path'
+import { dirname, extname, join } from 'path'
 import Piscina from 'piscina'
 import type { BundleConfig } from '../types'
 import type { SizeStats } from '../plugins/output-state-plugin'
-import type { EntryWorkerTask } from '../worker'
+import type { ErrorDetails, EntryWorkerTask } from '../worker'
+import { logger, pauseActiveSpinner } from '../logger'
 
 // Below this entry count builds stay in-process: a handful of module graphs
 // fits comfortably in one heap, and skipping the pool avoids worker startup.
 export const MIN_ENTRIES_FOR_WORKERS = 8
 
-// The handler is loaded from this file by its export name, so no separate
-// worker asset needs to exist in dist.
+// The handler is loaded from a file by its export name, so no separate worker
+// asset needs to exist in dist.
 export const WORKER_HANDLER_NAME = 'buildEntryInWorker'
 
 function resolveWorkerFile(): string {
-  // This code runs from src/lib/ in dev and is bundled into dist/index.js and
-  // dist/bin/cli.js when compiled, so locate the package root first and
-  // resolve the worker from there. When running from source, worker threads
-  // inherit execArgv, so the TypeScript register hook loads the .ts worker.
-  let packageRoot = __dirname
-  while (!fs.existsSync(join(packageRoot, 'package.json'))) {
-    packageRoot = dirname(packageRoot)
-  }
-  return join(
-    packageRoot,
-    __filename.endsWith('.ts') ? 'src/worker.ts' : 'dist/index.js',
-  )
+  // Running from source, the handler is a sibling module. Bundled, this code
+  // is only ever reachable through the package's main entry — the bin requires
+  // that entry rather than inlining it — and the same bundle re-exports the
+  // handler, so the file to hand piscina is the one this code is running from.
+  const sibling = join(dirname(__dirname), `worker${extname(__filename)}`)
+  return fs.existsSync(sibling) ? sibling : __filename
 }
 
-// Build each entry in its own worker so every entry's module graphs live in
-// an isolated V8 heap: peak memory per heap is one entry, not the whole
-// package, no matter how many entries there are.
+function restoreErrorDetails(error: any): unknown {
+  const details: ErrorDetails | undefined = error?.cause
+  if (!details?.props) {
+    // Not one of ours: a worker that exited, or a task failed by pool.destroy.
+    return error
+  }
+  delete error.cause
+  error.name = details.name
+  return Object.assign(error, details.props)
+}
+
+// Build entries in a pool of worker threads so a single entry's module graphs
+// never share a heap with the rest of the package. Threads are reused across
+// entries, so a heap can hold more than one entry's garbage over time — what
+// it never holds is all of them at once.
 export async function runEntriesInWorkers(
   cwd: string,
+  cliEntryPath: string,
   entryNames: string[],
   options: BundleConfig,
 ): Promise<SizeStats[]> {
-  const { _callbacks, onSuccess, ...plainOptions } = options
+  // `_callbacks` holds functions, which structured clone cannot move.
+  const { _callbacks, ...plainOptions } = options
   const pool = new Piscina({
     filename: resolveWorkerFile(),
     maxThreads: Math.max(
@@ -48,16 +57,34 @@ export async function runEntriesInWorkers(
       ),
     ),
   })
+  const resumeSpinner = pauseActiveSpinner()
+  if (process.env.DEBUG) {
+    logger.log(
+      `Building ${entryNames.length} entries in ${pool.maxThreads} worker threads`,
+    )
+  }
+
   try {
     return await Promise.all(
       entryNames.map((entryName) => {
-        const task: EntryWorkerTask = { cwd, entryName, options: plainOptions }
+        const task: EntryWorkerTask = {
+          cwd,
+          cliEntryPath,
+          entryName,
+          options: plainOptions,
+        }
         return pool.run(task, {
           name: WORKER_HANDLER_NAME,
         }) as Promise<SizeStats>
       }),
     )
+  } catch (error) {
+    // The first entry to fail rejects here, and destroying the pool below
+    // fails whatever is still queued — the rest of the package is not built
+    // just to be thrown away.
+    throw restoreErrorDetails(error)
   } finally {
     await pool.destroy()
+    resumeSpinner()
   }
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -10,6 +10,7 @@ type SpinnerLike = {
   isSpinning: boolean | (() => boolean)
   clear: () => void
   start: () => void
+  stop?: () => void
 }
 
 let activeSpinner: SpinnerLike | null = null
@@ -63,6 +64,26 @@ export function setActiveSpinner(spinner: SpinnerLike | null) {
     console.warn = originalConsole.warn
     console.error = originalConsole.error
     console.info = originalConsole.info
+  }
+}
+
+/**
+ * Stop animating the spinner until the returned function is called.
+ *
+ * The console patch above only pauses the spinner for writes made on this
+ * thread. Worker threads write straight to the shared stdout, so the spinner
+ * has to be parked for as long as they are running or their output gets
+ * interleaved with spinner frames.
+ */
+export function pauseActiveSpinner(): () => void {
+  if (!isSpinnerActive() || !activeSpinner) {
+    return () => {}
+  }
+  const spinner = activeSpinner
+  spinner.clear()
+  spinner.stop?.()
+  return () => {
+    spinner.start()
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,10 +62,13 @@ type BundleConfig = {
     onBuildStart?: (state: any) => void
 
     /*
-     * This hook is called before the build starts
+     * This hook is called when the build finishes.
+     * `assetJobs` holds one item per completed build job; what the items are
+     * depends on the path taken (rollup outputs, watchers, or per-entry size
+     * stats from the worker pool), so only its length is meaningful.
      * @experimental
      */
-    onBuildEnd?: (assetJobs: any) => void
+    onBuildEnd?: (assetJobs: any[]) => void
 
     /*
      * This hook is called when the build errors

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -4,35 +4,84 @@ import bundle from './bundle'
 
 export type EntryWorkerTask = {
   cwd: string
+  cliEntryPath: string
   entryName: string
   options: BundleConfig
 }
 
-// Piscina task: build a single entry (all of its output formats and types)
-// in this worker's own isolate, so its module graphs never share a heap with
-// other entries. Returns the size stats for the main thread's output table.
-// Loaded by name from src/worker.ts in dev and from dist/index.js when
-// compiled — a named export is what makes the single handler work for both.
+// Everything crossing a thread boundary goes through structured clone, and for
+// an Error that keeps the message, the stack and the cause — dropping the name
+// along with the frame/loc/id/plugin/code that make a rollup error readable.
+// The cause does survive, so the rest travels in there and is put back on the
+// main thread.
+export type ErrorDetails = {
+  name: string
+  props: Record<string, unknown>
+}
+
+function isCloneable(value: unknown): boolean {
+  try {
+    structuredClone(value)
+    return true
+  } catch {
+    // A plugin is free to hang a function or a class instance off its error.
+    return false
+  }
+}
+
+function toTransferableError(error: any): Error {
+  const props: Record<string, unknown> = {}
+  const keys = error && typeof error === 'object' ? Object.keys(error) : []
+  for (const key of keys) {
+    if (isCloneable(error[key])) {
+      props[key] = error[key]
+    }
+  }
+  const details: ErrorDetails = { name: error?.name ?? 'Error', props }
+  const transferable = new Error(error?.message ?? String(error))
+  // Assigned rather than passed to the constructor: the project targets ES2019
+  // and structured clone picks up an own `cause` property either way.
+  ;(transferable as Error & { cause?: ErrorDetails }).cause = details
+  transferable.stack = error?.stack
+  return transferable
+}
+
+// Piscina task: build a single entry (all of its output formats and types) in
+// this worker's own isolate, so its module graphs never share a heap with the
+// entries handed to other threads. Returns the size stats for the main
+// thread's output table.
+// Loaded by name from src/worker.ts in dev and from the package's main bundle
+// when compiled — a named export is what makes the single handler work for
+// both.
 /** @internal */
 export async function buildEntryInWorker({
   cwd,
+  cliEntryPath,
   entryName,
   options,
 }: EntryWorkerTask): Promise<SizeStats> {
   let buildContext: BuildContext | undefined
-  await bundle('', {
-    ...options,
-    cwd,
-    // The output directory is cleaned once on the main thread before the
-    // entries are dispatched; workers run concurrently and must not remove
-    // each other's output.
-    clean: false,
-    _entryFilter: [entryName],
-    _callbacks: {
-      onBuildStart(context: BuildContext) {
-        buildContext = context
+  try {
+    // cliEntryPath decides `isFromCli` and can override the source of the
+    // `./index` entry, so it has to be replayed here — otherwise this worker
+    // resolves a different set of entries than the main thread listed, and
+    // the assigned entry silently builds nothing.
+    await bundle(cliEntryPath, {
+      ...options,
+      cwd,
+      // The output directory is cleaned once on the main thread before the
+      // entries are dispatched; workers run concurrently and must not remove
+      // each other's output.
+      clean: false,
+      _entryFilter: [entryName],
+      _callbacks: {
+        onBuildStart(context: BuildContext) {
+          buildContext = context
+        },
       },
-    },
-  })
+    })
+  } catch (error) {
+    throw toTransferableError(error)
+  }
   return buildContext?.pluginContext.outputState.getSizeStats() ?? new Map()
 }

--- a/test/integration/many-entries-cli/index.test.ts
+++ b/test/integration/many-entries-cli/index.test.ts
@@ -1,0 +1,48 @@
+import path from 'path'
+import { afterAll, describe, expect, it } from 'vitest'
+import { getFileNamesFromDirectory, removeDirectory } from '../../testing-utils'
+import { executeBunchee } from '../../testing-utils/shared'
+
+// Nine entries, so the build fans out to workers, and the `.` export has no
+// src/index.ts behind it — it exists only because an entry file is passed on
+// the command line. A worker that does not replay that entry path resolves a
+// different entries map than the main thread listed, and silently builds
+// nothing for the entry it was assigned.
+const dir = __dirname
+const distDir = path.join(dir, 'dist')
+
+async function build(env: NodeJS.ProcessEnv = {}) {
+  await removeDirectory(distDir)
+  const result = await executeBunchee(['./src/custom-entry.ts', '--cwd', dir], {
+    env,
+  })
+  expect(result.stderr).toBe('')
+  expect(result.code).toBe(0)
+  return {
+    files: await getFileNamesFromDirectory(distDir),
+    stdout: result.stdout,
+  }
+}
+
+describe('integration - many-entries-cli', () => {
+  afterAll(async () => {
+    if (!process.env.TEST_NOT_CLEANUP) {
+      await removeDirectory(distDir)
+    }
+  })
+
+  it('should build the entry file passed on the command line', async () => {
+    const { files, stdout } = await build()
+
+    expect(files).toContain('index.d.ts')
+    // The `.` export is reported, not dropped on the floor.
+    expect(stdout).toMatch(/^\.\s+dist\/index\.d\.ts/m)
+  }, 120_000)
+
+  it('should produce the same output as an in-process build', async () => {
+    const workers = await build()
+    const inProcess = await build({ TEST_NO_WORKERS: '1' })
+
+    expect(inProcess.files).toEqual(workers.files)
+  }, 240_000)
+})

--- a/test/integration/many-entries-cli/index.test.ts
+++ b/test/integration/many-entries-cli/index.test.ts
@@ -1,6 +1,10 @@
 import path from 'path'
 import { afterAll, describe, expect, it } from 'vitest'
-import { getFileNamesFromDirectory, removeDirectory } from '../../testing-utils'
+import {
+  getFileNamesFromDirectory,
+  removeDirectory,
+  stripANSIColor,
+} from '../../testing-utils'
 import { executeBunchee } from '../../testing-utils/shared'
 
 // Nine entries, so the build fans out to workers, and the `.` export has no
@@ -20,7 +24,9 @@ async function build(env: NodeJS.ProcessEnv = {}) {
   expect(result.code).toBe(0)
   return {
     files: await getFileNamesFromDirectory(distDir),
-    stdout: result.stdout,
+    // The size table is colorized whenever picocolors thinks the terminal
+    // supports it, which includes any environment setting CI.
+    stdout: stripANSIColor(result.stdout),
   }
 }
 

--- a/test/integration/many-entries-cli/package.json
+++ b/test/integration/many-entries-cli/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "many-entries-cli",
+  "version": "0.0.0",
+  "type": "module",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./a": {
+      "types": "./dist/a.d.ts",
+      "import": "./dist/a.js"
+    },
+    "./b": {
+      "types": "./dist/b.d.ts",
+      "import": "./dist/b.js"
+    },
+    "./c": {
+      "types": "./dist/c.d.ts",
+      "import": "./dist/c.js"
+    },
+    "./d": {
+      "types": "./dist/d.d.ts",
+      "import": "./dist/d.js"
+    },
+    "./e": {
+      "types": "./dist/e.d.ts",
+      "import": "./dist/e.js"
+    },
+    "./f": {
+      "types": "./dist/f.d.ts",
+      "import": "./dist/f.js"
+    },
+    "./g": {
+      "types": "./dist/g.d.ts",
+      "import": "./dist/g.js"
+    },
+    "./h": {
+      "types": "./dist/h.d.ts",
+      "import": "./dist/h.js"
+    }
+  }
+}

--- a/test/integration/many-entries-cli/src/a.ts
+++ b/test/integration/many-entries-cli/src/a.ts
@@ -1,0 +1,1 @@
+export const a = 'a'

--- a/test/integration/many-entries-cli/src/b.ts
+++ b/test/integration/many-entries-cli/src/b.ts
@@ -1,0 +1,1 @@
+export const b = 'b'

--- a/test/integration/many-entries-cli/src/c.ts
+++ b/test/integration/many-entries-cli/src/c.ts
@@ -1,0 +1,1 @@
+export const c = 'c'

--- a/test/integration/many-entries-cli/src/custom-entry.ts
+++ b/test/integration/many-entries-cli/src/custom-entry.ts
@@ -1,0 +1,1 @@
+export const index = 'custom-entry'

--- a/test/integration/many-entries-cli/src/d.ts
+++ b/test/integration/many-entries-cli/src/d.ts
@@ -1,0 +1,1 @@
+export const d = 'd'

--- a/test/integration/many-entries-cli/src/e.ts
+++ b/test/integration/many-entries-cli/src/e.ts
@@ -1,0 +1,1 @@
+export const e = 'e'

--- a/test/integration/many-entries-cli/src/f.ts
+++ b/test/integration/many-entries-cli/src/f.ts
@@ -1,0 +1,1 @@
+export const f = 'f'

--- a/test/integration/many-entries-cli/src/g.ts
+++ b/test/integration/many-entries-cli/src/g.ts
@@ -1,0 +1,1 @@
+export const g = 'g'

--- a/test/integration/many-entries-cli/src/h.ts
+++ b/test/integration/many-entries-cli/src/h.ts
@@ -1,0 +1,1 @@
+export const h = 'h'

--- a/test/integration/many-entries/index.test.ts
+++ b/test/integration/many-entries/index.test.ts
@@ -1,0 +1,79 @@
+import path from 'path'
+import { afterAll, describe, expect, it } from 'vitest'
+import {
+  getFileContents,
+  getFileNamesFromDirectory,
+  removeDirectory,
+} from '../../testing-utils'
+import { executeBunchee } from '../../testing-utils/shared'
+
+// Nine entries, above MIN_ENTRIES_FOR_WORKERS, with no directive layers: this
+// is the fixture that takes the worker pool path.
+const dir = __dirname
+const distDir = path.join(dir, 'dist')
+
+async function build(env: NodeJS.ProcessEnv = {}) {
+  await removeDirectory(distDir)
+  const result = await executeBunchee(['--cwd', dir], { env })
+  expect(result.stderr).toBe('')
+  expect(result.code).toBe(0)
+  return {
+    stdout: result.stdout,
+    files: await getFileNamesFromDirectory(distDir),
+    contents: await getFileContents(distDir),
+  }
+}
+
+describe('integration - many-entries', () => {
+  afterAll(async () => {
+    if (!process.env.TEST_NOT_CLEANUP) {
+      await removeDirectory(distDir)
+    }
+  })
+
+  it('should build every entry', async () => {
+    const { files, contents } = await build()
+
+    expect(files).toMatchInlineSnapshot(`
+      [
+        "a.d.ts",
+        "a.js",
+        "b.d.ts",
+        "b.js",
+        "c.d.ts",
+        "c.js",
+        "d.d.ts",
+        "d.js",
+        "e.d.ts",
+        "e.js",
+        "f.d.ts",
+        "f.js",
+        "g.d.ts",
+        "g.js",
+        "h.d.ts",
+        "h.js",
+        "index.d.ts",
+        "index.js",
+      ]
+    `)
+    // The entry that imports a sibling entry keeps it external instead of
+    // inlining it, which the worker has to get right from its own copy of the
+    // full entries map.
+    expect(contents['index.js']).toContain(`from './a.js'`)
+    expect(contents['index.js']).not.toContain(`'a:'`)
+  }, 120_000)
+
+  it('should produce the same output as an in-process build', async () => {
+    const workers = await build({ DEBUG: '1' })
+    const inProcess = await build({ DEBUG: '1', TEST_NO_WORKERS: '1' })
+
+    // Guard the comparison: it only means anything if the first build really
+    // did fan out. Runs from source and from dist resolve the worker file
+    // differently, so this has to hold for both.
+    expect(workers.stdout).toMatch(/Building 9 entries in \d+ worker threads/)
+    expect(inProcess.stdout).not.toContain('worker threads')
+
+    expect(inProcess.files).toEqual(workers.files)
+    expect(inProcess.contents).toEqual(workers.contents)
+  }, 240_000)
+})

--- a/test/integration/many-entries/package.json
+++ b/test/integration/many-entries/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "many-entries",
+  "version": "0.0.0",
+  "type": "module",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./a": {
+      "types": "./dist/a.d.ts",
+      "import": "./dist/a.js"
+    },
+    "./b": {
+      "types": "./dist/b.d.ts",
+      "import": "./dist/b.js"
+    },
+    "./c": {
+      "types": "./dist/c.d.ts",
+      "import": "./dist/c.js"
+    },
+    "./d": {
+      "types": "./dist/d.d.ts",
+      "import": "./dist/d.js"
+    },
+    "./e": {
+      "types": "./dist/e.d.ts",
+      "import": "./dist/e.js"
+    },
+    "./f": {
+      "types": "./dist/f.d.ts",
+      "import": "./dist/f.js"
+    },
+    "./g": {
+      "types": "./dist/g.d.ts",
+      "import": "./dist/g.js"
+    },
+    "./h": {
+      "types": "./dist/h.d.ts",
+      "import": "./dist/h.js"
+    }
+  }
+}

--- a/test/integration/many-entries/src/a.ts
+++ b/test/integration/many-entries/src/a.ts
@@ -1,0 +1,3 @@
+import { shared } from './shared'
+
+export const a = 'a:' + shared

--- a/test/integration/many-entries/src/b.ts
+++ b/test/integration/many-entries/src/b.ts
@@ -1,0 +1,3 @@
+import { shared } from './shared'
+
+export const b = 'b:' + shared

--- a/test/integration/many-entries/src/c.ts
+++ b/test/integration/many-entries/src/c.ts
@@ -1,0 +1,3 @@
+import { shared } from './shared'
+
+export const c = 'c:' + shared

--- a/test/integration/many-entries/src/d.ts
+++ b/test/integration/many-entries/src/d.ts
@@ -1,0 +1,3 @@
+import { shared } from './shared'
+
+export const d = 'd:' + shared

--- a/test/integration/many-entries/src/e.ts
+++ b/test/integration/many-entries/src/e.ts
@@ -1,0 +1,3 @@
+import { shared } from './shared'
+
+export const e = 'e:' + shared

--- a/test/integration/many-entries/src/f.ts
+++ b/test/integration/many-entries/src/f.ts
@@ -1,0 +1,3 @@
+import { shared } from './shared'
+
+export const f = 'f:' + shared

--- a/test/integration/many-entries/src/g.ts
+++ b/test/integration/many-entries/src/g.ts
@@ -1,0 +1,3 @@
+import { shared } from './shared'
+
+export const g = 'g:' + shared

--- a/test/integration/many-entries/src/h.ts
+++ b/test/integration/many-entries/src/h.ts
@@ -1,0 +1,3 @@
+import { shared } from './shared'
+
+export const h = 'h:' + shared

--- a/test/integration/many-entries/src/index.ts
+++ b/test/integration/many-entries/src/index.ts
@@ -1,0 +1,4 @@
+import { a } from './a'
+import { shared } from './shared'
+
+export const index = 'index:' + a + ':' + shared

--- a/test/integration/many-entries/src/shared.ts
+++ b/test/integration/many-entries/src/shared.ts
@@ -1,0 +1,1 @@
+export const shared = 'shared'


### PR DESCRIPTION
Follow-up to #739. Self-contained fixes to the worker build path; no change to when the pool is used or how much it builds at once.

## An entry file passed on the command line was silently dropped

`bunchee ./src/entry.ts` produced no output for that entry on a package with enough exports to fan out — no error, just a missing file and a missing row in the size table.

The CLI entry path decides `isFromCli` and overrides the source of the `./index` entry, but workers called `bundle('')`. Each one rebuilt the entries map without it and resolved a different set of entries than the main thread had listed, so the worker assigned to `./index` found nothing to build whenever that entry existed only because of the CLI argument. Workers now replay the entry path they were dispatched with.

## Errors lost their detail crossing the thread boundary

Structured clone keeps an Error's `message`, `stack` and `cause` and drops the rest, so rollup's `frame`, `loc`, `id`, `plugin` and `code` never arrived and a syntax error in a fanned-out build printed without its code frame. Those fields now ride along in `cause` and are reattached on the main thread — a broken build prints identically whether or not it fanned out.

## Smaller things

- The spinner is parked while workers write to the shared stdout. The console patch that pauses it only covers main-thread writes, so worker output was interleaving with spinner frames.
- The worker file is resolved as a sibling module when running from source, and as the running bundle when compiled. The bin requires the package entry rather than inlining it, so the pool code only ever executes from a bundle that also re-exports the handler.

`TEST_NO_WORKERS` is test-only, not a supported option — the tests use it to build the same package both ways and diff the output.

Two things this deliberately leaves alone, each in its own PR: chunk splitting for packages with directives (#741) and how much a non-fanned-out build holds at once (#742).