### PR TITLE
Fix exports parser crashes, types condition detection, and wildcard expansion

### DIFF
--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -11,11 +11,16 @@ import {
   fileExists,
   getPackageMeta,
   getSourcePathFromExportPath,
+  isBinExportPath,
   isTypescriptFile,
   removeOutputDir,
 } from './utils'
 import { MIN_ENTRIES_FOR_WORKERS, runEntriesInWorkers } from './lib/worker-pool'
-import { getExportFileTypePath, parseExports } from './exports'
+import {
+  getExportFileTypePath,
+  parseExports,
+  type ParsedExportsInfo,
+} from './exports'
 import type { BuildContext } from './types'
 import {
   TypescriptOptions,
@@ -38,9 +43,9 @@ function assignDefault(
   }
 }
 
-function hasMultiEntryExport(exportPaths: object): boolean {
-  const exportKeys = Object.keys(exportPaths).filter(
-    (key) => key !== './package.json',
+function hasMultiEntryExport(parsedExportsInfo: ParsedExportsInfo): boolean {
+  const exportKeys = [...parsedExportsInfo.keys()].filter(
+    (key) => key !== './package.json' && !isBinExportPath(key),
   )
 
   return (

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -86,6 +86,16 @@ export const DEFAULT_TS_CONFIG = {
 
 export const BINARY_TAG = '$binary'
 
+// Matches private shared modules living inside an underscore-prefixed directory,
+// e.g. `_utils/index.ts`, `a/_b/c.ts`.
 export const PRIVATE_GLOB_PATTERN = '**/_*/**'
+// Matches underscore-prefixed files themselves, e.g. `_utils.ts`, `lib/_helper.ts`.
+// PRIVATE_GLOB_PATTERN alone never matches these, since `_*` only matches a
+// directory segment that has children.
+const PRIVATE_FILE_GLOB_PATTERN = '**/_*'
+export const PRIVATE_GLOB_PATTERNS = [
+  PRIVATE_GLOB_PATTERN,
+  PRIVATE_FILE_GLOB_PATTERN,
+]
 export const TESTS_GLOB_PATTERN =
   '**/{__tests__/**,__mocks__/**,*.{test,spec}.*}'

--- a/src/entries.ts
+++ b/src/entries.ts
@@ -4,6 +4,7 @@ import path, { posix } from 'path'
 import { glob } from 'tinyglobby'
 import {
   getExportTypeFromFile,
+  getFileExportType,
   isCjsExportName,
   type ParsedExportsInfo,
 } from './exports'
@@ -37,8 +38,11 @@ export async function collectEntriesFromParsedExports(
   sourceFile: string | undefined,
 ): Promise<Entries> {
   const entries: Entries = {}
-  if (sourceFile) {
-    const defaultExport = parsedExportsInfo.get('./index')![0]
+  // A CLI entry file only becomes `./index` when package.json actually declares an
+  // output for it. Without `-o` and without a `.` export there's no output path to
+  // build to, so fall through to the export-derived entries below.
+  const defaultExport = parsedExportsInfo.get('./index')?.[0]
+  if (sourceFile && defaultExport) {
     entries['./index'] = {
       source: sourceFile,
       name: '.',
@@ -382,7 +386,7 @@ export async function collectSourceEntriesFromExportPaths(
     const specialConditions = new Set<string>()
     for (const [outputPath, composedExportType] of exportInfo) {
       // Collect required private shared module formats while walking export outputs.
-      const exportType = composedExportType.split('.').pop()
+      const exportType = getFileExportType(composedExportType)
       if (exportType !== 'types') {
         const ext = path.extname(outputPath).slice(1)
         requiredPrivateModuleFormats |= isCjsExportName(

--- a/src/exports.test.ts
+++ b/src/exports.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
-import { parseExports } from './exports'
+import {
+  getFileExportType,
+  isCjsExportName,
+  isEsmExportName,
+  parseExports,
+} from './exports'
 import type { PackageMetadata } from './types'
 import * as wildcard from './wildcard'
 
@@ -280,6 +285,40 @@ describe('parse-exports', () => {
     ])
   })
 
+  it('should skip export paths blocked with null', async () => {
+    const pkg: PackageMetadata = {
+      name: 'test-pkg',
+      type: 'module',
+      exports: {
+        '.': './dist/index.js',
+        './internal': null,
+        './nested': { import: null, require: './dist/nested.cjs' },
+      },
+    }
+
+    const result = await parseExports(pkg)
+    expect(result.get('./index')).toEqual([['./dist/index.js', 'default']])
+    expect(result.get('./internal')).toBeUndefined()
+    expect(result.get('./nested')).toEqual([['./dist/nested.cjs', 'require']])
+  })
+
+  it('should skip wildcard export paths blocked with null', async () => {
+    const pkg: PackageMetadata = {
+      name: 'test-pkg',
+      type: 'module',
+      exports: {
+        './features/*': null,
+      },
+    }
+
+    vi.mocked(wildcard.expandWildcardPattern).mockResolvedValue(
+      new Map([['./features/foo', 'foo']]),
+    )
+
+    const result = await parseExports(pkg, mockCwd)
+    expect(result.get('./features/foo')).toBeUndefined()
+  })
+
   it('should handle nested export conditions', async () => {
     const pkg: PackageMetadata = {
       name: 'test-pkg',
@@ -302,5 +341,67 @@ describe('parse-exports', () => {
         ['./dist/index.js', 'default'],
       ]),
     )
+  })
+})
+
+describe('export condition classification', () => {
+  describe('getFileExportType', () => {
+    it('should detect the types condition wherever it is nested', () => {
+      expect(getFileExportType('types')).toBe('types')
+      expect(getFileExportType('import.types')).toBe('types')
+      // `"types": { "import": ..., "require": ... }` nests the other way around
+      expect(getFileExportType('types.import')).toBe('types')
+      expect(getFileExportType('types.require')).toBe('types')
+      expect(getFileExportType('development.require.types')).toBe('types')
+    })
+
+    it('should return the last condition for non-types conditions', () => {
+      expect(getFileExportType('import.default')).toBe('default')
+      expect(getFileExportType('development.import.default')).toBe('default')
+      expect(getFileExportType('require')).toBe('require')
+    })
+  })
+
+  describe('isEsmExportName', () => {
+    it('should match esm conditions nested in a composed condition', () => {
+      expect(isEsmExportName('import', 'js')).toBe(true)
+      expect(isEsmExportName('import.default', 'js')).toBe(true)
+      expect(isEsmExportName('development.import.default', 'js')).toBe(true)
+      expect(isEsmExportName('module.default', 'js')).toBe(true)
+      expect(isEsmExportName('module-sync.default', 'js')).toBe(true)
+    })
+
+    it('should not match cjs conditions', () => {
+      expect(isEsmExportName('require.default', 'js')).toBe(false)
+      expect(isEsmExportName('default', 'js')).toBe(false)
+    })
+
+    it('should always treat .mjs as esm', () => {
+      expect(isEsmExportName('require', 'mjs')).toBe(true)
+    })
+  })
+
+  describe('isCjsExportName', () => {
+    const cjsPkg: PackageMetadata = { name: 'p', type: 'commonjs' }
+    const esmPkg: PackageMetadata = { name: 'p', type: 'module' }
+
+    it('should not classify a nested import condition as cjs', () => {
+      expect(isCjsExportName(cjsPkg, 'import', 'js')).toBe(false)
+      expect(isCjsExportName(cjsPkg, 'import.default', 'js')).toBe(false)
+      expect(isCjsExportName(cjsPkg, 'development.import.default', 'js')).toBe(
+        false,
+      )
+    })
+
+    it('should classify require conditions in a cjs package as cjs', () => {
+      expect(isCjsExportName(cjsPkg, 'require', 'js')).toBe(true)
+      expect(isCjsExportName(cjsPkg, 'require.default', 'js')).toBe(true)
+      expect(isCjsExportName(cjsPkg, 'default', 'js')).toBe(true)
+    })
+
+    it('should classify by extension in an esm package', () => {
+      expect(isCjsExportName(esmPkg, 'require.default', 'cjs')).toBe(true)
+      expect(isCjsExportName(esmPkg, 'import.default', 'js')).toBe(false)
+    })
   })
 })

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -67,6 +67,11 @@ async function processWildcardExportValue(
   exportToDist: ParsedExportsInfo,
   matchedSubpath: string,
 ) {
+  // `null` blocks a subpath from being resolved, there's nothing to build for it.
+  if (exportValue == null) {
+    return
+  }
+
   // End of searching, export value is file path.
   // <export key>: <export value> (string)
   if (typeof exportValue === 'string') {
@@ -159,6 +164,11 @@ function collectExportPath(
   exportTypes: Set<string>,
   exportToDist: ParsedExportsInfo,
 ) {
+  // `null` blocks a subpath from being resolved, there's nothing to build for it.
+  if (exportValue == null) {
+    return
+  }
+
   // End of searching, export value is file path.
   // <export key>: <export value> (string)
   if (typeof exportValue === 'string') {
@@ -357,8 +367,15 @@ export function constructDefaultExportCondition(
   return constructFullExportCondition(exportCondition, packageType)
 }
 
+const esmConditions = new Set(['import', 'module', 'module-sync'])
+const cjsConditions = new Set(['require', 'main'])
+
 export function isEsmExportName(name: string, ext: string) {
-  return ['import', 'module', 'module-sync'].includes(name) || ext === 'mjs'
+  // `name` is a composed condition such as `import.default` or
+  // `development.import.types`, so match on segments rather than the whole string.
+  return (
+    name.split('.').some((cond) => esmConditions.has(cond)) || ext === 'mjs'
+  )
 }
 
 export function isCjsExportName(
@@ -367,7 +384,9 @@ export function isCjsExportName(
   ext: string,
 ) {
   const isESModule = isESModulePackage(pkg.type)
-  const isCjsCondition = ['require', 'main'].includes(exportCondition)
+  const isCjsCondition = exportCondition
+    .split('.')
+    .some((cond) => cjsConditions.has(cond))
   const isNotEsmExportName = !isEsmExportName(exportCondition, ext)
   return (
     (!isESModule && isNotEsmExportName && (ext !== 'mjs' || isCjsCondition)) ||
@@ -375,8 +394,17 @@ export function isCjsExportName(
   )
 }
 
+// `import.types` -> types
+// `types.import` -> types
+// `development.import.default` -> default
 export function getFileExportType(composedTypes: string) {
-  return composedTypes.split('.').pop() as string
+  const conditions = composedTypes.split('.')
+  // `types` can be nested either way around, and it always wins: it decides
+  // whether the output is a declaration file or a JS asset.
+  if (conditions.includes('types')) {
+    return 'types'
+  }
+  return conditions[conditions.length - 1]
 }
 
 export type ExportOutput = {

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -197,7 +197,15 @@ export async function lint(cwd: string) {
   const fieldState = validateFilesField(pkg)
 
   const warningsCount =
-    exportsState.badTypesExport.length + fieldState.missingFiles.length
+    exportsState.badTypesExport.length +
+    fieldState.missingFiles.length +
+    exportsState.badCjsRequireExport.paths.length +
+    exportsState.badCjsImportExport.paths.length +
+    exportsState.badEsmRequireExport.paths.length +
+    exportsState.badEsmImportExport.paths.length +
+    Number(exportsState.badMainExtension) +
+    Number(exportsState.badMainExport) +
+    Number(exportsState.invalidExportsFieldType)
 
   if (warningsCount) {
     logger.warn(`Lint: ${warningsCount} issues found.`)

--- a/src/prepare/prepare-entries.ts
+++ b/src/prepare/prepare-entries.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'fs'
 import { glob } from 'tinyglobby'
 import {
   BINARY_TAG,
-  PRIVATE_GLOB_PATTERN,
+  PRIVATE_GLOB_PATTERNS,
   TESTS_GLOB_PATTERN,
   availableExtensions,
 } from '../constants'
@@ -28,13 +28,13 @@ export async function collectSourceEntries(sourceFolderPath: string) {
 
   const binMatches = await glob(binPattern, {
     cwd: sourceFolderPath,
-    ignore: [PRIVATE_GLOB_PATTERN, TESTS_GLOB_PATTERN], // ignore private entries
+    ignore: [...PRIVATE_GLOB_PATTERNS, TESTS_GLOB_PATTERN], // ignore private entries
     expandDirectories: false,
   })
 
   const srcMatches = await glob(srcPattern, {
     cwd: sourceFolderPath,
-    ignore: [PRIVATE_GLOB_PATTERN, TESTS_GLOB_PATTERN], // ignore private entries
+    ignore: [...PRIVATE_GLOB_PATTERNS, TESTS_GLOB_PATTERN], // ignore private entries
     expandDirectories: false,
   })
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,8 +22,10 @@ type FullExportCondition = {
   [key: string]: string
 }
 
+// `null` is valid in package.json `exports` and blocks a subpath from resolving.
 type ExportCondition =
   | string
+  | null
   | {
       [key: string]: ExportCondition | string
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -105,7 +105,8 @@ export async function getSourcePathFromExportPath(
 ): Promise<string | undefined> {
   for (const ext of availableExtensions) {
     // ignore package.json
-    if (exportPath === '/package.json') return
+    if (exportPath === './package.json' || exportPath === '/package.json')
+      return
     if (exportPath === '.') exportPath = './index'
 
     // Find convention-based source file for specific export types

--- a/src/wildcard.test.ts
+++ b/src/wildcard.test.ts
@@ -125,7 +125,7 @@ describe('wildcard', () => {
       expect(result.get('./features/baz')).toBe('baz')
     })
 
-    it('should handle nested paths in wildcard expansion', async () => {
+    it('should expand nested paths in wildcard expansion', async () => {
       vi.mocked(existsSync).mockReturnValue(true)
       vi.mocked(utils.fileExists).mockReturnValue(true)
       vi.mocked(glob).mockResolvedValue(['features/nested/deep/file.ts'])
@@ -133,8 +133,64 @@ describe('wildcard', () => {
       const result = await expandWildcardPattern('./features/*', mockCwd)
 
       expect(result.size).toBe(1)
-      // Should extract the first segment after features/
-      expect(result.get('./features/nested')).toBe('nested')
+      // `*` matches across `/`, matching Node's subpath pattern resolution
+      expect(result.get('./features/nested/deep/file')).toBe('nested/deep/file')
+    })
+
+    it('should expand a wildcard prefixed within a segment', async () => {
+      vi.mocked(existsSync).mockReturnValue(true)
+      vi.mocked(utils.fileExists).mockReturnValue(true)
+      vi.mocked(glob).mockResolvedValue(['feat-alpha.ts', 'other.ts'])
+
+      const result = await expandWildcardPattern('./feat-*', mockCwd)
+
+      expect(result.size).toBe(1)
+      expect(result.get('./feat-alpha')).toBe('alpha')
+    })
+
+    it('should expand a wildcard followed by a suffix', async () => {
+      vi.mocked(existsSync).mockReturnValue(true)
+      vi.mocked(utils.fileExists).mockReturnValue(true)
+      vi.mocked(glob).mockResolvedValue([
+        'alpha/utils.ts',
+        'beta/utils.ts',
+        'alpha/other.ts',
+      ])
+
+      const result = await expandWildcardPattern('./*/utils', mockCwd)
+
+      expect(result.size).toBe(2)
+      expect(result.get('./alpha/utils')).toBe('alpha')
+      expect(result.get('./beta/utils')).toBe('beta')
+    })
+
+    it('should not expand export-condition variants into their own exports', async () => {
+      vi.mocked(existsSync).mockReturnValue(true)
+      vi.mocked(utils.fileExists).mockReturnValue(true)
+      vi.mocked(glob).mockResolvedValue([
+        'features/foo.ts',
+        'features/foo.development.ts',
+        'features/bar.react-server.ts',
+      ])
+
+      const result = await expandWildcardPattern('./features/*', mockCwd)
+
+      // `foo.development.ts` is a variant of `./features/foo`, and
+      // `bar.react-server.ts` is a variant of `./features/bar`.
+      expect(result.size).toBe(2)
+      expect(result.get('./features/foo')).toBe('foo')
+      expect(result.get('./features/bar')).toBe('bar')
+      expect(result.get('./features/foo.development')).toBeUndefined()
+    })
+
+    it('should not match when the wildcard stands for nothing', async () => {
+      vi.mocked(existsSync).mockReturnValue(true)
+      vi.mocked(utils.fileExists).mockReturnValue(true)
+      vi.mocked(glob).mockResolvedValue(['feat-.ts'])
+
+      const result = await expandWildcardPattern('./feat-*', mockCwd)
+
+      expect(result.size).toBe(0)
     })
 
     it('should ignore private files and test files', async () => {

--- a/src/wildcard.ts
+++ b/src/wildcard.ts
@@ -3,8 +3,9 @@ import { glob } from 'tinyglobby'
 import {
   availableExtensions,
   SRC,
-  PRIVATE_GLOB_PATTERN,
+  PRIVATE_GLOB_PATTERNS,
   TESTS_GLOB_PATTERN,
+  specialExportConventions,
 } from './constants'
 import { logger } from './logger'
 import { fileExists, normalizePath } from './utils'
@@ -41,10 +42,51 @@ export function substituteWildcardInPath(
 }
 
 /**
+ * Turn a source file path into the subpath it serves, or undefined if it serves none.
+ *
+ * "features/foo.ts"             -> "features/foo"
+ * "features/bar/index.ts"       -> "features/bar"
+ * "features/foo.development.ts" -> "features/foo"  (a condition variant, not its own export)
+ */
+function sourceFileToSubpath(sourceFile: string): string | undefined {
+  const relativePath = normalizePath(sourceFile)
+  const ext = path.extname(relativePath)
+  if (!ext) {
+    return undefined
+  }
+  let subpath = relativePath.slice(0, -ext.length)
+
+  // Strip a trailing export-convention segment, e.g. `foo.development` -> `foo`.
+  // Those files are variants of the base export, not exports of their own.
+  const segments = path.posix.basename(subpath).split('.')
+  if (
+    segments.length > 1 &&
+    specialExportConventions.has(segments[segments.length - 1])
+  ) {
+    const dir = path.posix.dirname(subpath)
+    const baseName = segments.slice(0, -1).join('.')
+    subpath = dir === '.' ? baseName : path.posix.join(dir, baseName)
+  }
+
+  // `foo/index.ts` serves `foo`, not `foo/index`.
+  if (subpath.endsWith('/index')) {
+    subpath = subpath.slice(0, -'/index'.length)
+  } else if (subpath === 'index') {
+    return undefined
+  }
+
+  return subpath || undefined
+}
+
+/**
  * Expand a wildcard export pattern by finding matching source files
  * Returns a map of concrete export paths to their matched subpaths
  * Example: "./features/*" with files ["foo.ts", "bar.ts"] in src/features/
  *   -> { "./features/foo": "foo", "./features/bar": "bar" }
+ *
+ * A `*` may appear anywhere in the key and, per Node's subpath-pattern rules,
+ * matches across `/`. So `./feat-*`, `./*\/utils` and deeply nested files under
+ * `./features/*` all expand.
  */
 export async function expandWildcardPattern(
   wildcardPattern: string,
@@ -57,28 +99,33 @@ export async function expandWildcardPattern(
     return expanded
   }
 
-  // Convert wildcard pattern to glob pattern
   // "./features/*" -> "features/*"
   const cleanPattern = wildcardPattern.replace(/^\.\//, '')
 
-  // Extract the base path before the wildcard
-  // "features/*" -> "features"
-  const basePathParts = cleanPattern.split('*')
-  const basePath = basePathParts[0].replace(/\/$/, '')
+  // Node only honours the first `*` in a subpath pattern.
+  // "features/*"  -> prefix "features/", suffix ""
+  // "feat-*"      -> prefix "feat-",     suffix ""
+  // "*/utils"     -> prefix "",          suffix "/utils"
+  const starIndex = cleanPattern.indexOf('*')
+  if (starIndex === -1) {
+    return expanded
+  }
+  const prefix = cleanPattern.slice(0, starIndex)
+  const suffix = cleanPattern.slice(starIndex + 1).replace(/\*/g, '')
 
-  // Build glob pattern to match files
-  // "features/*" -> "features/*.{js,ts,tsx,...}"
   const extPattern = `{${[...availableExtensions].join(',')}}`
-  const globPatterns = [
-    `${cleanPattern}.${extPattern}`,
-    `${cleanPattern}/index.${extPattern}`,
-  ]
+  // Narrow the search to the static directory part of the prefix, so
+  // `./features/*` only walks `src/features`. A prefix without a directory part
+  // (`./feat-*`, `./*/utils`) can match anywhere, so it needs the whole tree.
+  const prefixDir = prefix.includes('/')
+    ? prefix.slice(0, prefix.lastIndexOf('/') + 1)
+    : ''
 
   let matches: string[] = []
   try {
-    matches = await glob(globPatterns, {
+    matches = await glob([`${prefixDir}**/*.${extPattern}`], {
       cwd: sourceDir,
-      ignore: [PRIVATE_GLOB_PATTERN, TESTS_GLOB_PATTERN],
+      ignore: [...PRIVATE_GLOB_PATTERNS, TESTS_GLOB_PATTERN],
       expandDirectories: false,
     })
   } catch (error) {
@@ -89,45 +136,24 @@ export async function expandWildcardPattern(
   }
 
   for (const match of matches) {
-    // Extract the matched subpath
-    // "features/foo.ts" -> "foo"
-    // "features/bar/index.ts" -> "bar"
-    const relativePath = normalizePath(match)
-    const ext = path.extname(relativePath)
-    const withoutExt = relativePath.slice(0, -ext.length)
-
-    // Remove the base path to get just the matched part
-    // "features/foo" -> "foo" (when basePath is "features")
-    let matchedPart = withoutExt
-    if (basePath && matchedPart.startsWith(basePath + '/')) {
-      matchedPart = matchedPart.slice(basePath.length + 1)
-    } else if (basePath && matchedPart === basePath) {
-      // This shouldn't happen, but handle it
+    const subpath = sourceFileToSubpath(match)
+    if (
+      !subpath ||
+      !subpath.startsWith(prefix) ||
+      !subpath.endsWith(suffix) ||
+      // The prefix and suffix must not overlap, otherwise `*` matched nothing.
+      subpath.length <= prefix.length + suffix.length
+    ) {
       continue
     }
 
-    // Handle index files
-    let matchedSubpath: string
-    if (matchedPart.endsWith('/index')) {
-      matchedSubpath = matchedPart.slice(0, -6) // Remove "/index"
-      // If there's still a path, take the last segment
-      const lastSlash = matchedSubpath.lastIndexOf('/')
-      matchedSubpath =
-        lastSlash >= 0 ? matchedSubpath.slice(lastSlash + 1) : matchedSubpath
-    } else {
-      // Take the first segment (what matches the *)
-      const firstSlash = matchedPart.indexOf('/')
-      matchedSubpath =
-        firstSlash >= 0 ? matchedPart.slice(0, firstSlash) : matchedPart
-    }
+    // What `*` stands for, e.g. "features/nested/deep" -> "nested/deep"
+    const matchedSubpath = subpath.slice(
+      prefix.length,
+      subpath.length - suffix.length,
+    )
 
-    // Build the concrete export path
-    // "./features/*" + "foo" -> "./features/foo"
-    const concreteExportPath = basePath
-      ? `./${basePath}/${matchedSubpath}`
-      : `./${matchedSubpath}`
-
-    expanded.set(concreteExportPath, matchedSubpath)
+    expanded.set(`./${subpath}`, matchedSubpath)
   }
 
   return expanded

--- a/test/integration/prepare-ts-with-private-file/.gitignore
+++ b/test/integration/prepare-ts-with-private-file/.gitignore
@@ -1,0 +1,2 @@
+package.json
+tsconfig.json

--- a/test/integration/prepare-ts-with-private-file/index.test.ts
+++ b/test/integration/prepare-ts-with-private-file/index.test.ts
@@ -1,0 +1,26 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+import fsp from 'fs/promises'
+import { join } from 'path'
+import { assertContainFiles, createJob, deleteFile } from '../../testing-utils'
+
+describe('integration prepare-ts-with-private-file', () => {
+  const dir = __dirname
+  beforeAll(async () => {
+    await deleteFile(join(dir, './package.json'))
+    await deleteFile(join(dir, './tsconfig.json'))
+  })
+  createJob({
+    args: ['prepare'],
+    directory: __dirname,
+  })
+  it('should not expose private shared modules as exports', async () => {
+    assertContainFiles(dir, ['package.json'])
+    const pkgJson = JSON.parse(
+      await fsp.readFile(join(dir, './package.json'), 'utf-8'),
+    )
+    // Underscore-prefixed files and directories are shared modules, not entries.
+    // Regression: `_shared.ts` and `lib/_helper.ts` used to be written out as
+    // public subpath exports, since the ignore glob only matched directories.
+    expect(Object.keys(pkgJson.exports).sort()).toEqual(['.', './lib/pub'])
+  })
+})

--- a/test/integration/prepare-ts-with-private-file/src/_internal/index.ts
+++ b/test/integration/prepare-ts-with-private-file/src/_internal/index.ts
@@ -1,0 +1,1 @@
+export const internal = 'internal'

--- a/test/integration/prepare-ts-with-private-file/src/_shared.ts
+++ b/test/integration/prepare-ts-with-private-file/src/_shared.ts
@@ -1,0 +1,1 @@
+export const shared = 'shared'

--- a/test/integration/prepare-ts-with-private-file/src/index.ts
+++ b/test/integration/prepare-ts-with-private-file/src/index.ts
@@ -1,0 +1,1 @@
+export const index = 'index'

--- a/test/integration/prepare-ts-with-private-file/src/lib/_helper.ts
+++ b/test/integration/prepare-ts-with-private-file/src/lib/_helper.ts
@@ -1,0 +1,1 @@
+export const helper = 'helper'

--- a/test/integration/prepare-ts-with-private-file/src/lib/pub.ts
+++ b/test/integration/prepare-ts-with-private-file/src/lib/pub.ts
@@ -1,0 +1,1 @@
+export const pub = 'pub'

--- a/test/integration/types-condition-first/index.test.ts
+++ b/test/integration/types-condition-first/index.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assertContainFiles,
+  createJob,
+  getFileContents,
+} from '../../testing-utils'
+
+describe('integration types-condition-first', () => {
+  const { distDir } = createJob({ directory: __dirname })
+
+  it('should emit declarations, not JS, when types nests the format conditions', async () => {
+    await assertContainFiles(distDir, [
+      'index.js',
+      'index.cjs',
+      'index.d.mts',
+      'index.d.cts',
+    ])
+
+    const contents = await getFileContents(distDir)
+
+    // Regression: `types.import` used to be classified by its last condition
+    // (`import`), so the JS bundle was written into the .d.mts/.d.cts files.
+    for (const dtsFile of ['index.d.mts', 'index.d.cts']) {
+      expect(contents[dtsFile]).toContain('declare const value: number')
+      expect(contents[dtsFile]).not.toContain('const value = 1')
+    }
+
+    expect(contents['index.js']).toContain('const value = 1')
+    expect(contents['index.cjs']).toContain('const value = 1')
+  })
+})

--- a/test/integration/types-condition-first/package.json
+++ b/test/integration/types-condition-first/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "types-condition-first",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": {
+        "import": "./dist/index.d.mts",
+        "require": "./dist/index.d.cts"
+      },
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  }
+}

--- a/test/integration/types-condition-first/src/index.ts
+++ b/test/integration/types-condition-first/src/index.ts
@@ -1,0 +1,2 @@
+export const value: number = 1
+export type Value = typeof value

--- a/test/integration/wildcard-patterns/index.test.ts
+++ b/test/integration/wildcard-patterns/index.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assertContainFiles,
+  createJob,
+  getFileNamesFromDirectory,
+} from '../../testing-utils'
+
+describe('integration wildcard-patterns', () => {
+  const { distDir } = createJob({ directory: __dirname })
+
+  it('should expand wildcards that are not a whole trailing segment', async () => {
+    // `./feat-*` — wildcard prefixed within a segment
+    // `./*/utils` — wildcard followed by a suffix
+    // `./features/*` — wildcard matching across `/`
+    await assertContainFiles(distDir, [
+      'index.js',
+      'feat-alpha.js',
+      'feat-beta.js',
+      'features/flat.js',
+      'features/nested/inner/deep.js',
+      'alpha/utils.js',
+      'beta/utils.js',
+    ])
+  })
+
+  it('should not expand private modules into public wildcard exports', async () => {
+    const files = await getFileNamesFromDirectory(distDir)
+    // `_private.ts` is a shared module, so it is still emitted, but it must not
+    // be treated as the `./features/_private` subpath export.
+    expect(files).not.toContain('features/_private/index.js')
+  })
+
+  it('should not emit a bundle per wildcard segment prefix', async () => {
+    const files = await getFileNamesFromDirectory(distDir)
+    // Regression: `./feat-*` used to resolve to the bogus export `./feat-/feat-alpha`
+    expect(files.filter((f) => f.startsWith('feat-/'))).toEqual([])
+    // Regression: `./*/utils` used to collapse to `./alpha` / `./beta`
+    expect(files).not.toContain('alpha.js')
+    expect(files).not.toContain('beta.js')
+  })
+})

--- a/test/integration/wildcard-patterns/package.json
+++ b/test/integration/wildcard-patterns/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "wildcard-patterns",
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js",
+    "./feat-*": "./dist/feat-*.js",
+    "./features/*": "./dist/features/*.js",
+    "./*/utils": "./dist/*/utils.js"
+  }
+}

--- a/test/integration/wildcard-patterns/src/alpha/utils.ts
+++ b/test/integration/wildcard-patterns/src/alpha/utils.ts
@@ -1,0 +1,1 @@
+export const alphaUtils = 'alpha utils'

--- a/test/integration/wildcard-patterns/src/beta/utils.ts
+++ b/test/integration/wildcard-patterns/src/beta/utils.ts
@@ -1,0 +1,1 @@
+export const betaUtils = 'beta utils'

--- a/test/integration/wildcard-patterns/src/feat-alpha.ts
+++ b/test/integration/wildcard-patterns/src/feat-alpha.ts
@@ -1,0 +1,1 @@
+export const featAlpha = 'feat alpha'

--- a/test/integration/wildcard-patterns/src/feat-beta.ts
+++ b/test/integration/wildcard-patterns/src/feat-beta.ts
@@ -1,0 +1,1 @@
+export const featBeta = 'feat beta'

--- a/test/integration/wildcard-patterns/src/features/_private.ts
+++ b/test/integration/wildcard-patterns/src/features/_private.ts
@@ -1,0 +1,1 @@
+export const shared = 'private shared'

--- a/test/integration/wildcard-patterns/src/features/flat.ts
+++ b/test/integration/wildcard-patterns/src/features/flat.ts
@@ -1,0 +1,1 @@
+export const flat = 'flat feature'

--- a/test/integration/wildcard-patterns/src/features/nested/inner/deep.ts
+++ b/test/integration/wildcard-patterns/src/features/nested/inner/deep.ts
@@ -1,0 +1,1 @@
+export const deep = 'deep nested'

--- a/test/integration/wildcard-patterns/src/index.ts
+++ b/test/integration/wildcard-patterns/src/index.ts
@@ -1,0 +1,1 @@
+export const index = 'index'


### PR DESCRIPTION
## Summary

Bugs in `parseExports` and the CJS/ESM condition detection that either crash the build or silently ship a broken package.

- **`"./x": null` crashed the build.** `null` is valid in `exports` (it blocks a subpath), but the parser fell through to `Object.keys(null)` and died with `TypeError: Cannot convert undefined or null to object`. Both walkers now skip blocked subpaths.

- **`"types": { "import": …, "require": … }` wrote JavaScript into `.d.mts`/`.d.cts`.** `getFileExportType` read the last segment of the composed condition, so `types.import` was classified as `import` and routed to the JS build. `index.d.mts` came out as `const i = 1; export { i }` and the package shipped no declarations at all. `types` is now decisive wherever it appears.

- **`isEsmExportName`/`isCjsExportName` compared the whole composed condition,** so `import.default` never registered as ESM. Now matched per segment.

- **`"./feat-*"` resolved to the bogus export `./feat-/feat-alpha`** and reported `⨯ missing source files` instead of building `src/feat-alpha.ts`. The wildcard prefix was treated as a directory.

- **`"./*/utils"` collapsed to `./alpha` and built nothing,** same cause.

- **Deeply nested files under `"./features/*"` were never built.** Node's `*` matches across `/`, so `pkg/features/nested/inner/deep` resolved to a file that did not exist. Expansion now splits the key at the first `*` into prefix and suffix, narrowing the glob to the prefix's static directory part so `./features/*` still only walks `src/features`.

- **`src/features/a.development.ts` became its own export `./features/a.development`** and then errored as missing, instead of being the `development` variant of `./features/a`.

- **`prepare` published private shared modules.** `PRIVATE_GLOB_PATTERN` (`**/_*/**`) only matches `_*` as a directory with children, never a file like `_shared.ts`, so `./_shared` and `./lib/_helper` were written into `exports` and wildcards exposed `./features/_private`.

- **`bunchee src/foo.ts` crashed on a package whose `exports` has no `.` entry** — a non-null assertion on `parsedExportsInfo.get('./index')`. It now falls through to the export-derived entries.

- **`hasMultiEntryExport` called `Object.keys` on a `Map`,** which is always `[]`, so it has returned `false` unconditionally since the parser started returning a Map and `isMultiEntries` was dead. Bin paths are excluded so a package with `bin` still counts as multi-entry.

- **`getSourcePathFromExportPath` compared against `'/package.json'`,** a value it never receives.

- **`lint`'s "N issues found" counted only bad types exports and missing files,** omitting every bad-extension warning it went on to print.

## Note

The wildcard fixes widen `exports` patterns to full Node subpath semantics. Per [#469](https://github.com/huozhi/bunchee/issues/469) the alternative direction is to narrow wildcards back to the single `./dir/*` shape, or re-deprecate them in favour of `prepare` — happy to adjust this to either.