### PR TITLE
Represent export conditions as data instead of dot-joined strings

### DIFF
--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -139,10 +139,11 @@ async function buildConfig(
   if (!dts && isFromCli && outputExports.length === 0 && !pkg.bin) {
     const isEsmPkg = isESModulePackage(pkg.type)
     const defaultFormat: OutputOptions['format'] = isEsmPkg ? 'esm' : 'cjs'
+    const file = join(cwd, 'dist/index.js'.replace('/', path.sep))
     outputExports.push({
       format: defaultFormat,
-      file: join(cwd, 'dist/index.js'.replace('/', path.sep)),
-      exportCondition: 'default',
+      file,
+      target: { path: file, conditions: ['default'] },
     })
   }
   let bundleOptions: ExportOutput[] = []
@@ -155,7 +156,7 @@ async function buildConfig(
         {
           file: absoluteTypeFile,
           format: 'esm',
-          exportCondition: 'types',
+          target: { path: absoluteTypeFile, conditions: ['types'] },
         },
       ]
     } else {
@@ -164,7 +165,7 @@ async function buildConfig(
         {
           file: absoluteFile,
           format: bundleConfig.format || fallbackExport.format,
-          exportCondition: fallbackExport.exportCondition,
+          target: { ...fallbackExport.target, path: absoluteFile },
         },
       ]
     }
@@ -181,8 +182,8 @@ async function buildConfig(
       bundleOptions = Array.from(uniqTypes).map((typeFile) => {
         return {
           file: typeFile,
-          format: 'esm',
-          exportCondition: 'types',
+          format: 'esm' as const,
+          target: { path: typeFile, conditions: ['types'] },
         }
       })
     } else {
@@ -190,21 +191,17 @@ async function buildConfig(
         return {
           file: resolve(cwd, exportDist.file),
           format: exportDist.format,
-          exportCondition: exportDist.exportCondition,
+          target: exportDist.target,
         }
       })
     }
   }
 
   const outputConfigs = bundleOptions.map(async (bundleOption) => {
-    const targetExportCondition = {
+    // Narrow the entry down to the single output currently being built.
+    const targetExportCondition: ParsedExportCondition = {
       ...exportCondition,
-      export: {
-        [bundleOption.exportCondition]:
-          bundleOption.exportCondition === 'types'
-            ? bundleOption.file
-            : exportCondition.export[bundleOption.exportCondition],
-      },
+      targets: [bundleOption.target],
     }
     return await buildRollupConfigs(
       entry,

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -218,8 +218,11 @@ async function bundle(
       // from a js path when it is not always lands in the same directory.
       if (options.clean && !isFromCli) {
         for (const entry of Object.values(entries)) {
-          for (const distFile of Object.values(entry.export)) {
-            await removeOutputDir({ dir: dirname(resolve(cwd, distFile)) }, cwd)
+          for (const target of entry.targets) {
+            await removeOutputDir(
+              { dir: dirname(resolve(cwd, target.path)) },
+              cwd,
+            )
           }
         }
       }

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -103,13 +103,12 @@ async function bundle(
         typesEntryPath = getExportFileTypePath(mainExportPath)
       }
 
-      parsedExportsInfo.set(
-        './index',
-        [
-          [mainExportPath, 'default'],
-          Boolean(typesEntryPath) && [typesEntryPath, 'types'],
-        ].filter(Boolean) as [string, string][],
-      )
+      parsedExportsInfo.set('./index', [
+        { path: mainExportPath, conditions: ['default'] },
+        ...(typesEntryPath
+          ? [{ path: typesEntryPath, conditions: ['types'] }]
+          : []),
+      ])
     }
   }
 

--- a/src/entries.test.ts
+++ b/src/entries.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeExportPath } from './entries'
+
+describe('normalizeExportPath', () => {
+  it('should strip export condition suffixes', () => {
+    expect(normalizeExportPath('./index')).toBe('.')
+    expect(normalizeExportPath('./index.development')).toBe('.')
+    expect(normalizeExportPath('./index.react-server')).toBe('.')
+    expect(normalizeExportPath('./shared')).toBe('./shared')
+    expect(normalizeExportPath('./shared.development')).toBe('./shared')
+  })
+
+  it('should strip stacked condition suffixes', () => {
+    expect(normalizeExportPath('./index.development.react-server')).toBe('.')
+    expect(normalizeExportPath('./shared.production.node')).toBe('./shared')
+  })
+
+  it('should keep dots that are part of the subpath', () => {
+    // Regression: these used to be truncated to `./v1` and `./charts`, because
+    // everything after the first dot was assumed to be a condition.
+    expect(normalizeExportPath('./v1.2/thing')).toBe('./v1.2/thing')
+    expect(normalizeExportPath('./charts.min')).toBe('./charts.min')
+    expect(normalizeExportPath('./foo.bar')).toBe('./foo.bar')
+  })
+
+  it('should leave binary paths alone', () => {
+    expect(normalizeExportPath('$binary')).toBe('$binary')
+    expect(normalizeExportPath('$binary/index')).toBe('$binary')
+    expect(normalizeExportPath('$binary/foo')).toBe('$binary/foo')
+  })
+})

--- a/src/entries.ts
+++ b/src/entries.ts
@@ -3,7 +3,6 @@ import fsp from 'fs/promises'
 import path, { posix } from 'path'
 import { glob } from 'tinyglobby'
 import {
-  conditionKey,
   getExportTypeFromFile,
   getOutputFormat,
   getSpecialCondition,
@@ -54,7 +53,6 @@ export async function collectEntriesFromParsedExports(
       source: sourceFile,
       name: '.',
       targets: [target],
-      export: { default: target.path },
     }
   }
 
@@ -111,7 +109,6 @@ export async function collectEntriesFromParsedExports(
           source: sourceFile,
           name: normalizedExportPath,
           targets: [],
-          export: {},
         }
       } else if (matchedExportType === entryExportPathType) {
         entries[entryExportPath].source = sourceFile
@@ -139,7 +136,6 @@ export async function collectEntriesFromParsedExports(
           continue
         }
         entries[entryExportPath].targets.push(target)
-        entries[entryExportPath].export[conditionKey(target)] = target.path
       }
     }
   }
@@ -156,7 +152,6 @@ export async function collectEntriesFromParsedExports(
         source: sourceFile,
         name: exportPath,
         targets: [target],
-        export: { [conditionKey(target)]: target.path },
       }
     }
   }
@@ -206,7 +201,6 @@ export async function collectBinaries(
         source: binEntryPath,
         name: binName,
         targets: [target],
-        export: { [conditionKey(target)]: target.path },
       }
     }
   }
@@ -269,6 +263,29 @@ export function getSpecialExportTypeFromConditionNames(
   return exportType
 }
 
+// A trailing dot segment is only a condition if it actually names one.
+// Anything else is part of the subpath, e.g. `./v1.2` or `./charts.min`.
+const isConditionSuffix = (segment: string) =>
+  specialExportConventions.has(segment) ||
+  segment === 'import' ||
+  segment === 'require' ||
+  segment === 'types'
+
+// ./index.react-server        -> ./index
+// ./index.development.node    -> ./index
+// ./v1.2/thing                -> ./v1.2/thing  (`2/thing` is not a condition)
+function stripSpecialCondition(exportPath: string): string {
+  let result = exportPath
+  // Conditions can stack, e.g. `index.development.react-server.ts`.
+  while (true) {
+    const lastDot = result.lastIndexOf('.')
+    // index 0 is the leading `.` of `./foo`, never a condition separator.
+    if (lastDot <= 0) return result
+    if (!isConditionSuffix(result.slice(lastDot + 1))) return result
+    result = result.slice(0, lastDot)
+  }
+}
+
 // ./index -> .
 // ./index.development -> .
 // ./index.react-server -> .
@@ -284,16 +301,11 @@ export function normalizeExportPath(exportPath: string): string {
     }
     return exportPath
   }
-  const baseName = exportPath.split('.').slice(0, 2).join('.')
+  const baseName = stripSpecialCondition(exportPath)
   if (baseName === './index') {
     return '.'
   }
   return baseName
