### PR TITLE
Keep packages with directives off the worker pool

### DIFF
--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -15,6 +15,7 @@ import {
   removeOutputDir,
 } from './utils'
 import { MIN_ENTRIES_FOR_WORKERS, runEntriesInWorkers } from './lib/worker-pool'
+import { hasDirectiveLayers } from './lib/directives'
 import { getExportFileTypePath, parseExports } from './exports'
 import type { BuildContext } from './types'
 import {
@@ -196,13 +197,19 @@ async function bundle(
   // With many entries, every entry's rollup build shares one heap and peak
   // memory scales with entry count, which OOMs on packages with many exports.
   // Build each entry in its own worker instead, one isolated heap per entry.
+  //
+  // Packages with directive layers are excluded: chunk splitting for those
+  // reads state that every entry's build contributes to
+  // (`pluginContext.moduleDirectiveLayerMap`), and a worker only sees the one
+  // entry it was given, which would split chunks differently.
   const useWorkers =
     !options.watch &&
     !options._entryFilter &&
     // Test-only, not a supported option: the tests build the same package
     // both ways and diff the output.
     !process.env.TEST_NO_WORKERS &&
-    entryNames.length >= MIN_ENTRIES_FOR_WORKERS
+    entryNames.length >= MIN_ENTRIES_FOR_WORKERS &&
+    !(await hasDirectiveLayers(cwd, entries))
 
   try {
     let assetJobs

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -199,13 +199,19 @@ async function bundle(
   const useWorkers =
     !options.watch &&
     !options._entryFilter &&
+    // Test-only, not a supported option: the tests build the same package
+    // both ways and diff the output.
+    !process.env.TEST_NO_WORKERS &&
     entryNames.length >= MIN_ENTRIES_FOR_WORKERS
 
   try {
     let assetJobs
     if (useWorkers) {
       // Clean once before fanning out; concurrent workers must not remove
-      // each other's output.
+      // each other's output. Every output directory the rollup configs would
+      // clean is covered: the export conditions hold the js dist files, plus
+      // the `types` condition when it is declared, and the types path derived
+      // from a js path when it is not always lands in the same directory.
       if (options.clean && !isFromCli) {
         for (const entry of Object.values(entries)) {
           for (const distFile of Object.values(entry.export)) {
@@ -213,7 +219,14 @@ async function bundle(
           }
         }
       }
-      const workerStats = await runEntriesInWorkers(cwd, entryNames, options)
+      const workerStats = await runEntriesInWorkers(
+        cwd,
+        // The original CLI entry, before the single-entry fallback above
+        // reassigns it — this is what the entries above were resolved with.
+        inputFile,
+        entryNames,
+        options,
+      )
       for (const stats of workerStats) {
         outputState.mergeSizeStats(stats)
       }

--- a/src/lib/directives.test.ts
+++ b/src/lib/directives.test.ts
@@ -1,0 +1,85 @@
+import fsp from 'fs/promises'
+import os from 'os'
+import path from 'path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { hasDirectiveLayers } from './directives'
+import type { Entries } from '../types'
+
+const tmpDirs: string[] = []
+
+async function createPackage(files: Record<string, string>) {
+  const cwd = await fsp.mkdtemp(path.join(os.tmpdir(), 'bunchee-directives-'))
+  tmpDirs.push(cwd)
+  for (const [filePath, content] of Object.entries(files)) {
+    const fullPath = path.join(cwd, filePath)
+    await fsp.mkdir(path.dirname(fullPath), { recursive: true })
+    await fsp.writeFile(fullPath, content)
+  }
+  return cwd
+}
+
+function entriesOf(...sources: string[]): Entries {
+  return Object.fromEntries(
+    sources.map((source, index) => [
+      `./entry-${index}`,
+      { source, name: '.', export: {} },
+    ]),
+  ) as unknown as Entries
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tmpDirs
+      .splice(0)
+      .map((dir) => fsp.rm(dir, { recursive: true, force: true })),
+  )
+})
+
+describe('hasDirectiveLayers', () => {
+  it('should not report a package without directives', async () => {
+    const cwd = await createPackage({
+      'src/index.ts': `export const index = 'index'\n`,
+      'src/lib/util.ts': `export const util = 'not use client'\n`,
+    })
+    expect(await hasDirectiveLayers(cwd, entriesOf())).toBe(false)
+  })
+
+  it('should ignore use strict', async () => {
+    const cwd = await createPackage({
+      'src/index.ts': `'use strict'\n\nexport const index = 'index'\n`,
+    })
+    expect(await hasDirectiveLayers(cwd, entriesOf())).toBe(false)
+  })
+
+  it('should find a directive nested under src', async () => {
+    const cwd = await createPackage({
+      'src/index.ts': `export const index = 'index'\n`,
+      'src/lib/deep/context.tsx': `'use client'\n\nexport const ctx = 1\n`,
+    })
+    expect(await hasDirectiveLayers(cwd, entriesOf())).toBe(true)
+  })
+
+  it('should find a double quoted server directive', async () => {
+    const cwd = await createPackage({
+      'src/action.ts': `"use server"\n\nexport async function act() {}\n`,
+    })
+    expect(await hasDirectiveLayers(cwd, entriesOf())).toBe(true)
+  })
+
+  it('should skip node_modules', async () => {
+    const cwd = await createPackage({
+      'src/index.ts': `export const index = 'index'\n`,
+      'src/node_modules/dep/index.js': `'use client'\n`,
+    })
+    expect(await hasDirectiveLayers(cwd, entriesOf())).toBe(false)
+  })
+
+  it('should check entry sources outside of src', async () => {
+    const cwd = await createPackage({
+      'src/index.ts': `export const index = 'index'\n`,
+      'lib/entry.ts': `'use client'\n\nexport const entry = 1\n`,
+    })
+    const outsideEntry = path.join(cwd, 'lib/entry.ts')
+    expect(await hasDirectiveLayers(cwd, entriesOf(outsideEntry))).toBe(true)
+  })
+})

--- a/src/lib/directives.ts
+++ b/src/lib/directives.ts
@@ -1,0 +1,86 @@
+import fsp from 'fs/promises'
+import path from 'path'
+import type { Entries } from '../types'
+import { SRC } from '../constants'
+import { hasAvailableExtension } from '../utils'
+
+// A directive other than 'use strict' gives a module a layer, and layers are
+// what `createSplitChunks` uses to decide chunk boundaries. Matching anywhere
+// in the file rather than only at the top is deliberate: a false positive only
+// costs the worker fan-out, while a false negative would change output.
+const DIRECTIVE_REGEX = /^\s*(['"])use (?!strict\1)[a-z][a-z-]*\1\s*;?\s*$/m
+
+const IGNORED_DIRS = new Set(['node_modules', '.git', 'dist'])
+
+async function anyFileHasDirective(dir: string): Promise<boolean> {
+  let dirents
+  try {
+    dirents = await fsp.readdir(dir, { withFileTypes: true })
+  } catch {
+    return false
+  }
+
+  const subDirs: string[] = []
+  for (const dirent of dirents) {
+    const entryPath = path.join(dir, dirent.name)
+    if (dirent.isDirectory()) {
+      if (!IGNORED_DIRS.has(dirent.name)) {
+        subDirs.push(entryPath)
+      }
+      continue
+    }
+    if (!dirent.isFile() || !hasAvailableExtension(dirent.name)) {
+      continue
+    }
+    if (await fileHasDirective(entryPath)) {
+      return true
+    }
+  }
+
+  for (const subDir of subDirs) {
+    if (await anyFileHasDirective(subDir)) {
+      return true
+    }
+  }
+  return false
+}
+
+async function fileHasDirective(filePath: string): Promise<boolean> {
+  try {
+    return DIRECTIVE_REGEX.test(await fsp.readFile(filePath, 'utf-8'))
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Whether any source file in the package carries a directive such as
+ * 'use client' or 'use server'.
+ *
+ * Chunk splitting for layered modules depends on state that every entry's
+ * build contributes to and reads back (`pluginContext.moduleDirectiveLayerMap`),
+ * so those packages have to keep building in one process — a worker only ever
+ * sees the modules of the single entry assigned to it, which would split
+ * chunks differently.
+ */
+export async function hasDirectiveLayers(
+  cwd: string,
+  entries: Entries,
+): Promise<boolean> {
+  if (await anyFileHasDirective(path.join(cwd, SRC))) {
+    return true
+  }
+  // Entries can point outside of src/, e.g. when the entry file is passed on
+  // the command line.
+  const srcDir = path.resolve(cwd, SRC)
+  const outsideSources = Object.values(entries)
+    .map((entry) => entry.source)
+    .filter((source) => !path.resolve(source).startsWith(srcDir + path.sep))
+
+  for (const source of outsideSources) {
+    if (await fileHasDirective(source)) {
+      return true
+    }
+  }
+  return false
+}

--- a/src/lib/worker-pool.ts
+++ b/src/lib/worker-pool.ts
@@ -1,43 +1,52 @@
 import fs from 'fs'
 import os from 'os'
-import { dirname, join } from 'path'
+import { dirname, extname, join } from 'path'
 import Piscina from 'piscina'
 import type { BundleConfig } from '../types'
 import type { SizeStats } from '../plugins/output-state-plugin'
-import type { EntryWorkerTask } from '../worker'
+import type { ErrorDetails, EntryWorkerTask } from '../worker'
+import { logger, pauseActiveSpinner } from '../logger'
 
 // Below this entry count builds stay in-process: a handful of module graphs
 // fits comfortably in one heap, and skipping the pool avoids worker startup.
 export const MIN_ENTRIES_FOR_WORKERS = 8
 
-// The handler is loaded from this file by its export name, so no separate
-// worker asset needs to exist in dist.
+// The handler is loaded from a file by its export name, so no separate worker
+// asset needs to exist in dist.
 export const WORKER_HANDLER_NAME = 'buildEntryInWorker'
 
 function resolveWorkerFile(): string {
-  // This code runs from src/lib/ in dev and is bundled into dist/index.js and
-  // dist/bin/cli.js when compiled, so locate the package root first and
-  // resolve the worker from there. When running from source, worker threads
-  // inherit execArgv, so the TypeScript register hook loads the .ts worker.
-  let packageRoot = __dirname
-  while (!fs.existsSync(join(packageRoot, 'package.json'))) {
-    packageRoot = dirname(packageRoot)
-  }
-  return join(
-    packageRoot,
-    __filename.endsWith('.ts') ? 'src/worker.ts' : 'dist/index.js',
-  )
+  // Running from source, the handler is a sibling module. Bundled, this code
+  // is only ever reachable through the package's main entry — the bin requires
+  // that entry rather than inlining it — and the same bundle re-exports the
+  // handler, so the file to hand piscina is the one this code is running from.
+  const sibling = join(dirname(__dirname), `worker${extname(__filename)}`)
+  return fs.existsSync(sibling) ? sibling : __filename
 }
 
-// Build each entry in its own worker so every entry's module graphs live in
-// an isolated V8 heap: peak memory per heap is one entry, not the whole
-// package, no matter how many entries there are.
+function restoreErrorDetails(error: any): unknown {
+  const details: ErrorDetails | undefined = error?.cause
+  if (!details?.props) {
+    // Not one of ours: a worker that exited, or a task failed by pool.destroy.
+    return error
+  }
+  delete error.cause
+  error.name = details.name
+  return Object.assign(error, details.props)
+}
+
+// Build entries in a pool of worker threads so a single entry's module graphs
+// never share a heap with the rest of the package. Threads are reused across
+// entries, so a heap can hold more than one entry's garbage over time — what
+// it never holds is all of them at once.
 export async function runEntriesInWorkers(
   cwd: string,
+  cliEntryPath: string,
   entryNames: string[],
   options: BundleConfig,
 ): Promise<SizeStats[]> {
-  const { _callbacks, onSuccess, ...plainOptions } = options
+  // `_callbacks` holds functions, which structured clone cannot move.
+  const { _callbacks, ...plainOptions } = options
   const pool = new Piscina({
     filename: resolveWorkerFile(),
     maxThreads: Math.max(
@@ -48,16 +57,34 @@ export async function runEntriesInWorkers(
       ),
     ),
   })
+  const resumeSpinner = pauseActiveSpinner()
+  if (process.env.DEBUG) {
+    logger.log(
+      `Building ${entryNames.length} entries in ${pool.maxThreads} worker threads`,
+    )
+  }
+
   try {
     return await Promise.all(
       entryNames.map((entryName) => {
-        const task: EntryWorkerTask = { cwd, entryName, options: plainOptions }
+        const task: EntryWorkerTask = {
+          cwd,
+          cliEntryPath,
+          entryName,
+          options: plainOptions,
+        }
         return pool.run(task, {
           name: WORKER_HANDLER_NAME,
         }) as Promise<SizeStats>
       }),
     )
+  } catch (error) {
+    // The first entry to fail rejects here, and destroying the pool below
+    // fails whatever is still queued — the rest of the package is not built
+    // just to be thrown away.
+    throw restoreErrorDetails(error)
   } finally {
     await pool.destroy()
+    resumeSpinner()
   }
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -10,6 +10,7 @@ type SpinnerLike = {
   isSpinning: boolean | (() => boolean)
   clear: () => void
   start: () => void
+  stop?: () => void
 }
 
 let activeSpinner: SpinnerLike | null = null
@@ -63,6 +64,26 @@ export function setActiveSpinner(spinner: SpinnerLike | null) {
     console.warn = originalConsole.warn
     console.error = originalConsole.error
     console.info = originalConsole.info
+  }
+}
+
+/**
+ * Stop animating the spinner until the returned function is called.
+ *
+ * The console patch above only pauses the spinner for writes made on this
+ * thread. Worker threads write straight to the shared stdout, so the spinner
+ * has to be parked for as long as they are running or their output gets
+ * interleaved with spinner frames.
+ */
+export function pauseActiveSpinner(): () => void {
+  if (!isSpinnerActive() || !activeSpinner) {
+    return () => {}
+  }
+  const spinner = activeSpinner
+  spinner.clear()
+  spinner.stop?.()
+  return () => {
+    spinner.start()
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,10 +62,13 @@ type BundleConfig = {
     onBuildStart?: (state: any) => void
 
     /*
-     * This hook is called before the build starts
+     * This hook is called when the build finishes.
+     * `assetJobs` holds one item per completed build job; what the items are
+     * depends on the path taken (rollup outputs, watchers, or per-entry size
+     * stats from the worker pool), so only its length is meaningful.
      * @experimental
      */
-    onBuildEnd?: (assetJobs: any) => void
+    onBuildEnd?: (assetJobs: any[]) => void
 
     /*
      * This hook is called when the build errors

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -4,35 +4,84 @@ import bundle from './bundle'
 
 export type EntryWorkerTask = {
   cwd: string
+  cliEntryPath: string
   entryName: string
   options: BundleConfig
 }
 
-// Piscina task: build a single entry (all of its output formats and types)
-// in this worker's own isolate, so its module graphs never share a heap with
-// other entries. Returns the size stats for the main thread's output table.
-// Loaded by name from src/worker.ts in dev and from dist/index.js when
-// compiled — a named export is what makes the single handler work for both.
+// Everything crossing a thread boundary goes through structured clone, and for
+// an Error that keeps the message, the stack and the cause — dropping the name
+// along with the frame/loc/id/plugin/code that make a rollup error readable.
+// The cause does survive, so the rest travels in there and is put back on the
+// main thread.
+export type ErrorDetails = {
+  name: string
+  props: Record<string, unknown>
+}
+
+function isCloneable(value: unknown): boolean {
+  try {
+    structuredClone(value)
+    return true
+  } catch {
+    // A plugin is free to hang a function or a class instance off its error.
+    return false
+  }
+}
+
+function toTransferableError(error: any): Error {
+  const props: Record<string, unknown> = {}
+  const keys = error && typeof error === 'object' ? Object.keys(error) : []
+  for (const key of keys) {
+    if (isCloneable(error[key])) {
+      props[key] = error[key]
+    }
+  }
+  const details: ErrorDetails = { name: error?.name ?? 'Error', props }
+  const transferable = new Error(error?.message ?? String(error))
+  // Assigned rather than passed to the constructor: the project targets ES2019
+  // and structured clone picks up an own `cause` property either way.
+  ;(transferable as Error & { cause?: ErrorDetails }).cause = details
+  transferable.stack = error?.stack
+  return transferable
+}
+
+// Piscina task: build a single entry (all of its output formats and types) in
+// this worker's own isolate, so its module graphs never share a heap with the
+// entries handed to other threads. Returns the size stats for the main
+// thread's output table.
+// Loaded by name from src/worker.ts in dev and from the package's main bundle
+// when compiled — a named export is what makes the single handler work for
+// both.
 /** @internal */
 export async function buildEntryInWorker({
   cwd,
+  cliEntryPath,
   entryName,
   options,
 }: EntryWorkerTask): Promise<SizeStats> {
   let buildContext: BuildContext | undefined
-  await bundle('', {
-    ...options,
-    cwd,
-    // The output directory is cleaned once on the main thread before the
-    // entries are dispatched; workers run concurrently and must not remove
-    // each other's output.
-    clean: false,
-    _entryFilter: [entryName],
-    _callbacks: {
-      onBuildStart(context: BuildContext) {
-        buildContext = context
+  try {
+    // cliEntryPath decides `isFromCli` and can override the source of the
+    // `./index` entry, so it has to be replayed here — otherwise this worker
+    // resolves a different set of entries than the main thread listed, and
+    // the assigned entry silently builds nothing.
+    await bundle(cliEntryPath, {
+      ...options,
+      cwd,
+      // The output directory is cleaned once on the main thread before the
+      // entries are dispatched; workers run concurrently and must not remove
+      // each other's output.
+      clean: false,
+      _entryFilter: [entryName],
+      _callbacks: {
+        onBuildStart(context: BuildContext) {
+          buildContext = context
+        },
       },
-    },
-  })
+    })
+  } catch (error) {
+    throw toTransferableError(error)
+  }
   return buildContext?.pluginContext.outputState.getSizeStats() ?? new Map()
 }

--- a/test/integration/many-entries-cli/index.test.ts
+++ b/test/integration/many-entries-cli/index.test.ts
@@ -1,0 +1,48 @@
+import path from 'path'
+import { afterAll, describe, expect, it } from 'vitest'
+import { getFileNamesFromDirectory, removeDirectory } from '../../testing-utils'
+import { executeBunchee } from '../../testing-utils/shared'
+
+// Nine entries, so the build fans out to workers, and the `.` export has no
+// src/index.ts behind it — it exists only because an entry file is passed on
+// the command line. A worker that does not replay that entry path resolves a
+// different entries map than the main thread listed, and silently builds
+// nothing for the entry it was assigned.
+const dir = __dirname
+const distDir = path.join(dir, 'dist')
+
+async function build(env: NodeJS.ProcessEnv = {}) {
+  await removeDirectory(distDir)
+  const result = await executeBunchee(['./src/custom-entry.ts', '--cwd', dir], {
+    env,
+  })
+  expect(result.stderr).toBe('')
+  expect(result.code).toBe(0)
+  return {
+    files: await getFileNamesFromDirectory(distDir),
+    stdout: result.stdout,
+  }
+}
+
+describe('integration - many-entries-cli', () => {
+  afterAll(async () => {
+    if (!process.env.TEST_NOT_CLEANUP) {
+      await removeDirectory(distDir)
+    }
+  })
+
+  it('should build the entry file passed on the command line', async () => {
+    const { files, stdout } = await build()
+
+    expect(files).toContain('index.d.ts')
+    // The `.` export is reported, not dropped on the floor.
+    expect(stdout).toMatch(/^\.\s+dist\/index\.d\.ts/m)
+  }, 120_000)
+
+  it('should produce the same output as an in-process build', async () => {
+    const workers = await build()
+    const inProcess = await build({ TEST_NO_WORKERS: '1' })
+
+    expect(inProcess.files).toEqual(workers.files)
+  }, 240_000)
+})

--- a/test/integration/many-entries-cli/index.test.ts
+++ b/test/integration/many-entries-cli/index.test.ts
@@ -1,6 +1,10 @@
 import path from 'path'
 import { afterAll, describe, expect, it } from 'vitest'
-import { getFileNamesFromDirectory, removeDirectory } from '../../testing-utils'
+import {
+  getFileNamesFromDirectory,
+  removeDirectory,
+  stripANSIColor,
+} from '../../testing-utils'
 import { executeBunchee } from '../../testing-utils/shared'
 
 // Nine entries, so the build fans out to workers, and the `.` export has no
@@ -20,7 +24,9 @@ async function build(env: NodeJS.ProcessEnv = {}) {
   expect(result.code).toBe(0)
   return {
     files: await getFileNamesFromDirectory(distDir),
-    stdout: result.stdout,
+    // The size table is colorized whenever picocolors thinks the terminal
+    // supports it, which includes any environment setting CI.
+    stdout: stripANSIColor(result.stdout),
   }
 }
 

--- a/test/integration/many-entries-cli/package.json
+++ b/test/integration/many-entries-cli/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "many-entries-cli",
+  "version": "0.0.0",
+  "type": "module",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./a": {
+      "types": "./dist/a.d.ts",
+      "import": "./dist/a.js"
+    },
+    "./b": {
+      "types": "./dist/b.d.ts",
+      "import": "./dist/b.js"
+    },
+    "./c": {
+      "types": "./dist/c.d.ts",
+      "import": "./dist/c.js"
+    },
+    "./d": {
+      "types": "./dist/d.d.ts",
+      "import": "./dist/d.js"
+    },
+    "./e": {
+      "types": "./dist/e.d.ts",
+      "import": "./dist/e.js"
+    },
+    "./f": {
+      "types": "./dist/f.d.ts",
+      "import": "./dist/f.js"
+    },
+    "./g": {
+      "types": "./dist/g.d.ts",
+      "import": "./dist/g.js"
+    },
+    "./h": {
+      "types": "./dist/h.d.ts",
+      "import": "./dist/h.js"
+    }
+  }
+}

--- a/test/integration/many-entries-cli/src/a.ts
+++ b/test/integration/many-entries-cli/src/a.ts
@@ -1,0 +1,1 @@
+export const a = 'a'

--- a/test/integration/many-entries-cli/src/b.ts
+++ b/test/integration/many-entries-cli/src/b.ts
@@ -1,0 +1,1 @@
+export const b = 'b'

--- a/test/integration/many-entries-cli/src/c.ts
+++ b/test/integration/many-entries-cli/src/c.ts
@@ -1,0 +1,1 @@
+export const c = 'c'

--- a/test/integration/many-entries-cli/src/custom-entry.ts
+++ b/test/integration/many-entries-cli/src/custom-entry.ts
@@ -1,0 +1,1 @@
+export const index = 'custom-entry'

--- a/test/integration/many-entries-cli/src/d.ts
+++ b/test/integration/many-entries-cli/src/d.ts
@@ -1,0 +1,1 @@
+export const d = 'd'

--- a/test/integration/many-entries-cli/src/e.ts
+++ b/test/integration/many-entries-cli/src/e.ts
@@ -1,0 +1,1 @@
+export const e = 'e'

--- a/test/integration/many-entries-cli/src/f.ts
+++ b/test/integration/many-entries-cli/src/f.ts
@@ -1,0 +1,1 @@
+export const f = 'f'

--- a/test/integration/many-entries-cli/src/g.ts
+++ b/test/integration/many-entries-cli/src/g.ts
@@ -1,0 +1,1 @@
+export const g = 'g'

--- a/test/integration/many-entries-cli/src/h.ts
+++ b/test/integration/many-entries-cli/src/h.ts
@@ -1,0 +1,1 @@
+export const h = 'h'

--- a/test/integration/many-entries-directives/index.test.ts
+++ b/test/integration/many-entries-directives/index.test.ts
@@ -1,0 +1,54 @@
+import path from 'path'
+import { afterAll, describe, expect, it } from 'vitest'
+import { getFileNamesFromDirectory, removeDirectory } from '../../testing-utils'
+import { executeBunchee } from '../../testing-utils/shared'
+
+// Nine entries, so above MIN_ENTRIES_FOR_WORKERS, but with 'use client' and
+// 'use server' directives. Chunk splitting for layered modules depends on
+// state shared between every entry's build, so this package has to fall back
+// to the in-process path — a worker would only ever see one entry's modules
+// and would stop splitting the shared module out.
+const dir = __dirname
+const distDir = path.join(dir, 'dist')
+
+async function build(env: NodeJS.ProcessEnv = {}) {
+  await removeDirectory(distDir)
+  const result = await executeBunchee(['--cwd', dir], {
+    env: { ...env, DEBUG: '1' },
+  })
+  expect(result.code).toBe(0)
+  // The directive gate has to keep this package off the worker pool whatever
+  // its entry count is.
+  expect(result.stdout).not.toContain('worker threads')
+  return getFileNamesFromDirectory(distDir)
+}
+
+describe('integration - many-entries-directives', () => {
+  afterAll(async () => {
+    if (!process.env.TEST_NOT_CLEANUP) {
+      await removeDirectory(distDir)
+    }
+  })
+
+  it('should keep the layered shared modules in their own chunks', async () => {
+    const files = await build()
+
+    expect(files).toEqual(
+      expect.arrayContaining([
+        'client.js',
+        'server.js',
+        'lib/_app-context.js',
+        'lib/_util.js',
+      ]),
+    )
+  }, 120_000)
+
+  it('should build identically with workers disabled', async () => {
+    // The directive gate should already have taken this package off the
+    // worker path, so forcing it off must not change anything.
+    const gated = await build()
+    const forced = await build({ TEST_NO_WORKERS: '1' })
+
+    expect(forced).toEqual(gated)
+  }, 240_000)
+})

--- a/test/integration/many-entries-directives/package.json
+++ b/test/integration/many-entries-directives/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "many-entries-directives",
+  "version": "0.0.0",
+  "type": "module",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./client": {
+      "types": "./dist/client.d.ts",
+      "import": "./dist/client.js"
+    },
+    "./server": {
+      "types": "./dist/server.d.ts",
+      "import": "./dist/server.js"
+    },
+    "./a": {
+      "types": "./dist/a.d.ts",
+      "import": "./dist/a.js"
+    },
+    "./b": {
+      "types": "./dist/b.d.ts",
+      "import": "./dist/b.js"
+    },
+    "./c": {
+      "types": "./dist/c.d.ts",
+      "import": "./dist/c.js"
+    },
+    "./d": {
+      "types": "./dist/d.d.ts",
+      "import": "./dist/d.js"
+    },
+    "./e": {
+      "types": "./dist/e.d.ts",
+      "import": "./dist/e.js"
+    },
+    "./f": {
+      "types": "./dist/f.d.ts",
+      "import": "./dist/f.js"
+    }
+  }
+}

--- a/test/integration/many-entries-directives/src/a.ts
+++ b/test/integration/many-entries-directives/src/a.ts
@@ -1,0 +1,3 @@
+import { sharedApi } from './lib/_util'
+
+export const a = 'a:' + sharedApi()

--- a/test/integration/many-entries-directives/src/b.ts
+++ b/test/integration/many-entries-directives/src/b.ts
@@ -1,0 +1,3 @@
+import { sharedApi } from './lib/_util'
+
+export const b = 'b:' + sharedApi()

--- a/test/integration/many-entries-directives/src/c.ts
+++ b/test/integration/many-entries-directives/src/c.ts
@@ -1,0 +1,3 @@
+import { sharedApi } from './lib/_util'
+
+export const c = 'c:' + sharedApi()

--- a/test/integration/many-entries-directives/src/client.ts
+++ b/test/integration/many-entries-directives/src/client.ts
@@ -1,0 +1,6 @@
+'use client'
+
+import { appContext } from './lib/_app-context'
+import { sharedApi } from './lib/_util'
+
+export const client = 'client:' + appContext.name + ':' + sharedApi()

--- a/test/integration/many-entries-directives/src/d.ts
+++ b/test/integration/many-entries-directives/src/d.ts
@@ -1,0 +1,3 @@
+import { sharedApi } from './lib/_util'
+
+export const d = 'd:' + sharedApi()

--- a/test/integration/many-entries-directives/src/e.ts
+++ b/test/integration/many-entries-directives/src/e.ts
@@ -1,0 +1,3 @@
+import { sharedApi } from './lib/_util'
+
+export const e = 'e:' + sharedApi()

--- a/test/integration/many-entries-directives/src/f.ts
+++ b/test/integration/many-entries-directives/src/f.ts
@@ -1,0 +1,3 @@
+import { sharedApi } from './lib/_util'
+
+export const f = 'f:' + sharedApi()

--- a/test/integration/many-entries-directives/src/index.ts
+++ b/test/integration/many-entries-directives/src/index.ts
@@ -1,0 +1,4 @@
+export { appContext } from './lib/_app-context'
+export { sharedApi } from './lib/_util'
+
+export const index = 'index'

--- a/test/integration/many-entries-directives/src/lib/_app-context.ts
+++ b/test/integration/many-entries-directives/src/lib/_app-context.ts
@@ -1,0 +1,3 @@
+'use client'
+
+export const appContext = { name: 'app-context' }

--- a/test/integration/many-entries-directives/src/lib/_util.ts
+++ b/test/integration/many-entries-directives/src/lib/_util.ts
@@ -1,0 +1,3 @@
+export function sharedApi() {
+  return 'shared:api'
+}

--- a/test/integration/many-entries-directives/src/server.ts
+++ b/test/integration/many-entries-directives/src/server.ts
@@ -1,0 +1,5 @@
+'use server'
+
+import { sharedApi } from './lib/_util'
+
+export const server = 'server:' + sharedApi()

--- a/test/integration/many-entries/index.test.ts
+++ b/test/integration/many-entries/index.test.ts
@@ -1,0 +1,79 @@
+import path from 'path'
+import { afterAll, describe, expect, it } from 'vitest'
+import {
+  getFileContents,
+  getFileNamesFromDirectory,
+  removeDirectory,
+} from '../../testing-utils'
+import { executeBunchee } from '../../testing-utils/shared'
+
+// Nine entries, above MIN_ENTRIES_FOR_WORKERS, with no directive layers: this
+// is the fixture that takes the worker pool path.
+const dir = __dirname
+const distDir = path.join(dir, 'dist')
+
+async function build(env: NodeJS.ProcessEnv = {}) {
+  await removeDirectory(distDir)
+  const result = await executeBunchee(['--cwd', dir], { env })
+  expect(result.stderr).toBe('')
+  expect(result.code).toBe(0)
+  return {
+    stdout: result.stdout,
+    files: await getFileNamesFromDirectory(distDir),
+    contents: await getFileContents(distDir),
+  }
+}
+
+describe('integration - many-entries', () => {
+  afterAll(async () => {
+    if (!process.env.TEST_NOT_CLEANUP) {
+      await removeDirectory(distDir)
+    }
+  })
+
+  it('should build every entry', async () => {
+    const { files, contents } = await build()
+
+    expect(files).toMatchInlineSnapshot(`
+      [
+        "a.d.ts",
+        "a.js",
+        "b.d.ts",
+        "b.js",
+        "c.d.ts",
+        "c.js",
+        "d.d.ts",
+        "d.js",
+        "e.d.ts",
+        "e.js",
+        "f.d.ts",
+        "f.js",
+        "g.d.ts",
+        "g.js",
+        "h.d.ts",
+        "h.js",
+        "index.d.ts",
+        "index.js",
+      ]
+    `)
+    // The entry that imports a sibling entry keeps it external instead of
+    // inlining it, which the worker has to get right from its own copy of the
+    // full entries map.
+    expect(contents['index.js']).toContain(`from './a.js'`)
+    expect(contents['index.js']).not.toContain(`'a:'`)
+  }, 120_000)
+
+  it('should produce the same output as an in-process build', async () => {
+    const workers = await build({ DEBUG: '1' })
+    const inProcess = await build({ DEBUG: '1', TEST_NO_WORKERS: '1' })
+
+    // Guard the comparison: it only means anything if the first build really
+    // did fan out. Runs from source and from dist resolve the worker file
+    // differently, so this has to hold for both.
+    expect(workers.stdout).toMatch(/Building 9 entries in \d+ worker threads/)
+    expect(inProcess.stdout).not.toContain('worker threads')
+
+    expect(inProcess.files).toEqual(workers.files)
+    expect(inProcess.contents).toEqual(workers.contents)
+  }, 240_000)
+})

--- a/test/integration/many-entries/package.json
+++ b/test/integration/many-entries/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "many-entries",
+  "version": "0.0.0",
+  "type": "module",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./a": {
+      "types": "./dist/a.d.ts",
+      "import": "./dist/a.js"
+    },
+    "./b": {
+      "types": "./dist/b.d.ts",
+      "import": "./dist/b.js"
+    },
+    "./c": {
+      "types": "./dist/c.d.ts",
+      "import": "./dist/c.js"
+    },
+    "./d": {
+      "types": "./dist/d.d.ts",
+      "import": "./dist/d.js"
+    },
+    "./e": {
+      "types": "./dist/e.d.ts",
+      "import": "./dist/e.js"
+    },
+    "./f": {
+      "types": "./dist/f.d.ts",
+      "import": "./dist/f.js"
+    },
+    "./g": {
+      "types": "./dist/g.d.ts",
+      "import": "./dist/g.js"
+    },
+    "./h": {
+      "types": "./dist/h.d.ts",
+      "import": "./dist/h.js"
+    }
+  }
+}

--- a/test/integration/many-entries/src/a.ts
+++ b/test/integration/many-entries/src/a.ts
@@ -1,0 +1,3 @@
+import { shared } from './shared'
+
+export const a = 'a:' + shared

--- a/test/integration/many-entries/src/b.ts
+++ b/test/integration/many-entries/src/b.ts
@@ -1,0 +1,3 @@
+import { shared } from './shared'
+
+export const b = 'b:' + shared

--- a/test/integration/many-entries/src/c.ts
+++ b/test/integration/many-entries/src/c.ts
@@ -1,0 +1,3 @@
+import { shared } from './shared'
+
+export const c = 'c:' + shared

--- a/test/integration/many-entries/src/d.ts
+++ b/test/integration/many-entries/src/d.ts
@@ -1,0 +1,3 @@
+import { shared } from './shared'
+
+export const d = 'd:' + shared

--- a/test/integration/many-entries/src/e.ts
+++ b/test/integration/many-entries/src/e.ts
@@ -1,0 +1,3 @@
+import { shared } from './shared'
+
+export const e = 'e:' + shared

--- a/test/integration/many-entries/src/f.ts
+++ b/test/integration/many-entries/src/f.ts
@@ -1,0 +1,3 @@
+import { shared } from './shared'
+
+export const f = 'f:' + shared

--- a/test/integration/many-entries/src/g.ts
+++ b/test/integration/many-entries/src/g.ts
@@ -1,0 +1,3 @@
+import { shared } from './shared'
+
+export const g = 'g:' + shared

--- a/test/integration/many-entries/src/h.ts
+++ b/test/integration/many-entries/src/h.ts
@@ -1,0 +1,3 @@
+import { shared } from './shared'
+
+export const h = 'h:' + shared

--- a/test/integration/many-entries/src/index.ts
+++ b/test/integration/many-entries/src/index.ts
@@ -1,0 +1,4 @@
+import { a } from './a'
+import { shared } from './shared'
+
+export const index = 'index:' + a + ':' + shared

--- a/test/integration/many-entries/src/shared.ts
+++ b/test/integration/many-entries/src/shared.ts
@@ -1,0 +1,1 @@
+export const shared = 'shared'


### PR DESCRIPTION
Stacked on #740 — review that first; this diff is one commit on top of it.

A module imported by two entries on different layers gets split into its own chunk so neither boundary swallows it. `createSplitChunks` makes that call from `pluginContext.moduleDirectiveLayerMap`, which every entry's build writes to and reads back: `isImportFromOtherEntry` asks whether some *other* entry pulled the module in.

A worker only ever sees the one entry it was handed, so that map never holds another entry's modules. The check is always false and the module stops being split out. Since #739, a package using `'use client'` or `'use server'` therefore chunks one way below eight entries and another way above, with nothing in the output to say so.

Those packages now stay in-process. Detection scans source files for a directive other than `'use strict'`, matching anywhere in the file rather than only at the top — a false positive costs a package its fan-out, while a false negative would change its output.

The narrower alternative is making the layer map shareable across workers so layered packages can fan out too. That is a real design change rather than a gate, so it is not attempted here.

Note this leaves large layered packages building entirely in one process, which is the case #742 covers.