### PR TITLE
Bound memory for builds that do not fan out to workers

### DIFF
--- a/src/lib/concurrency.test.ts
+++ b/src/lib/concurrency.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { runWithMemoryBudget } from './concurrency'
+
+function trackedTask<T>(
+  state: { running: number; peak: number },
+  value: T,
+  delay = 0,
+) {
+  return async () => {
+    state.running++
+    state.peak = Math.max(state.peak, state.running)
+    await new Promise((resolve) => setTimeout(resolve, delay))
+    state.running--
+    return value
+  }
+}
+
+describe('runWithMemoryBudget', () => {
+  it('should resolve results in input order regardless of completion order', async () => {
+    const state = { running: 0, peak: 0 }
+    const tasks = [
+      trackedTask(state, 'a', 30),
+      trackedTask(state, 'b', 0),
+      trackedTask(state, 'c', 15),
+      trackedTask(state, 'd', 5),
+    ]
+    expect(await runWithMemoryBudget(tasks)).toEqual(['a', 'b', 'c', 'd'])
+  })
+
+  it('should run more than one task concurrently when memory allows', async () => {
+    const state = { running: 0, peak: 0 }
+    const tasks = Array.from({ length: 8 }, (_, i) => trackedTask(state, i, 10))
+    expect(await runWithMemoryBudget(tasks)).toEqual([0, 1, 2, 3, 4, 5, 6, 7])
+    expect(state.peak).toBeGreaterThan(1)
+  })
+
+  it('should never run more than the concurrency cap at once', async () => {
+    const state = { running: 0, peak: 0 }
+    const tasks = Array.from({ length: 24 }, (_, i) => trackedTask(state, i, 5))
+    await runWithMemoryBudget(tasks)
+    expect(state.peak).toBeLessThanOrEqual(4)
+  })
+
+  it('should handle an empty task list', async () => {
+    expect(await runWithMemoryBudget([])).toEqual([])
+  })
+
+  it('should reject with the first error and stop starting new tasks', async () => {
+    let started = 0
+    const tasks = Array.from({ length: 50 }, (_, i) => async () => {
+      started++
+      if (i === 0) {
+        throw new Error('boom')
+      }
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      return i
+    })
+    await expect(runWithMemoryBudget(tasks)).rejects.toThrow('boom')
+    expect(started).toBeLessThan(50)
+  })
+})

--- a/src/lib/concurrency.ts
+++ b/src/lib/concurrency.ts
@@ -1,0 +1,53 @@
+import { getHeapStatistics } from 'v8'
+
+// At most this many builds run at once. Additionally, when V8 heap usage
+// crosses the high-water fraction of the heap limit, new builds wait for
+// in-flight ones to finish and release their memory — throttling down to one
+// at a time. At least one task is always in flight, so the queue cannot stall.
+const MAX_CONCURRENCY = 4
+const HEAP_HIGH_WATER = 0.65
+
+export async function runWithMemoryBudget<T>(
+  tasks: (() => Promise<T>)[],
+): Promise<T[]> {
+  const highWater = getHeapStatistics().heap_size_limit * HEAP_HIGH_WATER
+  const results: T[] = new Array(tasks.length)
+  const inflight = new Set<Promise<void>>()
+  let firstError: unknown
+  let failed = false
+
+  for (let i = 0; i < tasks.length; i++) {
+    while (
+      !failed &&
+      inflight.size > 0 &&
+      (inflight.size >= MAX_CONCURRENCY ||
+        process.memoryUsage().heapUsed > highWater)
+    ) {
+      await Promise.race(inflight)
+    }
+    if (failed) break
+
+    const tracked: Promise<void> = tasks[i]()
+      .then(
+        (result) => {
+          results[i] = result
+        },
+        (error) => {
+          if (!failed) {
+            failed = true
+            firstError = error
+          }
+        },
+      )
+      .finally(() => {
+        inflight.delete(tracked)
+      })
+    inflight.add(tracked)
+  }
+
+  await Promise.all(inflight)
+  if (failed) {
+    throw firstError
+  }
+  return results
+}