-}
-
-// ./index.react-server -> ./index
-function stripSpecialCondition(exportPath: string): string {
-  return exportPath.split('.').slice(0, 2).join('.')
 }
 
 export async function collectSourceEntriesByExportPath(
@@ -344,13 +356,15 @@ export async function collectSourceEntriesByExportPath(
     if (isBinaryPath) {
       bins.set(normalizeExportPath(originalSubpath), sourceFileAbsolutePath)
     } else {
+      // `index.development.ts` carries a condition; `charts.min.ts` does not.
       const parts = path.basename(file).split('.')
+      const filenameCondition =
+        parts.length > 2 && isConditionSuffix(parts[1]) ? parts[1] : undefined
       const exportType =
-        parts.length > 2 ? parts[1] : getExportTypeFromExportPath(exportPath)
-      const specialExportPath =
-        exportType !== 'index' && parts.length > 2
-          ? exportPath + '.' + exportType
-          : exportPath // Adjust for direct file matches
+        filenameCondition ?? getExportTypeFromExportPath(exportPath)
+      const specialExportPath = filenameCondition
+        ? exportPath + '.' + filenameCondition
+        : exportPath // Adjust for direct file matches
 
       const sourceFilesMap = exportsEntries.get(specialExportPath) || {}
       sourceFilesMap[exportType] = sourceFileAbsolutePath

--- a/src/entries.ts
+++ b/src/entries.ts
@@ -3,12 +3,15 @@ import fsp from 'fs/promises'
 import path, { posix } from 'path'
 import { glob } from 'tinyglobby'
 import {
+  conditionKey,
   getExportTypeFromFile,
-  getFileExportType,
-  isCjsExportName,
+  getOutputFormat,
+  getSpecialCondition,
+  isTypesTarget,
+  type OutputTarget,
   type ParsedExportsInfo,
 } from './exports'
-import { PackageMetadata, type Entries, ExportPaths } from './types'
+import { PackageMetadata, type Entries } from './types'
 import { logger } from './logger'
 import { baseNameWithoutExtension, validateEntryFiles } from './util/file-path'
 import {
@@ -43,12 +46,15 @@ export async function collectEntriesFromParsedExports(
   // build to, so fall through to the export-derived entries below.
   const defaultExport = parsedExportsInfo.get('./index')?.[0]
   if (sourceFile && defaultExport) {
+    const target: OutputTarget = {
+      path: defaultExport.path,
+      conditions: ['default'],
+    }
     entries['./index'] = {
       source: sourceFile,
       name: '.',
-      export: {
-        default: defaultExport[0],
-      },
+      targets: [target],
+      export: { default: target.path },
     }
   }
 
@@ -87,12 +93,9 @@ export async function collectEntriesFromParsedExports(
       continue
     }
 
-    for (const [outputPath, outputComposedExportType] of outputExports) {
+    for (const target of outputExports) {
       // export type can be: default, development, react-server, etc.
-
-      const matchedExportType = getSpecialExportTypeFromComposedExportPath(
-        outputComposedExportType,
-      )
+      const matchedExportType = getSpecialCondition(target)
       const specialSet = pathSpecialConditionsMap[normalizedExportPath]
       const hasSpecialEntry = specialSet.has(matchedExportType)
       const sourceFile =
@@ -107,6 +110,7 @@ export async function collectEntriesFromParsedExports(
         entries[entryExportPath] = {
           source: sourceFile,
           name: normalizedExportPath,
+          targets: [],
           export: {},
         }
       } else if (matchedExportType === entryExportPathType) {
@@ -134,8 +138,8 @@ export async function collectEntriesFromParsedExports(
         ) {
           continue
         }
-        const exportMap = entries[entryExportPath].export
-        exportMap[outputComposedExportType] = outputPath
+        entries[entryExportPath].targets.push(target)
+        entries[entryExportPath].export[conditionKey(target)] = target.path
       }
     }
   }
@@ -147,13 +151,12 @@ export async function collectEntriesFromParsedExports(
       continue
     }
 
-    for (const [outputPath, exportType] of outputExports) {
+    for (const target of outputExports) {
       entries[exportPath] = {
         source: sourceFile,
         name: exportPath,
-        export: {
-          [exportType]: outputPath,
-        },
+        targets: [target],
+        export: { [conditionKey(target)]: target.path },
       }
     }
   }
@@ -178,14 +181,16 @@ export async function collectBinaries(
             binaryExports[key],
           ])
 
-    const binExportPaths = binPairs.reduce((acc, [binName, binDistPath]) => {
-      const exportType = getExportTypeFromFile(binDistPath, pkg.type)
-
-      acc[binName] = {
-        [exportType]: binDistPath,
-      }
-      return acc
-    }, {} as ExportPaths)
+    const binTargets = binPairs.reduce(
+      (acc, [binName, binDistPath]) => {
+        acc[binName] = {
+          path: binDistPath,
+          conditions: [getExportTypeFromFile(binDistPath, pkg.type)],
+        }
+        return acc
+      },
+      {} as Record<string, OutputTarget>,
+    )
 
     for (const [binName] of binPairs) {
       const source = await getSourcePathFromExportPath(cwd, binName, BINARY_TAG)
@@ -196,10 +201,12 @@ export async function collectBinaries(
       }
 
       const binEntryPath = await resolveSourceFile(cwd, source)
+      const target = binTargets[binName]
       entries[binName] = {
         source: binEntryPath,
         name: binName,
-        export: binExportPaths[binName],
+        targets: [target],
+        export: { [conditionKey(target)]: target.path },
       }
     }
   }
@@ -384,22 +391,16 @@ export async function collectSourceEntriesFromExportPaths(
 
   for (const [exportPath, exportInfo] of parsedExportsInfo.entries()) {
     const specialConditions = new Set<string>()
-    for (const [outputPath, composedExportType] of exportInfo) {
+    for (const target of exportInfo) {
       // Collect required private shared module formats while walking export outputs.
-      const exportType = getFileExportType(composedExportType)
-      if (exportType !== 'types') {
-        const ext = path.extname(outputPath).slice(1)
-        requiredPrivateModuleFormats |= isCjsExportName(
-          pkg,
-          composedExportType,
-          ext,
-        )
-          ? ModuleFormat.cjs
-          : ModuleFormat.esm
+      if (!isTypesTarget(target)) {
+        requiredPrivateModuleFormats |=
+          getOutputFormat(pkg, target) === 'cjs'
+            ? ModuleFormat.cjs
+            : ModuleFormat.esm
       }
 
-      const specialExportType =
-        getSpecialExportTypeFromComposedExportPath(composedExportType)
+      const specialExportType = getSpecialCondition(target)
       if (specialExportType !== 'default') {
         specialConditions.add(specialExportType)
       }
@@ -448,9 +449,9 @@ export async function collectSourceEntriesFromExportPaths(
     const normalizedExportPath = stripSpecialCondition(exportPath)
     const isSpecialExport = specialExportType !== 'default'
 
-    // export type: default => ''
-    // export type: development => '.development'
-    const condPart = isSpecialExport ? specialExportType + '.' : ''
+    // Special conditions prefix the composed condition, e.g.
+    // `development` + `import` + `types`.
+    const condPrefix = isSpecialExport ? [specialExportType] : []
     const sourceExt = path.extname(file).slice(1)
     const formats =
       sourceExt === 'cts'
@@ -462,40 +463,34 @@ export async function collectSourceEntriesFromExportPaths(
     // Map private shared files to the dist directory
     // e.g. ./_utils.ts -> ./dist/_utils.js
     const isTs = isTypescriptFile(file)
-    const privateExportInfo: [string, string][] = []
+    const privateExportInfo: OutputTarget[] = []
+    const distPath = (ext: string) =>
+      posixRelativify(posix.join('./dist', exportPath + ext))
 
     if (formats === ModuleFormat.esm || formats === ModuleFormat.all) {
       if (isTs) {
-        privateExportInfo.push([
-          posixRelativify(
-            posix.join('./dist', exportPath + (isEsmPkg ? '.d.ts' : '.d.mts')),
-          ),
-          condPart + 'import.types',
-        ])
+        privateExportInfo.push({
+          path: distPath(isEsmPkg ? '.d.ts' : '.d.mts'),
+          conditions: [...condPrefix, 'import', 'types'],
+        })
       }
-      privateExportInfo.push([
-        posixRelativify(
-          posix.join('./dist', exportPath + (isEsmPkg ? '.js' : '.mjs')),
-        ),
-        condPart + 'import.default',
-      ])
+      privateExportInfo.push({
+        path: distPath(isEsmPkg ? '.js' : '.mjs'),
+        conditions: [...condPrefix, 'import', 'default'],
+      })
     }
 
     if (formats === ModuleFormat.cjs || formats === ModuleFormat.all) {
       if (isTs) {
-        privateExportInfo.push([
-          posixRelativify(
-            posix.join('./dist', exportPath + (isEsmPkg ? '.d.cts' : '.d.ts')),
-          ),
-          condPart + 'require.types',
-        ])
+        privateExportInfo.push({
+          path: distPath(isEsmPkg ? '.d.cts' : '.d.ts'),
+          conditions: [...condPrefix, 'require', 'types'],
+        })
       }
-      privateExportInfo.push([
-        posixRelativify(
-          posix.join('./dist', exportPath + (isEsmPkg ? '.cjs' : '.js')),
-        ),
-        condPart + 'require.default',
-      ])
+      privateExportInfo.push({
+        path: distPath(isEsmPkg ? '.cjs' : '.js'),
+        conditions: [...condPrefix, 'require', 'default'],
+      })
     }
 
     const exportsInfo = parsedExportsInfo.get(normalizedExportPath)

--- a/src/env.ts
+++ b/src/env.ts
@@ -15,16 +15,8 @@ export function getDefinedInlineVariables(
     return acc
   }, {})
 
-  const exportConditionNames = Object.keys(parsedExportCondition.export).reduce(
-    (acc, key) => {
-      // key could be 'require' or 'import.development' etc.
-      const exportTypes = key.split('.')
-      for (const exportType of exportTypes) {
-        acc.add(exportType)
-      }
-      return acc
-    },
-    new Set() as Set<string>,
+  const exportConditionNames = new Set(
+    parsedExportCondition.targets.flatMap((target) => target.conditions),
   )
 
   // For development and production convention, we override the NODE_ENV value

--- a/src/exports.test.ts
+++ b/src/exports.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import {
-  getFileExportType,
-  isCjsExportName,
-  isEsmExportName,
+  getOutputFormat,
+  getSpecialCondition,
+  isTypesTarget,
   parseExports,
+  type OutputTarget,
 } from './exports'
 import type { PackageMetadata } from './types'
 import * as wildcard from './wildcard'
@@ -23,6 +24,11 @@ vi.mock('tinyglobby', async () => {
     ...actual,
     glob: vi.fn(),
   }
+})
+
+const t = (path: string, ...conditions: string[]): OutputTarget => ({
+  path,
+  conditions,
 })
 
 describe('parse-exports', () => {
@@ -47,7 +53,7 @@ describe('parse-exports', () => {
     }
 
     const result = await parseExports(pkg)
-    expect(result.get('./index')).toEqual([['./dist/index.js', 'import']])
+    expect(result.get('./index')).toEqual([t('./dist/index.js', 'import')])
   })
 
   it('should parse exports with import and require conditions', async () => {
@@ -66,8 +72,8 @@ describe('parse-exports', () => {
     const exports = result.get('./index')
     expect(exports).toEqual(
       expect.arrayContaining([
-        ['./dist/index.mjs', 'import'],
-        ['./dist/index.cjs', 'require'],
+        t('./dist/index.mjs', 'import'),
+        t('./dist/index.cjs', 'require'),
       ]),
     )
   })
@@ -88,8 +94,8 @@ describe('parse-exports', () => {
     const exports = result.get('./index')
     expect(exports).toEqual(
       expect.arrayContaining([
-        ['./dist/index.d.ts', 'types'],
-        ['./dist/index.js', 'default'],
+        t('./dist/index.d.ts', 'types'),
+        t('./dist/index.js', 'default'),
       ]),
     )
   })
@@ -106,9 +112,9 @@ describe('parse-exports', () => {
     }
 
     const result = await parseExports(pkg)
-    expect(result.get('./index')).toEqual([['./dist/index.js', 'default']])
-    expect(result.get('./lite')).toEqual([['./dist/lite.js', 'default']])
-    expect(result.get('./utils')).toEqual([['./dist/utils.js', 'default']])
+    expect(result.get('./index')).toEqual([t('./dist/index.js', 'default')])
+    expect(result.get('./lite')).toEqual([t('./dist/lite.js', 'default')])
+    expect(result.get('./utils')).toEqual([t('./dist/utils.js', 'default')])
   })
 
   it('should parse wildcard exports when cwd is provided', async () => {
@@ -137,10 +143,10 @@ describe('parse-exports', () => {
 
     // Verify wildcard exports were expanded
     expect(result.get('./features/foo')).toEqual([
-      ['./dist/features/foo.js', 'default'],
+      t('./dist/features/foo.js', 'default'),
     ])
     expect(result.get('./features/bar')).toEqual([
-      ['./dist/features/bar.js', 'default'],
+      t('./dist/features/bar.js', 'default'),
     ])
   })
 
@@ -184,9 +190,9 @@ describe('parse-exports', () => {
     const fooExports = result.get('./features/foo')
     expect(fooExports).toEqual(
       expect.arrayContaining([
-        ['./dist/features/foo.mjs', 'import'],
-        ['./dist/features/foo.cjs', 'require'],
-        ['./dist/features/foo.d.ts', 'types'],
+        t('./dist/features/foo.mjs', 'import'),
+        t('./dist/features/foo.cjs', 'require'),
+        t('./dist/features/foo.d.ts', 'types'),
       ]),
     )
   })
@@ -199,7 +205,7 @@ describe('parse-exports', () => {
     }
 
     const result = await parseExports(pkg)
-    expect(result.get('$binary')).toEqual([['./dist/bin/cli.js', 'import']])
+    expect(result.get('$binary')).toEqual([t('./dist/bin/cli.js', 'import')])
   })
 
   it('should parse multiple bin exports', async () => {
@@ -213,9 +219,11 @@ describe('parse-exports', () => {
     }
 
     const result = await parseExports(pkg)
-    expect(result.get('$binary/cli')).toEqual([['./dist/bin/cli.js', 'import']])
+    expect(result.get('$binary/cli')).toEqual([
+      t('./dist/bin/cli.js', 'import'),
+    ])
     expect(result.get('$binary/server')).toEqual([
-      ['./dist/bin/server.js', 'import'],
+      t('./dist/bin/server.js', 'import'),
     ])
   })
 
@@ -232,18 +240,24 @@ describe('parse-exports', () => {
     const exports = result.get('./index')
     expect(exports).toMatchInlineSnapshot(`
       [
-        [
-          "./dist/index.js",
-          "import",
-        ],
-        [
-          "./dist/index.mjs",
-          "module",
-        ],
-        [
-          "./dist/index.d.ts",
-          "types",
-        ],
+        {
+          "conditions": [
+            "import",
+          ],
+          "path": "./dist/index.js",
+        },
+        {
+          "conditions": [
+            "module",
+          ],
+          "path": "./dist/index.mjs",
+        },
+        {
+          "conditions": [
+            "types",
+          ],
+          "path": "./dist/index.d.ts",
+        },
       ]
     `)
   })
@@ -256,7 +270,7 @@ describe('parse-exports', () => {
     }
 
     const result = await parseExports(pkg)
-    expect(result.get('./index')).toEqual([['./dist/index.js', 'require']])
+    expect(result.get('./index')).toEqual([t('./dist/index.js', 'require')])
   })
 
   it('should handle mixed wildcard and normal exports', async () => {
@@ -276,12 +290,12 @@ describe('parse-exports', () => {
     const result = await parseExports(pkg, mockCwd)
 
     // Normal exports should work
-    expect(result.get('./index')).toEqual([['./dist/index.js', 'default']])
-    expect(result.get('./utils')).toEqual([['./dist/utils.js', 'default']])
+    expect(result.get('./index')).toEqual([t('./dist/index.js', 'default')])
+    expect(result.get('./utils')).toEqual([t('./dist/utils.js', 'default')])
 
     // Wildcard exports should be expanded
     expect(result.get('./features/foo')).toEqual([
-      ['./dist/features/foo.js', 'default'],
+      t('./dist/features/foo.js', 'default'),
     ])
   })
 
@@ -297,9 +311,9 @@ describe('parse-exports', () => {
     }
 
     const result = await parseExports(pkg)
-    expect(result.get('./index')).toEqual([['./dist/index.js', 'default']])
+    expect(result.get('./index')).toEqual([t('./dist/index.js', 'default')])
     expect(result.get('./internal')).toBeUndefined()
-    expect(result.get('./nested')).toEqual([['./dist/nested.cjs', 'require']])
+    expect(result.get('./nested')).toEqual([t('./dist/nested.cjs', 'require')])
   })
 
   it('should skip wildcard export paths blocked with null', async () => {
@@ -336,72 +350,94 @@ describe('parse-exports', () => {
     const exports = result.get('./index')
     expect(exports).toEqual(
       expect.arrayContaining([
-        ['./dist/index.react-server.js', 'react-server'],
-        ['./dist/index.edge-light.js', 'edge-light'],
-        ['./dist/index.js', 'default'],
+        t('./dist/index.react-server.js', 'react-server'),
+        t('./dist/index.edge-light.js', 'edge-light'),
+        t('./dist/index.js', 'default'),
       ]),
     )
   })
 })
 
 describe('export condition classification', () => {
-  describe('getFileExportType', () => {
+  const cjsPkg: PackageMetadata = { name: 'p', type: 'commonjs' }
+  const esmPkg: PackageMetadata = { name: 'p', type: 'module' }
+
+  describe('isTypesTarget', () => {
     it('should detect the types condition wherever it is nested', () => {
-      expect(getFileExportType('types')).toBe('types')
-      expect(getFileExportType('import.types')).toBe('types')
+      expect(isTypesTarget(t('./i.d.ts', 'types'))).toBe(true)
+      expect(isTypesTarget(t('./i.d.ts', 'import', 'types'))).toBe(true)
       // `"types": { "import": ..., "require": ... }` nests the other way around
-      expect(getFileExportType('types.import')).toBe('types')
-      expect(getFileExportType('types.require')).toBe('types')
-      expect(getFileExportType('development.require.types')).toBe('types')
+      expect(isTypesTarget(t('./i.d.mts', 'types', 'import'))).toBe(true)
+      expect(
+        isTypesTarget(t('./i.d.cts', 'development', 'require', 'types')),
+      ).toBe(true)
     })
 
-    it('should return the last condition for non-types conditions', () => {
-      expect(getFileExportType('import.default')).toBe('default')
-      expect(getFileExportType('development.import.default')).toBe('default')
-      expect(getFileExportType('require')).toBe('require')
-    })
-  })
-
-  describe('isEsmExportName', () => {
-    it('should match esm conditions nested in a composed condition', () => {
-      expect(isEsmExportName('import', 'js')).toBe(true)
-      expect(isEsmExportName('import.default', 'js')).toBe(true)
-      expect(isEsmExportName('development.import.default', 'js')).toBe(true)
-      expect(isEsmExportName('module.default', 'js')).toBe(true)
-      expect(isEsmExportName('module-sync.default', 'js')).toBe(true)
-    })
-
-    it('should not match cjs conditions', () => {
-      expect(isEsmExportName('require.default', 'js')).toBe(false)
-      expect(isEsmExportName('default', 'js')).toBe(false)
-    })
-
-    it('should always treat .mjs as esm', () => {
-      expect(isEsmExportName('require', 'mjs')).toBe(true)
+    it('should not treat JS conditions as types', () => {
+      expect(isTypesTarget(t('./i.js', 'import', 'default'))).toBe(false)
+      expect(
+        isTypesTarget(t('./i.js', 'development', 'import', 'default')),
+      ).toBe(false)
     })
   })
 
-  describe('isCjsExportName', () => {
-    const cjsPkg: PackageMetadata = { name: 'p', type: 'commonjs' }
-    const esmPkg: PackageMetadata = { name: 'p', type: 'module' }
-
-    it('should not classify a nested import condition as cjs', () => {
-      expect(isCjsExportName(cjsPkg, 'import', 'js')).toBe(false)
-      expect(isCjsExportName(cjsPkg, 'import.default', 'js')).toBe(false)
-      expect(isCjsExportName(cjsPkg, 'development.import.default', 'js')).toBe(
-        false,
+  describe('getSpecialCondition', () => {
+    it('should find the runtime or optimize condition', () => {
+      expect(getSpecialCondition(t('./i.js', 'development', 'import'))).toBe(
+        'development',
+      )
+      expect(getSpecialCondition(t('./i.js', 'react-server', 'default'))).toBe(
+        'react-server',
       )
     })
 
-    it('should classify require conditions in a cjs package as cjs', () => {
-      expect(isCjsExportName(cjsPkg, 'require', 'js')).toBe(true)
-      expect(isCjsExportName(cjsPkg, 'require.default', 'js')).toBe(true)
-      expect(isCjsExportName(cjsPkg, 'default', 'js')).toBe(true)
+    it('should fall back to default', () => {
+      expect(getSpecialCondition(t('./i.js', 'import', 'default'))).toBe(
+        'default',
+      )
+    })
+  })
+
+  describe('getOutputFormat', () => {
+    it('should decide by extension first', () => {
+      expect(getOutputFormat(esmPkg, t('./i.cjs', 'require', 'default'))).toBe(
+        'cjs',
+      )
+      expect(getOutputFormat(cjsPkg, t('./i.mjs', 'import', 'default'))).toBe(
+        'esm',
+      )
     })
 
-    it('should classify by extension in an esm package', () => {
-      expect(isCjsExportName(esmPkg, 'require.default', 'cjs')).toBe(true)
-      expect(isCjsExportName(esmPkg, 'import.default', 'js')).toBe(false)
+    it('should follow package type for extensionless-ambiguous .js', () => {
+      expect(getOutputFormat(esmPkg, t('./i.js', 'import', 'default'))).toBe(
+        'esm',
+      )
+      expect(getOutputFormat(cjsPkg, t('./i.js', 'require', 'default'))).toBe(
+        'cjs',
+      )
+      expect(getOutputFormat(cjsPkg, t('./i.js', 'default'))).toBe('cjs')
+    })
+
+    it('should honour a nested esm condition in a cjs package', () => {
+      // Regression: the composed condition used to be compared as a whole
+      // string, so `import.default` never registered as esm.
+      expect(getOutputFormat(cjsPkg, t('./i.js', 'import', 'default'))).toBe(
+        'esm',
+      )
+      expect(
+        getOutputFormat(
+          cjsPkg,
+          t('./i.js', 'development', 'import', 'default'),
+        ),
+      ).toBe('esm')
+      expect(getOutputFormat(cjsPkg, t('./i.js', 'module', 'default'))).toBe(
+        'esm',
+      )
+    })
+
+    it('should let an explicit require condition win for .mjs in a cjs package', () => {
+      expect(getOutputFormat(cjsPkg, t('./i.mjs', 'require'))).toBe('cjs')
+      expect(getOutputFormat(esmPkg, t('./i.mjs', 'require'))).toBe('esm')
     })
   })
 })

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -18,7 +18,11 @@ import {
   substituteWildcardInPath,
 } from './wildcard'
 import { baseNameWithoutExtension } from './util/file-path'
-import { BINARY_TAG, dtsExtensionsMap } from './constants'
+import {
+  BINARY_TAG,
+  dtsExtensionsMap,
+  specialExportConventions,
+} from './constants'
 import { OutputOptions } from 'rollup'
 
 export function getPackageTypings(pkg: PackageMetadata) {
@@ -52,116 +56,39 @@ function constructFullExportCondition(
 }
 
 /**
- * export path: -> [ output path, export type ]
+ * A single output file declared by package.json, together with the export
+ * conditions that lead to it, outermost first.
+ *
+ * `{ path: './dist/index.mjs', conditions: ['development', 'import', 'default'] }`
+ *
+ * Conditions are kept as a list rather than a dot-joined string so that
+ * classification is a lookup instead of re-parsing. `conditionKey` produces the
+ * dot-joined form where a stable map key or a log label is needed.
  */
-export type ParsedExportsInfo = Map<string, [string, string][]>
-
-/**
- * Process export value for wildcard patterns, substituting wildcards in output paths
- */
-async function processWildcardExportValue(
-  exportValue: ExportCondition,
-  originalExportKey: string,
-  currentPath: string,
-  exportTypes: Set<string>,
-  exportToDist: ParsedExportsInfo,
-  matchedSubpath: string,
-) {
-  // `null` blocks a subpath from being resolved, there's nothing to build for it.
-  if (exportValue == null) {
-    return
-  }
-
-  // End of searching, export value is file path.
-  // <export key>: <export value> (string)
-  if (typeof exportValue === 'string') {
-    const composedTypes = new Set(exportTypes)
-    const exportType = originalExportKey.startsWith('.')
-      ? 'default'
-      : originalExportKey
-    composedTypes.add(exportType)
-    const exportInfo = exportToDist.get(mapExportFullPath(currentPath))
-    const exportCondition = Array.from(composedTypes).join('.')
-
-    // Substitute wildcard in output path
-    const substitutedPath = substituteWildcardInPath(
-      exportValue,
-      matchedSubpath,
-    )
-
-    if (!exportInfo) {
-      const outputConditionPair: [string, string] = [
-        substitutedPath,
-        exportCondition,
-      ]
-      addToExportDistMap(exportToDist, currentPath, [outputConditionPair])
-    } else {
-      exportInfo.push([substitutedPath, exportCondition])
-    }
-    return
-  }
-
-  const exportKeys = Object.keys(exportValue)
-  for (const exportKey of exportKeys) {
-    // Clone the set to avoid modifying the parent set
-    const childExports = new Set(exportTypes)
-    // Normalize child export value to a map
-    const childExportValue = exportValue[exportKey]
-
-    // Substitute wildcard in nested string values
-    let processedChildValue: ExportCondition = childExportValue
-    if (typeof childExportValue === 'string') {
-      processedChildValue = substituteWildcardInPath(
-        childExportValue,
-        matchedSubpath,
-      )
-    } else if (
-      typeof childExportValue === 'object' &&
-      childExportValue !== null
-    ) {
-      // Recursively process nested objects
-      const processed: Record<string, ExportCondition | string> = {}
-      for (const [key, value] of Object.entries(childExportValue)) {
-        if (typeof value === 'string') {
-          processed[key] = substituteWildcardInPath(value, matchedSubpath)
-        } else if (value !== null && value !== undefined) {
-          processed[key] = value
-        }
-      }
-      processedChildValue = processed as ExportCondition
-    }
-
-    // Visit export path: ./subpath, ./subpath2, ...
-    if (exportKey.startsWith('.')) {
-      const childPath = joinRelativePath(currentPath, exportKey)
-      await processWildcardExportValue(
-        processedChildValue,
-        exportKey,
-        childPath,
-        childExports,
-        exportToDist,
-        matchedSubpath,
-      )
-    } else {
-      // Visit export type: import, require, ...
-      childExports.add(exportKey)
-      await processWildcardExportValue(
-        processedChildValue,
-        exportKey,
-        currentPath,
-        childExports,
-        exportToDist,
-        matchedSubpath,
-      )
-    }
-  }
+export type OutputTarget = {
+  path: string
+  conditions: string[]
 }
 
+/**
+ * export path -> the output targets declared for it
+ */
+export type ParsedExportsInfo = Map<string, OutputTarget[]>
+
+export const conditionKey = (target: OutputTarget) =>
+  target.conditions.join('.')
+
+/**
+ * Walk one export value, recording an output target for every leaf string.
+ *
+ * There is deliberately one walker: wildcard keys are expanded into concrete
+ * keys before this runs, so it never needs to know about `*`.
+ */
 function collectExportPath(
   exportValue: ExportCondition,
   exportKey: string,
   currentPath: string,
-  exportTypes: Set<string>,
+  conditions: string[],
   exportToDist: ParsedExportsInfo,
 ) {
   // `null` blocks a subpath from being resolved, there's nothing to build for it.
@@ -172,47 +99,37 @@ function collectExportPath(
   // End of searching, export value is file path.
   // <export key>: <export value> (string)
   if (typeof exportValue === 'string') {
-    const composedTypes = new Set(exportTypes)
-    const exportType = exportKey.startsWith('.') ? 'default' : exportKey
-    composedTypes.add(exportType)
-    const exportInfo = exportToDist.get(mapExportFullPath(currentPath))
-    const exportCondition = Array.from(composedTypes).join('.')
-    if (!exportInfo) {
-      const outputConditionPair: [string, string] = [
-        exportValue,
-        exportCondition,
-      ]
-      addToExportDistMap(exportToDist, currentPath, [outputConditionPair])
-    } else {
-      exportInfo.push([exportValue, exportCondition])
-    }
+    const condition = exportKey.startsWith('.') ? 'default' : exportKey
+    // Dedupe while preserving the authored order, matching the old Set-based
+    // composition (`{ import: { import: ... } }` composes to just `import`).
+    const composed = conditions.includes(condition)
+      ? conditions
+      : [...conditions, condition]
+
+    addToExportDistMap(exportToDist, currentPath, [
+      { path: exportValue, conditions: composed },
+    ])
     return
   }
 
-  const exportKeys = Object.keys(exportValue)
-  for (const exportKey of exportKeys) {
-    // Clone the set to avoid modifying the parent set
-    const childExports = new Set(exportTypes)
-    // Normalize child export value to a map
-    const childExportValue = exportValue[exportKey]
-    // Visit export path: ./subpath, ./subpath2, ...
-    if (exportKey.startsWith('.')) {
-      const childPath = joinRelativePath(currentPath, exportKey)
+  for (const childKey of Object.keys(exportValue)) {
+    const childValue = exportValue[childKey]
+    if (childKey.startsWith('.')) {
+      // Visit export path: ./subpath, ./subpath2, ...
       collectExportPath(
-        childExportValue,
-        exportKey,
-        childPath,
-        childExports,
+        childValue,
+        childKey,
+        joinRelativePath(currentPath, childKey),
+        conditions,
         exportToDist,
       )
     } else {
       // Visit export type: import, require, ...
-      childExports.add(exportKey)
       collectExportPath(
-        childExportValue,
-        exportKey,
+        childValue,
+        childKey,
         currentPath,
-        childExports,
+        conditions.includes(childKey) ? conditions : [...conditions, childKey],
         exportToDist,
       )
     }
@@ -225,16 +142,67 @@ const mapExportFullPath = (exportPath: string) =>
 function addToExportDistMap(
   exportToDist: ParsedExportsInfo,
   exportPath: string,
-  outputConditionPairs: [string, string][],
+  targets: OutputTarget[],
 ) {
   const fullPath = mapExportFullPath(exportPath)
 
-  const existingExportInfo = exportToDist.get(fullPath)
-  if (!existingExportInfo) {
-    exportToDist.set(fullPath, outputConditionPairs)
+  const existing = exportToDist.get(fullPath)
+  if (!existing) {
+    exportToDist.set(fullPath, targets)
   } else {
-    existingExportInfo.push(...outputConditionPairs)
+    existing.push(...targets)
   }
+}
+
+/** Replace every `*` in a nested export value with the matched subpath. */
+function substituteWildcardDeep(
+  exportValue: ExportCondition,
+  matchedSubpath: string,
+): ExportCondition {
+  if (exportValue == null) {
+    return null
+  }
+  if (typeof exportValue === 'string') {
+    return substituteWildcardInPath(exportValue, matchedSubpath)
+  }
+  const result: Record<string, ExportCondition> = {}
+  for (const [key, value] of Object.entries(exportValue)) {
+    result[key] = substituteWildcardDeep(value, matchedSubpath)
+  }
+  return result
+}
+
+/**
+ * Rewrite wildcard keys into concrete ones before any walking happens.
+ *
+ * Returns pairs rather than an object so that a literal subpath and a wildcard
+ * that expands to the same subpath both survive, as they do today.
+ */
+async function expandExportKeys(
+  exportsField: Record<string, ExportCondition>,
+  cwd: string | undefined,
+): Promise<[string, ExportCondition][]> {
+  const pairs: [string, ExportCondition][] = []
+
+  for (const exportKey of Object.keys(exportsField)) {
+    const exportValue = exportsField[exportKey]
+    const isExportPath = exportKey.startsWith('.')
+
+    if (isExportPath && hasWildcardPattern(exportKey) && cwd) {
+      const expanded = await expandWildcardPattern(exportKey, cwd)
+      for (const [concreteExportPath, matchedSubpath] of expanded) {
+        pairs.push([
+          concreteExportPath,
+          substituteWildcardDeep(exportValue, matchedSubpath),
+        ])
+      }
+      continue
+    }
+
+    pairs.push([exportKey, exportValue])
+  }
+
+  return pairs
 }
 
 /**
@@ -257,92 +225,60 @@ export async function parseExports(
   const isEsmPkg = isESModulePackage(pkg.type)
   const defaultCondition = isEsmPkg ? 'import' : 'require'
 
-  let currentPath = '.'
+  const rootPath = '.'
 
   if (typeof exportsField === 'string') {
-    const outputConditionPair: [string, string] = [
-      exportsField,
-      defaultCondition,
-    ]
-    addToExportDistMap(exportToDist, currentPath, [outputConditionPair])
+    addToExportDistMap(exportToDist, rootPath, [
+      { path: exportsField, conditions: [defaultCondition] },
+    ])
   } else {
-    // keys means unknown if they're relative path or export type
-    const exportConditionKeys = Object.keys(exportsField)
+    // Wildcards are resolved up front, so the walk below only sees concrete keys.
+    const exportPairs = await expandExportKeys(exportsField, cwd)
 
-    for (const exportKey of exportConditionKeys) {
-      const exportValue = exportsField[exportKey]
-      const exportTypes: Set<string> = new Set()
+    for (const [exportKey, exportValue] of exportPairs) {
       const isExportPath = exportKey.startsWith('.')
-
-      // Handle wildcard patterns
-      if (isExportPath && hasWildcardPattern(exportKey) && cwd) {
-        // Expand wildcard pattern to concrete exports
-        const expanded = await expandWildcardPattern(exportKey, cwd)
-
-        for (const [concreteExportPath, matchedSubpath] of expanded) {
-          const childPath = joinRelativePath(currentPath, concreteExportPath)
-
-          // Process the export value and substitute wildcards in output paths
-          await processWildcardExportValue(
-            exportValue,
-            exportKey,
-            childPath,
-            exportTypes,
-            exportToDist,
-            matchedSubpath,
-          )
-        }
-        continue
-      }
-
-      const childPath = isExportPath
-        ? joinRelativePath(currentPath, exportKey)
-        : currentPath
-
-      if (!isExportPath) {
-        exportTypes.add(exportKey)
-      }
-
       collectExportPath(
         exportValue,
         exportKey,
-        childPath,
-        exportTypes,
+        isExportPath ? joinRelativePath(rootPath, exportKey) : rootPath,
+        isExportPath ? [] : [exportKey],
         exportToDist,
       )
     }
   }
 
   if (typeof bins === 'string') {
-    const outputConditionPair: [string, string] = [bins, defaultCondition]
-    addToExportDistMap(exportToDist, BINARY_TAG, [outputConditionPair])
+    addToExportDistMap(exportToDist, BINARY_TAG, [
+      { path: bins, conditions: [defaultCondition] },
+    ])
   } else {
     for (const binName of Object.keys(bins)) {
       const binDistPath = bins[binName]
-      const exportType = getExportTypeFromFile(binDistPath, pkg.type)
-      const exportPath = posix.join(BINARY_TAG, binName)
-      const outputConditionPair: [string, string] = [binDistPath, exportType]
-      addToExportDistMap(exportToDist, exportPath, [outputConditionPair])
+      addToExportDistMap(exportToDist, posix.join(BINARY_TAG, binName), [
+        {
+          path: binDistPath,
+          conditions: [getExportTypeFromFile(binDistPath, pkg.type)],
+        },
+      ])
     }
   }
 
   // Handle package.json global exports fields
   if (pkg.main || pkg.module || pkg.types) {
-    const mainExportPath = pkg.main
-    const moduleExportPath = pkg.module
-    const typesEntryPath = pkg.types
-
+    const rootFields: [string | undefined, string][] = [
+      [pkg.main, getMainFieldExportType(pkg)],
+      [pkg.module, 'module'],
+      [pkg.types, 'types'],
+    ]
     addToExportDistMap(
       exportToDist,
       './index',
-      [
-        Boolean(mainExportPath) && [
-          mainExportPath,
-          getMainFieldExportType(pkg),
-        ],
-        Boolean(moduleExportPath) && [moduleExportPath, 'module'],
-        Boolean(typesEntryPath) && [typesEntryPath, 'types'],
-      ].filter(Boolean) as [string, string][],
+      rootFields
+        .filter(([path]) => Boolean(path))
+        .map(([path, condition]) => ({
+          path: path as string,
+          conditions: [condition],
+        })),
     )
   }
 
@@ -370,41 +306,47 @@ export function constructDefaultExportCondition(
 const esmConditions = new Set(['import', 'module', 'module-sync'])
 const cjsConditions = new Set(['require', 'main'])
 
-export function isEsmExportName(name: string, ext: string) {
-  // `name` is a composed condition such as `import.default` or
-  // `development.import.types`, so match on segments rather than the whole string.
-  return (
-    name.split('.').some((cond) => esmConditions.has(cond)) || ext === 'mjs'
-  )
-}
+/**
+ * Whether a target produces a declaration file rather than a JS asset.
+ *
+ * `types` is decisive wherever it appears: both `{ import: { types } }` and
+ * `{ types: { import } }` are valid nestings in the wild.
+ */
+export const isTypesTarget = (target: OutputTarget) =>
+  target.conditions.includes('types')
 
-export function isCjsExportName(
+/**
+ * The runtime/optimize condition a target belongs to, e.g. `react-server`,
+ * `development`. `default` when it is not condition-specific.
+ */
+export const getSpecialCondition = (target: OutputTarget) =>
+  target.conditions.find((cond) => specialExportConventions.has(cond)) ??
+  'default'
+
+/**
+ * The single place that decides CJS vs ESM for an output file.
+ *
+ * The file extension plus `pkg.type` fully determines the format for any valid
+ * package.json; the conditions only break ties for misconfigured ones (which
+ * `lint` warns about separately).
+ */
+export function getOutputFormat(
   pkg: PackageMetadata,
-  exportCondition: string,
-  ext: string,
-) {
-  const isESModule = isESModulePackage(pkg.type)
-  const isCjsCondition = exportCondition
-    .split('.')
-    .some((cond) => cjsConditions.has(cond))
-  const isNotEsmExportName = !isEsmExportName(exportCondition, ext)
-  return (
-    (!isESModule && isNotEsmExportName && (ext !== 'mjs' || isCjsCondition)) ||
-    ext === 'cjs'
-  )
-}
-
-// `import.types` -> types
-// `types.import` -> types
-// `development.import.default` -> default
-export function getFileExportType(composedTypes: string) {
-  const conditions = composedTypes.split('.')
-  // `types` can be nested either way around, and it always wins: it decides
-  // whether the output is a declaration file or a JS asset.
-  if (conditions.includes('types')) {
-    return 'types'
+  target: OutputTarget,
+): 'cjs' | 'esm' {
+  const ext = extname(target.path).slice(1)
+  if (ext === 'cjs') return 'cjs'
+  if (ext === 'mjs') {
+    // `.mjs` is ESM unless a CJS package explicitly routes it through `require`.
+    return !isESModulePackage(pkg.type) &&
+      target.conditions.some((cond) => cjsConditions.has(cond))
+      ? 'cjs'
+      : 'esm'
   }
-  return conditions[conditions.length - 1]
+  if (isESModulePackage(pkg.type)) return 'esm'
+  return target.conditions.some((cond) => esmConditions.has(cond))
+    ? 'esm'
+    : 'cjs'
 }
 
 export type ExportOutput = {
@@ -419,35 +361,22 @@ export function getExportsDistFilesOfCondition(
   dts: boolean,
 ): ExportOutput[] {
   const dist: ExportOutput[] = []
-  const exportConditionNames = Object.keys(parsedExportCondition.export)
   const uniqueFiles = new Set<string>()
-  for (const exportCondition of exportConditionNames) {
-    const exportType = getFileExportType(exportCondition)
-    // Filter out non-types field when generating types jobs
-    if (dts && exportType !== 'types') {
+  for (const target of parsedExportCondition.targets) {
+    // Types jobs emit declarations, asset jobs emit JS. Never both.
+    if (dts !== isTypesTarget(target)) {
       continue
     }
-    // Filter out types field when generating asset jobs
-    if (!dts && exportType === 'types') {
-      continue
-    }
-    const filePath = parsedExportCondition.export[exportCondition]
-    const ext = extname(filePath).slice(1)
-    const relativePath = parsedExportCondition.export[exportCondition]
-    const distFile = resolve(cwd, relativePath)
-    const format: OutputOptions['format'] = isCjsExportName(
-      pkg,
-      exportCondition,
-      ext,
-    )
-      ? 'cjs'
-      : 'esm'
-
+    const distFile = resolve(cwd, target.path)
     if (uniqueFiles.has(distFile)) {
       continue
     }
     uniqueFiles.add(distFile)
-    dist.push({ format, file: distFile, exportCondition })
+    dist.push({
+      format: getOutputFormat(pkg, target),
+      file: distFile,
+      exportCondition: conditionKey(target),
+    })
   }
 
   return dist

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -2,8 +2,6 @@ import { posix, join, resolve, dirname, extname } from 'path'
 import type {
   PackageMetadata,
   ExportCondition,
-  FullExportCondition,
-  PackageType,
   ParsedExportCondition,
 } from './types'
 import {
@@ -27,32 +25,6 @@ import { OutputOptions } from 'rollup'
 
 export function getPackageTypings(pkg: PackageMetadata) {
   return pkg.types || pkg.typings
-}
-
-function constructFullExportCondition(
-  exportCondition: string | Record<string, string | undefined>,
-  packageType: PackageType,
-): FullExportCondition {
-  let fullExportCond: FullExportCondition
-  if (typeof exportCondition === 'string') {
-    const exportType = getExportTypeFromFile(exportCondition, packageType)
-
-    fullExportCond = {
-      [exportType]: exportCondition,
-    }
-  } else {
-    const exportTypes: string[] = Object.keys(exportCondition)
-    fullExportCond = {}
-    exportTypes.forEach((exportType) => {
-      const condition = exportCondition[exportType]
-      // Filter out nullable value
-      if (condition) {
-        fullExportCond[exportType] = condition
-      }
-    })
-  }
-
-  return fullExportCond
 }
 
 /**
@@ -285,24 +257,6 @@ export async function parseExports(
   return exportToDist
 }
 
-export function constructDefaultExportCondition(
-  value: string | Record<string, string | undefined>,
-  packageType: PackageType,
-) {
-  const isEsmPackage = isESModulePackage(packageType)
-  let exportCondition
-  if (typeof value === 'string') {
-    const types = getPackageTypings(value as PackageMetadata)
-    exportCondition = {
-      [isEsmPackage ? 'import' : 'require']: value,
-      ...(types && { types }),
-    }
-  } else {
-    exportCondition = value
-  }
-  return constructFullExportCondition(exportCondition, packageType)
-}
-
 const esmConditions = new Set(['import', 'module', 'module-sync'])
 const cjsConditions = new Set(['require', 'main'])
 
@@ -351,8 +305,9 @@ export function getOutputFormat(
 
 export type ExportOutput = {
   format: OutputOptions['format']
+  /** Absolute output path */
   file: string
-  exportCondition: string
+  target: OutputTarget
 }
 export function getExportsDistFilesOfCondition(
   pkg: PackageMetadata,
@@ -375,7 +330,7 @@ export function getExportsDistFilesOfCondition(
     dist.push({
       format: getOutputFormat(pkg, target),
       file: distFile,
-      exportCondition: conditionKey(target),
+      target,
     })
   }
 

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -1,5 +1,10 @@
 import path from 'path'
-import { parseExports } from './exports'
+import {
+  conditionKey,
+  isTypesTarget,
+  parseExports,
+  type OutputTarget,
+} from './exports'
 import { logger } from './logger'
 import { PackageMetadata } from './types'
 import {
@@ -16,14 +21,8 @@ type BadExportItem = {
   paths: string[]
 }
 
-function validateTypesFieldCondition(pair: [string, string]) {
-  const [outputPath, composedExportType] = pair
-  const exportTypes = new Set(composedExportType.split('.'))
-
-  if (!exportTypes.has('types') && isTypeFile(outputPath)) {
-    return true
-  }
-  return false
+function validateTypesFieldCondition(target: OutputTarget) {
+  return !isTypesTarget(target) && isTypeFile(target.path)
 }
 
 function validateFilesField(packageJson: PackageMetadata) {
@@ -86,7 +85,7 @@ export async function lint(cwd: string) {
     badCjsImportExport: BadExportItem
     badEsmRequireExport: BadExportItem
     badEsmImportExport: BadExportItem
-    badTypesExport: [string, string][]
+    badTypesExport: OutputTarget[]
   } = {
     badMainExtension: false,
     badMainExport: false,
@@ -120,31 +119,23 @@ export async function lint(cwd: string) {
       } else if (typeof exports !== 'object') {
         exportsState.invalidExportsFieldType = true
       } else {
-        parsedExports.forEach((outputPairs) => {
-          for (const outputPair of outputPairs) {
-            const [outputPath, composedExportType] = outputPair
-            if (validateTypesFieldCondition([outputPath, composedExportType])) {
-              exportsState.badTypesExport.push([outputPath, composedExportType])
+        parsedExports.forEach((targets) => {
+          for (const target of targets) {
+            if (validateTypesFieldCondition(target)) {
+              exportsState.badTypesExport.push(target)
             }
 
-            const exportTypes = new Set(composedExportType.split('.'))
-            let requirePath: string = ''
-            let importPath: string = ''
-            if (exportTypes.has('require')) {
-              requirePath = outputPath
-            }
-            if (exportTypes.has('import')) {
-              importPath = outputPath
-            }
-            const requireExt = requirePath && path.extname(requirePath)
-            const importExt = importPath && path.extname(importPath)
-            if (requireExt === '.mjs' || requireExt === '.js') {
+            const ext = path.extname(target.path)
+            if (
+              target.conditions.includes('require') &&
+              (ext === '.mjs' || ext === '.js')
+            ) {
               exportsState.badEsmRequireExport.value = true
-              exportsState.badEsmRequireExport.paths.push(requirePath)
+              exportsState.badEsmRequireExport.paths.push(target.path)
             }
-            if (importExt === '.cjs') {
+            if (target.conditions.includes('import') && ext === '.cjs') {
               exportsState.badEsmImportExport.value = true
-              exportsState.badEsmImportExport.paths.push(importPath)
+              exportsState.badEsmImportExport.paths.push(target.path)
             }
           }
         })
@@ -163,30 +154,22 @@ export async function lint(cwd: string) {
       } else if (typeof exports !== 'object') {
         exportsState.invalidExportsFieldType = true
       } else {
-        parsedExports.forEach((outputPairs) => {
-          for (const outputPair of outputPairs) {
-            const [outputPath, composedExportType] = outputPair
-            if (validateTypesFieldCondition([outputPath, composedExportType])) {
-              exportsState.badTypesExport.push([outputPath, composedExportType])
+        parsedExports.forEach((targets) => {
+          for (const target of targets) {
+            if (validateTypesFieldCondition(target)) {
+              exportsState.badTypesExport.push(target)
             }
-            const exportTypes = new Set(composedExportType.split('.'))
-            let requirePath: string = ''
-            let importPath: string = ''
-            if (exportTypes.has('require')) {
-              requirePath = outputPath
-            }
-            if (exportTypes.has('import')) {
-              importPath = outputPath
-            }
-            const requireExt = requirePath && path.extname(requirePath)
-            const importExt = importPath && path.extname(importPath)
-            if (requireExt === '.mjs') {
+            const ext = path.extname(target.path)
+            if (target.conditions.includes('require') && ext === '.mjs') {
               exportsState.badCjsRequireExport.value = true
-              exportsState.badCjsRequireExport.paths.push(requirePath)
+              exportsState.badCjsRequireExport.paths.push(target.path)
             }
-            if (importExt === '.js' || importExt === '.cjs') {
+            if (
+              target.conditions.includes('import') &&
+              (ext === '.js' || ext === '.cjs')
+            ) {
               exportsState.badCjsImportExport.value = true
-              exportsState.badCjsImportExport.paths.push(importPath)
+              exportsState.badCjsImportExport.paths.push(target.path)
             }
           }
         })
@@ -276,9 +259,9 @@ export async function lint(cwd: string) {
   }
 
   if (exportsState.badTypesExport.length) {
-    exportsState.badTypesExport.forEach(([outputPath, composedExportType]) => {
+    exportsState.badTypesExport.forEach((target) => {
       logger.error(
-        `Bad export types field with ${composedExportType} in ${outputPath}, use "types" export condition for it`,
+        `Bad export types field with ${conditionKey(target)} in ${target.path}, use "types" export condition for it`,
       )
     })
   }

--- a/src/plugins/alias-plugin.ts
+++ b/src/plugins/alias-plugin.ts
@@ -127,7 +127,7 @@ export function aliasEntries({
   cwd: string
 }): Plugin {
   const currentConditionNames = new Set(
-    Object.keys(exportCondition.export)[0].split('.'),
+    exportCondition.targets[0]?.conditions ?? [],
   )
 
   // <imported source file path>: <relative path to source's bundle>
@@ -136,21 +136,13 @@ export function aliasEntries({
     currentConditionNames,
   )
   for (const [, exportCondition] of Object.entries(entries)) {
-    const exportDistMaps = exportCondition.export
-
-    const exportMapEntries = Object.entries(exportDistMaps).map(
-      ([composedKey, bundlePath]) => {
-        const conditionNames = new Set(composedKey.split('.'))
-
-        return {
-          conditionNames,
-          bundlePath,
-          format,
-          isDefaultCondition:
-            conditionNames.size === 1 && conditionNames.has('default'),
-        }
-      },
-    )
+    const exportMapEntries = exportCondition.targets.map((target) => ({
+      conditionNames: new Set(target.conditions),
+      bundlePath: target.path,
+      format,
+      isDefaultCondition:
+        target.conditions.length === 1 && target.conditions[0] === 'default',
+    }))
 
     let matchedBundlePath: string | undefined
     if (dts) {

--- a/src/rollup/output.ts
+++ b/src/rollup/output.ts
@@ -7,7 +7,6 @@ import type {
 import { createSplitChunks } from './split-chunks'
 import { resolve, dirname, basename } from 'path'
 import { filePathWithoutExtension, isESModulePackage } from '../utils'
-import { getExportFileTypePath } from '../exports'
 
 export async function buildOutputConfigs(
   bundleConfig: BundleConfig,
@@ -28,16 +27,8 @@ export async function buildOutputConfigs(
   const absoluteOutputFile = resolve(cwd, bundleConfig.file!)
   const isEsmPkg = isESModulePackage(pkg.type)
   const name = filePathWithoutExtension(absoluteOutputFile)
-  const dtsFile = resolve(
-    cwd,
-    dts
-      ? bundleConfig.file!
-      : (exportCondition.export.types ??
-          getExportFileTypePath(bundleConfig.file!)),
-  )
-  const typesDir = dirname(dtsFile)
-  const jsDir = dirname(absoluteOutputFile!)
-  const outputFile: string = dts ? dtsFile : absoluteOutputFile
+  // For a types job `bundleConfig.file` is already the declaration path.
+  const outputFile: string = absoluteOutputFile
   const entryFiles = new Set(
     Object.values(entries).map((entry) => entry.source),
   )
@@ -59,7 +50,7 @@ export async function buildOutputConfigs(
   const outputOptions: OutputOptions = {
     name: pkg.name || name,
     extend: true,
-    dir: dts ? typesDir : jsDir,
+    dir: dirname(outputFile),
     format,
     exports: 'named',
     esModule: useEsModuleMark || 'if-default-prop',

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,15 +136,8 @@ type BundleOptions = BundleConfig
 type ParsedExportCondition = {
   source: string
   name: string
-  /**
-   * The authoritative list of outputs for this entry.
-   */
+  /** Every output file this entry produces. */
   targets: OutputTarget[]
-  /**
-   * Dot-joined condition key -> output path. Derived from `targets`, kept while
-   * the rollup/plugin layer still looks outputs up by composed key.
-   */
-  export: FullExportCondition
 }
 
 type ExportPaths = Record<string, FullExportCondition>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import type { OutputTarget } from './exports'
 import type { JscTarget } from '@swc/types'
 import type { InputOptions, OutputOptions } from 'rollup'
 import type { OutputState } from './plugins/output-state-plugin'
@@ -135,6 +136,14 @@ type BundleOptions = BundleConfig
 type ParsedExportCondition = {
   source: string
   name: string
+  /**
+   * The authoritative list of outputs for this entry.
+   */
+  targets: OutputTarget[]
+  /**
+   * Dot-joined condition key -> output path. Derived from `targets`, kept while
+   * the rollup/plugin layer still looks outputs up by composed key.
+   */
   export: FullExportCondition
 }
 

--- a/test/integration/dotted-subpaths/index.test.ts
+++ b/test/integration/dotted-subpaths/index.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assertContainFiles,
+  createJob,
+  getFileContents,
+} from '../../testing-utils'
+
+describe('integration dotted-subpaths', () => {
+  const { distDir } = createJob({ directory: __dirname })
+
+  it('should build subpaths that contain a literal dot', async () => {
+    // Regression: `./v1.2/thing` and `./charts.min` were truncated to `./v1`
+    // and `./charts`, so neither entry resolved to a source file.
+    await assertContainFiles(distDir, [
+      'index.js',
+      'v1.2/thing.js',
+      'charts.min.js',
+    ])
+
+    const contents = await getFileContents(distDir)
+    expect(contents['v1.2/thing.js']).toContain('thing')
+    expect(contents['charts.min.js']).toContain('charts')
+  })
+})

--- a/test/integration/dotted-subpaths/package.json
+++ b/test/integration/dotted-subpaths/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "dotted-subpaths",
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js",
+    "./v1.2/thing": "./dist/v1.2/thing.js",
+    "./charts.min": "./dist/charts.min.js"
+  }
+}

--- a/test/integration/dotted-subpaths/src/charts.min.ts
+++ b/test/integration/dotted-subpaths/src/charts.min.ts
@@ -1,0 +1,1 @@
+export const charts = 'charts'

--- a/test/integration/dotted-subpaths/src/index.ts
+++ b/test/integration/dotted-subpaths/src/index.ts
@@ -1,0 +1,1 @@
+export const index = 'index'

--- a/test/integration/dotted-subpaths/src/v1.2/thing.ts
+++ b/test/integration/dotted-subpaths/src/v1.2/thing.ts
@@ -1,0 +1,1 @@
+export const thing = 'thing'


### PR DESCRIPTION
## Problem

Export conditions were flattened into a dot-joined string (`'development.import.default'`) and re-parsed with ad-hoc string ops at every consumer. The misclassification bugs in #743 were three copies of the same mistake — `.pop()` on `types.import`, whole-string compares on `import.default`.

The same assumption applied to export paths: everything after the first dot was treated as a condition, so `./v1.2/thing` truncated to `./v1` and never resolved to a source file.

## Change

- `[path, 'a.b.c']` becomes `{ path, conditions: ['a', 'b', 'c'] }`. Classification is a lookup: `isTypesTarget`, `getSpecialCondition`, `getOutputFormat`
- `getOutputFormat` is the single place deciding CJS vs ESM
- Wildcard keys are expanded to concrete keys before the walk, so there is one tree walker instead of two near-duplicates. The removed one is where the `null` crash came from
- A trailing dot segment is only stripped when it actually names a condition, fixing `./v1.2/thing` and `./charts.min`
- `ParsedExportCondition` carries only `targets`; the parallel dot-keyed record is gone
- Removed `constructDefaultExportCondition` / `constructFullExportCondition`, which nothing referenced, and a `types` lookup in `rollup/output.ts` that only had an effect on the path where it was never read

459 insertions, 571 deletions. `exports.ts` −116, `lint.ts` −17. Condition-string splitting goes from 14 sites to 3, all allowlist-guarded.

## Not included

The special-condition matching loop in `entries.ts` keeps its current control flow. Entry keys still encode the condition (`./index.react-server`) because they cross the worker boundary as ids, so that logic reads `name` and the stripped path rather than being restructured. It is the remaining cleanup in this area.