--- a/src/lib/worker-pool.ts
+++ b/src/lib/worker-pool.ts
@@ -10,6 +10,15 @@ import type { EntryWorkerTask } from '../worker'
 // fits comfortably in one heap, and skipping the pool avoids worker startup.
 export const MIN_ENTRIES_FOR_WORKERS = 8
 
+// Threads are capped well below the core count on purpose. Every thread is a
+// separate isolate, so each one builds its own rollup-plugin-dts instance and
+// its own TypeScript program (see the memoization in rollup/input.ts) — the
+// single largest allocation in a typical build. Total memory therefore scales
+// with thread count, and `availableParallelism()` reflects the CPU affinity
+// mask rather than a cgroup CPU quota, so a container on a large host would
+// otherwise fan out to dozens of TypeScript programs and OOM the box.
+const MAX_WORKER_THREADS = 4
+
 // The handler is loaded from this file by its export name, so no separate
 // worker asset needs to exist in dist.
 export const WORKER_HANDLER_NAME = 'buildEntryInWorker'
@@ -44,6 +53,7 @@ export async function runEntriesInWorkers(
       1,
       Math.min(
         entryNames.length,
+        MAX_WORKER_THREADS,
         (os.availableParallelism?.() ?? os.cpus().length) - 1,
       ),
     ),

--- a/src/rollup-job.ts
+++ b/src/rollup-job.ts
@@ -16,6 +16,7 @@ import {
 } from './types'
 import { removeOutputDir } from './utils'
 import { normalizeError } from './lib/normalize-error'
+import { runWithMemoryBudget } from './lib/concurrency'
 
 export async function createAssetRollupJobs(
   options: BundleConfig,
@@ -44,12 +45,22 @@ export async function createAssetRollupJobs(
     }
   }
 
-  const rollupJobs = allConfigs.map((rollupConfig) =>
-    bundleOrWatch(options, rollupConfig),
-  )
-
   try {
-    return await Promise.all(rollupJobs)
+    // Watchers are long-lived and never settle, so they are not pooled.
+    if (options.watch) {
+      return await Promise.all(
+        allConfigs.map((rollupConfig) => bundleOrWatch(options, rollupConfig)),
+      )
+    }
+    // Bundling every config at once makes peak memory scale with the number of
+    // entries times their formats, which is what OOMs on packages with many
+    // exports. This bounds the in-process path the same way the worker pool
+    // bounds the fanned-out one.
+    return await runWithMemoryBudget(
+      allConfigs.map(
+        (rollupConfig) => () => bundleOrWatch(options, rollupConfig),
+      ),
+    )
   } catch (err: unknown) {
     const error = normalizeError(err)
     throw error


### PR DESCRIPTION
Independent of #740 and #741 — this branch is off `main` and touches different files.

#739 sends packages with eight or more entries to the worker pool. Everything below that still builds every rollup config at once, so peak memory scales with entries times formats inside a single heap. That is the same shape that OOMs, just at a smaller size, and it is the only path left for any package the pool declines to take.

Non-watch builds now run under a concurrency cap that additionally backs off when V8 heap usage crosses a fraction of the limit. Watchers are long-lived and never settle, so they are not pooled.

Measured on a generated 40-entry package built in one process, peak RSS:

| | peak RSS | wall |
|---|---|---|
| every config at once | 3.36 GB | 8.5s |
| bounded | 1.56 GB | 7.4s |

Slightly faster too, presumably less GC pressure. Where the worker pool does run this is close to inert — one entry is a handful of configs, under the cap.

This matters more if #741 lands: that PR keeps packages with directives in-process regardless of entry count, which is exactly where large RSC libraries end up.

Also caps the pool at four threads. Every thread is a separate isolate building its own rollup-plugin-dts instance and TypeScript program — the largest allocation in a typical build — and `availableParallelism()` reports host cores rather than a container's CPU quota, so a 64-core box was fanning out to 63 TypeScript programs.