### PR TITLE
Build a full module graph across entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,8 +359,16 @@ builds each group once, writing one output per format from the same graph:
 bunchee --merge-entries
 ```
 
-Run with `DEBUG=1` to see the grouping, and the reason when a package is not
-merged.
+Declaration emit is linear in entry count and cannot be amortised by sharing a
+graph, so above the worker threshold the types are split into shards that each
+build a merged graph in their own worker. Set `BUNCHEE_DTS_SHARDS` to override
+how many. Run with `DEBUG=1` to see the grouping, the shard layout, and the
+reason when a package is not merged.
+
+This trades wall-clock time for total CPU. Merging is faster on both for
+packages below the worker threshold, and above it it uses roughly 1.4–2.5x less
+CPU while being at parity to ~25% slower in wall time on an otherwise idle
+multi-core machine.
 
 Two things change when this is on:
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,30 @@ Here's a example of entry files and exports configuration:
 
 This will automatically discover files in `src/features/` and generate exports like `./features/foo`, `./features/bar`, etc. The wildcard `*` is substituted in both the export path and output path.
 
+### How Entries Are Built
+
+Entries that can share a module graph are grouped and built together, so a
+package with many exports does not pay for a rollup instance per entry/output
+pair — 50 exports in two formats plus types would otherwise be 150 of them.
+Within a group each entry still lands on the exact path its export condition
+declares.
+
+Two consequences worth knowing:
+
+- Code shared between entries becomes a chunk instead of being copied into every
+  entry that imports it, so `dist` contains chunk files alongside the entries.
+- Re-exports of a sibling entry are emitted as named re-exports rather than
+  `export *`, because the sibling's exports are known.
+
+Type declarations are the one part that cannot be shared — declaration emit is
+linear in entry count — so they are split across workers instead. Set
+`BUNCHEE_DTS_SHARDS` to override how many. Run with `DEBUG=1` to see the
+grouping and the shard layout.
+
+Some packages are built one entry at a time instead, which `DEBUG=1` also
+reports: `bin` entries, runtime or `development`/`production` export conditions,
+`'use client'` / `'use server'` boundaries, a single `-o` output, and watch mode.
+
 ### Output Formats
 
 **bunchee** detects the format of each entry-point based on export condition type or the file extension. It supports the following output formats:
@@ -347,38 +371,6 @@ bunchee --no-external
 ```
 
 This will include all dependencies within your output bundle.
-
-#### Building entries in shared rollup instances
-
-bunchee groups every entry that can share a module graph and builds each group
-once, writing one output per format from the same graph, rather than creating a
-rollup instance per entry/output pair. A package with 50 exports in two formats
-plus types would otherwise build through 150 of them.
-
-Declaration emit is linear in entry count and cannot be amortised by sharing a
-graph, so above the worker threshold the types are split into shards that each
-build a merged graph in their own worker. Set `BUNCHEE_DTS_SHARDS` to override
-how many. Run with `DEBUG=1` to see the grouping, the shard layout, and the
-reason when a package is not merged.
-
-Two things differ from building each entry separately:
-
-- Code shared between entries becomes a chunk instead of being copied into every
-  entry that imports it, so the emitted file list gains chunk files.
-- Re-exports of a sibling entry are emitted as named re-exports rather than
-  `export *`, because rollup knows the sibling's exports once it is part of the
-  same graph.
-
-Packages that cannot be merged fall back to one instance per entry, with no
-change in output: `bin` entries, runtime or `development`/`production` export
-conditions, `'use client'` / `'use server'` boundaries, a single `-o` output,
-and watch mode.
-
-To opt out and build each entry in its own rollup instance:
-
-```sh
-bunchee --no-merge-entries
-```
 
 #### Build Successful Command
 

--- a/README.md
+++ b/README.md
@@ -348,16 +348,12 @@ bunchee --no-external
 
 This will include all dependencies within your output bundle.
 
-#### Merging entries into shared rollup instances (experimental)
+#### Building entries in shared rollup instances
 
-By default bunchee creates one rollup instance per entry/output pair, so a
-package with 50 exports in two formats plus types builds through 150 of them.
-`--merge-entries` instead groups every entry that can share a module graph and
-builds each group once, writing one output per format from the same graph:
-
-```sh
-bunchee --merge-entries
-```
+bunchee groups every entry that can share a module graph and builds each group
+once, writing one output per format from the same graph, rather than creating a
+rollup instance per entry/output pair. A package with 50 exports in two formats
+plus types would otherwise build through 150 of them.
 
 Declaration emit is linear in entry count and cannot be amortised by sharing a
 graph, so above the worker threshold the types are split into shards that each
@@ -365,12 +361,7 @@ build a merged graph in their own worker. Set `BUNCHEE_DTS_SHARDS` to override
 how many. Run with `DEBUG=1` to see the grouping, the shard layout, and the
 reason when a package is not merged.
 
-This trades wall-clock time for total CPU. Merging is faster on both for
-packages below the worker threshold, and above it it uses roughly 1.4–2.5x less
-CPU while being at parity to ~25% slower in wall time on an otherwise idle
-multi-core machine.
-
-Two things change when this is on:
+Two things differ from building each entry separately:
 
 - Code shared between entries becomes a chunk instead of being copied into every
   entry that imports it, so the emitted file list gains chunk files.
@@ -378,10 +369,16 @@ Two things change when this is on:
   `export *`, because rollup knows the sibling's exports once it is part of the
   same graph.
 
-bunchee falls back to the per-entry path — with no change in output — for
-packages it cannot merge yet: `bin` entries, runtime or `development`/
-`production` export conditions, `'use client'` / `'use server'` boundaries, a
-single `-o` output, and watch mode.
+Packages that cannot be merged fall back to one instance per entry, with no
+change in output: `bin` entries, runtime or `development`/`production` export
+conditions, `'use client'` / `'use server'` boundaries, a single `-o` output,
+and watch mode.
+
+To opt out and build each entry in its own rollup instance:
+
+```sh
+bunchee --no-merge-entries
+```
 
 #### Build Successful Command
 

--- a/README.md
+++ b/README.md
@@ -116,30 +116,6 @@ Here's a example of entry files and exports configuration:
 
 This will automatically discover files in `src/features/` and generate exports like `./features/foo`, `./features/bar`, etc. The wildcard `*` is substituted in both the export path and output path.
 
-### How Entries Are Built
-
-Entries that can share a module graph are grouped and built together, so a
-package with many exports does not pay for a rollup instance per entry/output
-pair — 50 exports in two formats plus types would otherwise be 150 of them.
-Within a group each entry still lands on the exact path its export condition
-declares.
-
-Two consequences worth knowing:
-
-- Code shared between entries becomes a chunk instead of being copied into every
-  entry that imports it, so `dist` contains chunk files alongside the entries.
-- Re-exports of a sibling entry are emitted as named re-exports rather than
-  `export *`, because the sibling's exports are known.
-
-Type declarations are the one part that cannot be shared — declaration emit is
-linear in entry count — so they are split across workers instead. Set
-`BUNCHEE_DTS_SHARDS` to override how many. Run with `DEBUG=1` to see the
-grouping and the shard layout.
-
-Some packages are built one entry at a time instead, which `DEBUG=1` also
-reports: `bin` entries, runtime or `development`/`production` export conditions,
-`'use client'` / `'use server'` boundaries, a single `-o` output, and watch mode.
-
 ### Output Formats
 
 **bunchee** detects the format of each entry-point based on export condition type or the file extension. It supports the following output formats:

--- a/README.md
+++ b/README.md
@@ -348,6 +348,33 @@ bunchee --no-external
 
 This will include all dependencies within your output bundle.
 
+#### Merging entries into shared rollup instances (experimental)
+
+By default bunchee creates one rollup instance per entry/output pair, so a
+package with 50 exports in two formats plus types builds through 150 of them.
+`--merge-entries` instead groups every entry that can share a module graph and
+builds each group once, writing one output per format from the same graph:
+
+```sh
+bunchee --merge-entries
+```
+
+Run with `DEBUG=1` to see the grouping, and the reason when a package is not
+merged.
+
+Two things change when this is on:
+
+- Code shared between entries becomes a chunk instead of being copied into every
+  entry that imports it, so the emitted file list gains chunk files.
+- Re-exports of a sibling entry are emitted as named re-exports rather than
+  `export *`, because rollup knows the sibling's exports once it is part of the
+  same graph.
+
+bunchee falls back to the per-entry path — with no change in output — for
+packages it cannot merge yet: `bin` entries, runtime or `development`/
+`production` export conditions, `'use client'` / `'use server'` boundaries, a
+single `-o` output, and watch mode.
+
 #### Build Successful Command
 
 A command to be executed after a build is successful can be specified using the `--success` option, which is useful for development watching mode:

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -40,6 +40,7 @@ Options:
   --no-dts               do not generate types, default: undefined
   --tsconfig             path to tsconfig file, default: tsconfig.json
   --dts-bundle           bundle type declaration files, default: false
+  --merge-entries        build all entries in shared rollup instances (experimental)
   --success <cmd>     run command after build success
 `
 
@@ -133,6 +134,10 @@ async function parseCliArgs(argv: string[]) {
       type: 'boolean',
       description: 'bundle type declaration files',
     })
+    .option('merge-entries', {
+      type: 'boolean',
+      description: 'build all entries in shared rollup instances',
+    })
     .option('prepare', {
       type: 'boolean',
       description: 'auto setup package.json for building',
@@ -193,6 +198,7 @@ async function parseCliArgs(argv: string[]) {
     cwd: args['cwd'],
     dts: args['dts'] === false ? false : undefined,
     dtsBundle: args['dts-bundle'],
+    mergeEntries: args['merge-entries'],
     help: args['help'],
     runtime: args['runtime'],
     target: args['target'] as CliArgs['target'],
@@ -233,6 +239,7 @@ async function run(args: CliArgs) {
     dtsBundle,
     env,
     clean,
+    mergeEntries,
     tsconfig,
     onSuccess,
   } = args
@@ -255,6 +262,7 @@ async function run(args: CliArgs) {
     sourcemap: sourcemap === false ? false : true,
     env: env?.split(',') || [],
     clean,
+    mergeEntries,
     tsconfig,
     onSuccess,
   }

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -40,7 +40,6 @@ Options:
   --no-dts               do not generate types, default: undefined
   --tsconfig             path to tsconfig file, default: tsconfig.json
   --dts-bundle           bundle type declaration files, default: false
-  --no-merge-entries     build each entry in its own rollup instance
   --success <cmd>     run command after build success
 `
 
@@ -134,11 +133,6 @@ async function parseCliArgs(argv: string[]) {
       type: 'boolean',
       description: 'bundle type declaration files',
     })
-    .option('merge-entries', {
-      type: 'boolean',
-      default: undefined,
-      description: 'build all entries in shared rollup instances',
-    })
     .option('prepare', {
       type: 'boolean',
       description: 'auto setup package.json for building',
@@ -199,7 +193,6 @@ async function parseCliArgs(argv: string[]) {
     cwd: args['cwd'],
     dts: args['dts'] === false ? false : undefined,
     dtsBundle: args['dts-bundle'],
-    mergeEntries: args['merge-entries'],
     help: args['help'],
     runtime: args['runtime'],
     target: args['target'] as CliArgs['target'],
@@ -240,7 +233,6 @@ async function run(args: CliArgs) {
     dtsBundle,
     env,
     clean,
-    mergeEntries,
     tsconfig,
     onSuccess,
   } = args
@@ -263,7 +255,6 @@ async function run(args: CliArgs) {
     sourcemap: sourcemap === false ? false : true,
     env: env?.split(',') || [],
     clean,
-    mergeEntries,
     tsconfig,
     onSuccess,
   }

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -40,7 +40,7 @@ Options:
   --no-dts               do not generate types, default: undefined
   --tsconfig             path to tsconfig file, default: tsconfig.json
   --dts-bundle           bundle type declaration files, default: false
-  --merge-entries        build all entries in shared rollup instances (experimental)
+  --no-merge-entries     build each entry in its own rollup instance
   --success <cmd>     run command after build success
 `
 
@@ -136,6 +136,7 @@ async function parseCliArgs(argv: string[]) {
     })
     .option('merge-entries', {
       type: 'boolean',
+      default: undefined,
       description: 'build all entries in shared rollup instances',
     })
     .option('prepare', {

--- a/src/build-config.ts
+++ b/src/build-config.ts
@@ -115,16 +115,20 @@ async function buildRollupConfigs(
   }
 }
 
-async function buildConfig(
+/**
+ * Every output file a single entry produces, as `{ file, format, target }`.
+ * Shared by the per-entry config path and the merged-group path so the two
+ * cannot drift on which files an entry is supposed to emit.
+ */
+export async function getEntryBundleOutputs(
   bundleConfig: BundleConfig,
   exportCondition: ParsedExportCondition,
   pluginContext: BuildContext,
   bundleEntryOptions: bundleEntryOptions,
-): Promise<BuncheeRollupConfig[]> {
+): Promise<ExportOutput[]> {
   const { file } = bundleConfig
   const { pkg, cwd } = pluginContext
   const { dts, isFromCli } = bundleEntryOptions
-  const entry = exportCondition.source
 
   const outputExports = getExportsDistFilesOfCondition(
     pkg,
@@ -196,6 +200,24 @@ async function buildConfig(
       })
     }
   }
+
+  return bundleOptions
+}
+
+async function buildConfig(
+  bundleConfig: BundleConfig,
+  exportCondition: ParsedExportCondition,
+  pluginContext: BuildContext,
+  bundleEntryOptions: bundleEntryOptions,
+): Promise<BuncheeRollupConfig[]> {
+  const { dts } = bundleEntryOptions
+  const entry = exportCondition.source
+  const bundleOptions = await getEntryBundleOutputs(
+    bundleConfig,
+    exportCondition,
+    pluginContext,
+    bundleEntryOptions,
+  )
 
   const outputConfigs = bundleOptions.map(async (bundleOption) => {
     // Narrow the entry down to the single output currently being built.

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -213,9 +213,7 @@ async function bundle(
   // `_entryFilter` is not a reason to skip merging: a worker gets a shard of
   // entries and builds them as one graph, with the entries it does not own
   // resolved as externals against their own output paths.
-  const useMerged =
-    options.mergeEntries !== false &&
-    (await canMergeEntries(entries, options, isFromCli))
+  const useMerged = await canMergeEntries(entries, options, isFromCli)
 
   // With many entries, every entry's rollup build shares one heap and peak
   // memory scales with entry count, which OOMs on packages with many exports.

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -29,7 +29,8 @@ import {
   writeDefaultTsconfig,
 } from './typescript'
 import { collectEntriesFromParsedExports } from './entries'
-import { createAssetRollupJobs } from './rollup-job'
+import { createAssetRollupJobs, createMergedRollupJobs } from './rollup-job'
+import { canMergeEntries } from './rollup/merged-config'
 import { spawn } from 'child_process'
 import { logger } from './logger'
 
@@ -197,10 +198,20 @@ async function bundle(
   const rollupJobsOptions: BundleJobOptions = { isFromCli, generateTypes }
 
   const entryNames = Object.keys(entries)
+
+  // Build every entry through a few shared rollup instances instead of one per
+  // entry/output pair. Experimental: shared code becomes a chunk rather than
+  // being copied into each entry that uses it.
+  const useMerged =
+    Boolean(options.mergeEntries) &&
+    !options._entryFilter &&
+    (await canMergeEntries(entries, options, isFromCli))
+
   // With many entries, every entry's rollup build shares one heap and peak
   // memory scales with entry count, which OOMs on packages with many exports.
   // Build each entry in its own worker instead, one isolated heap per entry.
   const useWorkers =
+    !useMerged &&
     !options.watch &&
     !options._entryFilter &&
     // Test-only, not a supported option: the tests build the same package
@@ -238,6 +249,12 @@ async function bundle(
         outputState.mergeSizeStats(stats)
       }
       assetJobs = workerStats
+    } else if (useMerged) {
+      assetJobs = await createMergedRollupJobs(
+        options,
+        buildContext,
+        rollupJobsOptions,
+      )
     } else {
       assetJobs = await createAssetRollupJobs(
         options,

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -15,7 +15,11 @@ import {
   isTypescriptFile,
   removeOutputDir,
 } from './utils'
-import { MIN_ENTRIES_FOR_WORKERS, runEntriesInWorkers } from './lib/worker-pool'
+import {
+  MIN_ENTRIES_FOR_WORKERS,
+  availableCores,
+  runEntriesInWorkers,
+} from './lib/worker-pool'
 import {
   getExportFileTypePath,
   parseExports,
@@ -30,7 +34,11 @@ import {
 } from './typescript'
 import { collectEntriesFromParsedExports } from './entries'
 import { createAssetRollupJobs, createMergedRollupJobs } from './rollup-job'
-import { canMergeEntries } from './rollup/merged-config'
+import {
+  canMergeEntries,
+  shardEntries,
+  typeShardCount,
+} from './rollup/merged-config'
 import { spawn } from 'child_process'
 import { logger } from './logger'
 
@@ -210,14 +218,21 @@ async function bundle(
   // With many entries, every entry's rollup build shares one heap and peak
   // memory scales with entry count, which OOMs on packages with many exports.
   // Build each entry in its own worker instead, one isolated heap per entry.
-  const useWorkers =
-    !useMerged &&
+  const workersAvailable =
     !options.watch &&
     !options._entryFilter &&
     // Test-only, not a supported option: the tests build the same package
     // both ways and diff the output.
     !process.env.TEST_NO_WORKERS &&
     entryNames.length >= MIN_ENTRIES_FOR_WORKERS
+
+  // Merging collapses the JS work to a couple of graphs, but declaration emit
+  // stays linear in entry count and one shared graph cannot amortise it. So
+  // above the worker threshold the two are combined: merged JS here, then the
+  // types split into shards that each build a merged graph in their own heap.
+  // Sharding them in this heap is slower, not faster — several TypeScript
+  // programs in one isolate spend their time in GC.
+  const useWorkers = workersAvailable && (!useMerged || generateTypes)
 
   try {
     let assetJobs
@@ -237,18 +252,33 @@ async function bundle(
           }
         }
       }
+      // The JS side first, so the workers are not competing with it and so
+      // everything is written after the clean above.
+      const mergedJobs = useMerged
+        ? await createMergedRollupJobs(options, buildContext, {
+            ...rollupJobsOptions,
+            generateTypes: false,
+          })
+        : []
+      const entryGroups = useMerged
+        ? shardEntries(
+            entryNames,
+            typeShardCount(entryNames.length, availableCores()),
+          )
+        : entryNames.map((entryName) => [entryName])
       const workerStats = await runEntriesInWorkers(
         cwd,
         // The original CLI entry, before the single-entry fallback above
         // reassigns it — this is what the entries above were resolved with.
         inputFile,
-        entryNames,
-        options,
+        entryGroups,
+        // With the JS assets already built, the workers only owe the types.
+        useMerged ? { ...options, _typesOnly: true } : options,
       )
       for (const stats of workerStats) {
         outputState.mergeSizeStats(stats)
       }
-      assetJobs = workerStats
+      assetJobs = [...mergedJobs, ...workerStats]
     } else if (useMerged) {
       assetJobs = await createMergedRollupJobs(
         options,

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -208,11 +208,13 @@ async function bundle(
   const entryNames = Object.keys(entries)
 
   // Build every entry through a few shared rollup instances instead of one per
-  // entry/output pair. Experimental: shared code becomes a chunk rather than
-  // being copied into each entry that uses it.
+  // entry/output pair, so shared code becomes a chunk instead of being copied
+  // into each entry that uses it.
+  // `_entryFilter` is not a reason to skip merging: a worker gets a shard of
+  // entries and builds them as one graph, with the entries it does not own
+  // resolved as externals against their own output paths.
   const useMerged =
-    Boolean(options.mergeEntries) &&
-    !options._entryFilter &&
+    options.mergeEntries !== false &&
     (await canMergeEntries(entries, options, isFromCli))
 
   // With many entries, every entry's rollup build shares one heap and peak

--- a/src/lib/worker-pool.ts
+++ b/src/lib/worker-pool.ts
@@ -20,12 +20,17 @@ export function availableCores(): number {
 export const WORKER_HANDLER_NAME = 'buildEntryInWorker'
 
 function resolveWorkerFile(): string {
-  // Running from source, the handler is a sibling module. Bundled, this code
-  // is only ever reachable through the package's main entry — the bin requires
-  // that entry rather than inlining it — and the same bundle re-exports the
-  // handler, so the file to hand piscina is the one this code is running from.
+  // Running from source, the handler is a sibling module.
   const sibling = join(dirname(__dirname), `worker${extname(__filename)}`)
-  return fs.existsSync(sibling) ? sibling : __filename
+  if (fs.existsSync(sibling)) return sibling
+
+  // Bundled, the handler is re-exported from the package's main entry. This
+  // file is not necessarily that entry: code shared between the entry and the
+  // bin lands in a chunk beside it, and a chunk exports nothing by name. The
+  // entry sits next to it, so look there before falling back to this file.
+  const mainEntry = join(dirname(__filename), `index${extname(__filename)}`)
+  if (mainEntry !== __filename && fs.existsSync(mainEntry)) return mainEntry
+  return __filename
 }
 
 function restoreErrorDetails(error: any): unknown {

--- a/src/lib/worker-pool.ts
+++ b/src/lib/worker-pool.ts
@@ -11,6 +11,10 @@ import { logger, pauseActiveSpinner } from '../logger'
 // fits comfortably in one heap, and skipping the pool avoids worker startup.
 export const MIN_ENTRIES_FOR_WORKERS = 8
 
+export function availableCores(): number {
+  return Math.max(1, (os.availableParallelism?.() ?? os.cpus().length) - 1)
+}
+
 // The handler is loaded from a file by its export name, so no separate worker
 // asset needs to exist in dist.
 export const WORKER_HANDLER_NAME = 'buildEntryInWorker'
@@ -42,35 +46,38 @@ function restoreErrorDetails(error: any): unknown {
 export async function runEntriesInWorkers(
   cwd: string,
   cliEntryPath: string,
-  entryNames: string[],
+  /**
+   * One group per worker task. Usually one entry each, but the merged path
+   * hands each worker a shard of entries to build together.
+   */
+  entryGroups: string[][],
   options: BundleConfig,
 ): Promise<SizeStats[]> {
   // `_callbacks` holds functions, which structured clone cannot move.
   const { _callbacks, ...plainOptions } = options
   const pool = new Piscina({
     filename: resolveWorkerFile(),
-    maxThreads: Math.max(
-      1,
-      Math.min(
-        entryNames.length,
-        (os.availableParallelism?.() ?? os.cpus().length) - 1,
-      ),
-    ),
+    maxThreads: Math.max(1, Math.min(entryGroups.length, availableCores())),
   })
   const resumeSpinner = pauseActiveSpinner()
   if (process.env.DEBUG) {
+    const entryCount = entryGroups.reduce((n, group) => n + group.length, 0)
+    const shape =
+      entryGroups.length === entryCount
+        ? ''
+        : ` (${entryGroups.length} shards of ~${entryGroups[0].length})`
     logger.log(
-      `Building ${entryNames.length} entries in ${pool.maxThreads} worker threads`,
+      `Building ${entryCount} entries in ${pool.maxThreads} worker threads${shape}`,
     )
   }
 
   try {
     return await Promise.all(
-      entryNames.map((entryName) => {
+      entryGroups.map((entryNames) => {
         const task: EntryWorkerTask = {
           cwd,
           cliEntryPath,
-          entryName,
+          entryNames,
           options: plainOptions,
         }
         return pool.run(task, {

--- a/src/plugins/alias-plugin.ts
+++ b/src/plugins/alias-plugin.ts
@@ -1,6 +1,6 @@
 import { OutputOptions, Plugin } from 'rollup'
 import { Entries, ParsedExportCondition } from '../types'
-import { posix } from 'path'
+import { dirname, posix, relative, resolve } from 'path'
 import { posixRelativify } from '../lib/format'
 import { getSpecialExportTypeFromConditionNames } from '../entries'
 import {
@@ -199,26 +199,27 @@ export function aliasEntries({
 
           const bundlePath = sourceToRelativeBundleMap.get(resolved.id)
           if (!bundlePath) return null
+          // Resolved with the platform's own path rules — `cwd` and the dist
+          // paths are native, and mixing them with posix helpers treats a
+          // Windows path as a single segment.
           return {
-            id: SIBLING_MARK + posix.resolve(cwd, bundlePath),
+            id: SIBLING_MARK + resolve(cwd, bundlePath),
             external: true,
           }
         },
       },
       renderChunk(code, chunk, outputOptions) {
         if (!code.includes(SIBLING_MARK)) return null
-        const chunkDir = posix.dirname(
-          posix.resolve(
-            outputOptions.dir ?? cwd,
-            normalizePath(chunk.fileName),
-          ),
+        const chunkDir = dirname(
+          resolve(outputOptions.dir ?? cwd, chunk.fileName),
         )
         const rewritten = code.replace(
-          // The mark is followed by an absolute posix path, up to the quote
-          // that closes the module specifier.
+          // The mark is followed by an absolute path, up to the quote that
+          // closes the module specifier.
           new RegExp(`${SIBLING_MARK}([^'"]+)`, 'g'),
           (_, target: string) =>
-            posixRelativify(normalizePath(posix.relative(chunkDir, target))),
+            // The specifier is always posix, whatever the platform's paths are.
+            posixRelativify(normalizePath(relative(chunkDir, target))),
         )
         return { code: rewritten, map: null }
       },

--- a/src/plugins/alias-plugin.ts
+++ b/src/plugins/alias-plugin.ts
@@ -108,6 +108,14 @@ function findTypesFileCallback({
   )
 }
 
+/**
+ * Marks an import of a sibling entry that this build does not own. The correct
+ * specifier is relative to the importing chunk, which is only known once the
+ * chunk has a file name, so the absolute target is parked behind this prefix
+ * and resolved in `renderChunk`.
+ */
+const SIBLING_MARK = '\0bunchee-sibling:'
+
 // Alias entry key to dist bundle path
 export function aliasEntries({
   entry: sourceFilePath,
@@ -117,6 +125,7 @@ export function aliasEntries({
   format,
   dts,
   cwd,
+  mergedSources,
 }: {
   entry: string
   entries: Entries
@@ -125,6 +134,12 @@ export function aliasEntries({
   exportCondition: ParsedExportCondition
   dts: boolean
   cwd: string
+  /**
+   * The sources this build owns as inputs. When set, the build is a merged one:
+   * rollup emits the references between these itself, and only entries outside
+   * the set need rewriting to a `<dist>` path.
+   */
+  mergedSources?: Set<string>
 }): Plugin {
   const currentConditionNames = new Set(
     exportCondition.targets[0]?.conditions ?? [],
@@ -169,6 +184,44 @@ export function aliasEntries({
     if (matchedBundlePath) {
       if (!sourceToRelativeBundleMap.has(exportCondition.source))
         sourceToRelativeBundleMap.set(exportCondition.source, matchedBundlePath)
+    }
+  }
+
+  if (mergedSources) {
+    return {
+      name: 'alias',
+      resolveId: {
+        async handler(source, importer, options) {
+          const resolved = await this.resolve(source, importer, options)
+          if (resolved == null) return null
+          // An input of this build: rollup emits the cross-chunk reference.
+          if (mergedSources.has(resolved.id)) return null
+
+          const bundlePath = sourceToRelativeBundleMap.get(resolved.id)
+          if (!bundlePath) return null
+          return {
+            id: SIBLING_MARK + posix.resolve(cwd, bundlePath),
+            external: true,
+          }
+        },
+      },
+      renderChunk(code, chunk, outputOptions) {
+        if (!code.includes(SIBLING_MARK)) return null
+        const chunkDir = posix.dirname(
+          posix.resolve(
+            outputOptions.dir ?? cwd,
+            normalizePath(chunk.fileName),
+          ),
+        )
+        const rewritten = code.replace(
+          // The mark is followed by an absolute posix path, up to the quote
+          // that closes the module specifier.
+          new RegExp(`${SIBLING_MARK}([^'"]+)`, 'g'),
+          (_, target: string) =>
+            posixRelativify(normalizePath(posix.relative(chunkDir, target))),
+        )
+        return { code: rewritten, map: null }
+      },
     }
   }
 

--- a/src/plugins/esm-shim.ts
+++ b/src/plugins/esm-shim.ts
@@ -1,6 +1,4 @@
-import { availableESExtensionsRegex } from '../constants'
 import { Plugin, ProgramNode, AstNode } from 'rollup'
-import { extname } from 'path'
 import MagicString from 'magic-string'
 
 const FILENAME_REGEX = /__filename/
@@ -31,76 +29,61 @@ ${useNodePath ? 'const __dirname = __node_cjsPath.dirname(__filename);' : ''}
   )
 }
 
+/**
+ * Defines `__filename` / `__dirname` for ESM output, where they do not exist.
+ *
+ * Runs on the rendered chunk rather than on each module, for two reasons: the
+ * format is only known per output, so one module graph can be written as both
+ * ESM and CJS with the shim landing only in the ESM one; and a chunk needs the
+ * declaration once, where doing it per module left rollup to deduplicate a
+ * `__filename` per module that used it.
+ */
 export function esmShim(): Plugin {
   return {
     name: 'esm-shim',
-    transform: {
-      order: 'post',
-      handler(code, id) {
-        const ext = extname(id)
-        if (
-          !availableESExtensionsRegex.test(ext) ||
-          code.includes(PolyfillComment)
-        ) {
-          return null
-        }
+    renderChunk(code, _chunk, outputOptions) {
+      // CJS has both bindings already. Rollup normalises `esm` to `es` here.
+      if (outputOptions.format !== 'es') return null
+      if (code.includes(PolyfillComment)) return null
 
-        let hasFilename = false
-        let hasDirname = false
-        if (FILENAME_REGEX.test(code)) {
-          hasFilename = true
-        }
-        if (DIRNAME_REGEX.test(code)) {
-          hasDirname = true
-        }
+      const hasFilename = FILENAME_REGEX.test(code)
+      const hasDirname = DIRNAME_REGEX.test(code)
+      if (!hasFilename && !hasDirname) return null
 
-        if (!hasFilename && !hasDirname) {
-          return null
-        }
+      const magicString = new MagicString(code)
+      let ast: null | ProgramNode = null
+      try {
+        ast = this.parse(magicString.toString(), {
+          allowReturnOutsideFunction: true,
+        })
+      } catch (e) {
+        console.warn(e)
+        return null
+      }
 
-        const magicString = new MagicString(code)
-        let ast: null | ProgramNode = null
-        try {
-          // rollup 2 built-in parser doesn't have `allowShebang`, we need to use the sliced code here. Hence the `magicString.toString()`
-          ast = this.parse(magicString.toString(), {
-            allowReturnOutsideFunction: true,
-          })
-        } catch (e) {
-          console.warn(e)
-          return null
-        }
+      if (ast.type !== 'Program') return null
 
-        if (ast.type !== 'Program') {
-          return null
+      // After the imports, so the shim can use them.
+      let lastImportNode = null
+      for (const node of ast.body) {
+        if (node.type === 'ImportDeclaration') {
+          lastImportNode = node
         }
-
-        let lastImportNode = null
-        for (const node of ast.body) {
-          if (node.type === 'ImportDeclaration') {
-            lastImportNode = node
-            continue
-          }
-        }
-        let end: number = 0
-
-        if (lastImportNode) {
-          end = (lastImportNode as any as AstNode).end
-        } else {
-          end = ast.body.length > 0 ? (ast.body[0] as any as AstNode).end : 0
-        }
-        magicString.appendRight(
-          end,
-          '\n' +
-            createESMShim({
-              filename: hasFilename,
-              dirname: hasDirname,
-            }),
-        )
-        return {
-          code: magicString.toString(),
-          map: magicString.generateMap({ hires: true }),
-        }
-      },
+      }
+      let end: number = 0
+      if (lastImportNode) {
+        end = (lastImportNode as any as AstNode).end
+      } else {
+        end = ast.body.length > 0 ? (ast.body[0] as any as AstNode).end : 0
+      }
+      magicString.appendRight(
+        end,
+        '\n' + createESMShim({ filename: hasFilename, dirname: hasDirname }),
+      )
+      return {
+        code: magicString.toString(),
+        map: magicString.generateMap({ hires: true }),
+      }
     },
   }
 }

--- a/src/plugins/prepend-shebang.ts
+++ b/src/plugins/prepend-shebang.ts
@@ -1,17 +1,27 @@
 import MagicString from 'magic-string'
 import type { Plugin } from 'rollup'
 
-export const prependShebang = (entry: string): Plugin => ({
-  name: 'prependShebang',
-  transform: (code: string, id: string) => {
-    if (id !== entry) return
-    const shebang = '#!/usr/bin/env node\n'
-    if (code.startsWith(shebang)) return
-    const magicString = new MagicString(code)
-    magicString.prepend(shebang)
-    return {
-      code: magicString.toString(),
-      map: magicString.generateMap({ hires: true }),
-    }
-  },
-})
+const SHEBANG = '#!/usr/bin/env node\n'
+
+/**
+ * Prepends a shebang to the bin entries' own modules.
+ *
+ * A merged build holds several entries at once, so the plugin takes every bin
+ * source rather than the single one being built.
+ */
+export const prependShebang = (entries: string | Set<string>): Plugin => {
+  const binSources = typeof entries === 'string' ? new Set([entries]) : entries
+  return {
+    name: 'prependShebang',
+    transform: (code: string, id: string) => {
+      if (!binSources.has(id)) return
+      if (code.startsWith(SHEBANG)) return
+      const magicString = new MagicString(code)
+      magicString.prepend(SHEBANG)
+      return {
+        code: magicString.toString(),
+        map: magicString.generateMap({ hires: true }),
+      }
+    },
+  }
+}

--- a/src/rollup-job.ts
+++ b/src/rollup-job.ts
@@ -89,9 +89,7 @@ export async function createMergedRollupJobs(
   // an earlier job's output.
   if (options.clean && !isFromCli) {
     for (const config of allConfigs) {
-      for (const output of config.outputs) {
-        await removeOutputDir(output, buildContext.cwd)
-      }
+      await removeOutputDir(config.output, buildContext.cwd)
     }
   }
 
@@ -99,8 +97,7 @@ export async function createMergedRollupJobs(
     const shape = allConfigs
       .map(
         (config) =>
-          `${Object.keys(config.input).length} inputs -> ` +
-          config.outputs.map((output) => output.format).join(','),
+          `${Object.keys(config.input).length} inputs -> ${config.output.format}`,
       )
       .join(' | ')
     logger.log(
@@ -125,10 +122,7 @@ export async function createMergedRollupJobs(
   }
 }
 
-async function runMergedBundle({
-  outputs,
-  ...restOptions
-}: MergedRollupConfig) {
+async function runMergedBundle({ output, ...restOptions }: MergedRollupConfig) {
   let bundle: RollupBuild
   const debug = Boolean(process.env.DEBUG)
   const started = Date.now()
@@ -141,17 +135,12 @@ async function runMergedBundle({
     logMergedGraph(bundle, Object.keys(restOptions.input).length, started)
   }
   try {
-    // One graph, N writes: the parse/transform/treeshake work is done once and
-    // only the generate step repeats per output.
-    const results: RollupOutput[] = []
-    for (const output of outputs) {
-      const writeStart = Date.now()
-      results.push(await bundle.write(output))
-      if (debug) {
-        logger.log(`  write ${output.format}: ${Date.now() - writeStart}ms`)
-      }
+    const writeStart = Date.now()
+    const result = await bundle.write(output)
+    if (debug) {
+      logger.log(`  write ${output.format}: ${Date.now() - writeStart}ms`)
     }
-    return results
+    return result
   } finally {
     await bundle.close()
   }

--- a/src/rollup-job.ts
+++ b/src/rollup-job.ts
@@ -28,10 +28,12 @@ export async function createAssetRollupJobs(
   bundleJobOptions: BundleJobOptions,
 ) {
   const { isFromCli, generateTypes } = bundleJobOptions
-  const assetsConfigs = await buildEntryConfig(options, buildContext, {
-    dts: false,
-    isFromCli,
-  })
+  const assetsConfigs = options._typesOnly
+    ? []
+    : await buildEntryConfig(options, buildContext, {
+        dts: false,
+        isFromCli,
+      })
   const typesConfigs = generateTypes
     ? await buildEntryConfig(options, buildContext, {
         dts: true,
@@ -71,10 +73,12 @@ export async function createMergedRollupJobs(
   bundleJobOptions: BundleJobOptions,
 ) {
   const { isFromCli, generateTypes } = bundleJobOptions
-  const assetsConfigs = await buildMergedConfigs(options, buildContext, {
-    dts: false,
-    isFromCli,
-  })
+  const assetsConfigs = options._typesOnly
+    ? []
+    : await buildMergedConfigs(options, buildContext, {
+        dts: false,
+        isFromCli,
+      })
   const typesConfigs = generateTypes
     ? await buildMergedConfigs(options, buildContext, { dts: true, isFromCli })
     : []
@@ -106,10 +110,11 @@ export async function createMergedRollupJobs(
   }
 
   try {
-    // Sequentially: the point of merging is that there are only a handful of
-    // graphs, and each is large. Running them concurrently puts every graph —
-    // including a full TypeScript program — in the heap at once, which is the
-    // same OOM the per-entry path hits.
+    // Sequentially: there are only a handful of graphs and each is large.
+    // Running them concurrently puts every graph — including a full TypeScript
+    // program — in one heap, which is both the OOM the per-entry path hits and,
+    // measured, slower than doing them in turn. Parallelism across types shards
+    // comes from the worker pool, where each shard gets its own heap.
     const results = []
     for (const config of allConfigs) {
       results.push(await runMergedBundle(config))

--- a/src/rollup-job.ts
+++ b/src/rollup-job.ts
@@ -7,15 +7,20 @@ import {
   watch as rollupWatch,
 } from 'rollup'
 
+import { statSync } from 'fs'
+
 import { buildEntryConfig } from './build-config'
+import { buildMergedConfigs } from './rollup/merged-config'
 import {
   BuildContext,
   BuncheeRollupConfig,
   BundleConfig,
   BundleJobOptions,
+  MergedRollupConfig,
 } from './types'
 import { removeOutputDir } from './utils'
 import { normalizeError } from './lib/normalize-error'
+import { logger } from './logger'
 
 export async function createAssetRollupJobs(
   options: BundleConfig,
@@ -53,6 +58,129 @@ export async function createAssetRollupJobs(
   } catch (err: unknown) {
     const error = normalizeError(err)
     throw error
+  }
+}
+
+/**
+ * Build every entry through a handful of shared rollup instances instead of one
+ * per entry/output pair: one module graph per group, written once per output.
+ */
+export async function createMergedRollupJobs(
+  options: BundleConfig,
+  buildContext: BuildContext,
+  bundleJobOptions: BundleJobOptions,
+) {
+  const { isFromCli, generateTypes } = bundleJobOptions
+  const assetsConfigs = await buildMergedConfigs(options, buildContext, {
+    dts: false,
+    isFromCli,
+  })
+  const typesConfigs = generateTypes
+    ? await buildMergedConfigs(options, buildContext, { dts: true, isFromCli })
+    : []
+  const allConfigs = assetsConfigs.concat(typesConfigs)
+
+  // Clean every output directory before anything is written: the JS and types
+  // groups usually share one dist directory, so cleaning per job would delete
+  // an earlier job's output.
+  if (options.clean && !isFromCli) {
+    for (const config of allConfigs) {
+      for (const output of config.outputs) {
+        await removeOutputDir(output, buildContext.cwd)
+      }
+    }
+  }
+
+  if (process.env.DEBUG) {
+    const shape = allConfigs
+      .map(
+        (config) =>
+          `${Object.keys(config.input).length} inputs -> ` +
+          config.outputs.map((output) => output.format).join(','),
+      )
+      .join(' | ')
+    logger.log(
+      `Building ${Object.keys(buildContext.entries).length} entries in ` +
+        `${allConfigs.length} shared rollup instances: ${shape}`,
+    )
+  }
+
+  try {
+    // Sequentially: the point of merging is that there are only a handful of
+    // graphs, and each is large. Running them concurrently puts every graph —
+    // including a full TypeScript program — in the heap at once, which is the
+    // same OOM the per-entry path hits.
+    const results = []
+    for (const config of allConfigs) {
+      results.push(await runMergedBundle(config))
+    }
+    return results
+  } catch (err: unknown) {
+    throw normalizeError(err)
+  }
+}
+
+async function runMergedBundle({
+  outputs,
+  ...restOptions
+}: MergedRollupConfig) {
+  let bundle: RollupBuild
+  const debug = Boolean(process.env.DEBUG)
+  const started = Date.now()
+  try {
+    bundle = await rollup({ ...restOptions, cache: false })
+  } catch (error) {
+    return catchErrorHandler(error)
+  }
+  if (debug) {
+    logMergedGraph(bundle, Object.keys(restOptions.input).length, started)
+  }
+  try {
+    // One graph, N writes: the parse/transform/treeshake work is done once and
+    // only the generate step repeats per output.
+    const results: RollupOutput[] = []
+    for (const output of outputs) {
+      const writeStart = Date.now()
+      results.push(await bundle.write(output))
+      if (debug) {
+        logger.log(`  write ${output.format}: ${Date.now() - writeStart}ms`)
+      }
+    }
+    return results
+  } finally {
+    await bundle.close()
+  }
+}
+
+/**
+ * What actually landed in one merged graph. This is how an unintended entry
+ * dragging in a large build-time-only dependency shows up — on a package where
+ * a `_`-prefixed private module imports something like the TypeScript compiler,
+ * that single module dominates the whole build.
+ */
+function logMergedGraph(
+  bundle: RollupBuild,
+  inputCount: number,
+  startedAt: number,
+) {
+  logger.log(`  graph of ${inputCount} inputs: ${Date.now() - startedAt}ms`)
+  const modules = bundle.watchFiles
+    .filter((file) => !file.startsWith('\0'))
+    .map((file) => ({
+      file,
+      size: statSync(file, { throwIfNoEntry: false })?.size ?? 0,
+    }))
+    .sort((a, b) => b.size - a.size)
+  const fromNodeModules = modules.filter((m) => m.file.includes('node_modules'))
+  const totalKb = Math.round(modules.reduce((sum, m) => sum + m.size, 0) / 1024)
+  logger.log(
+    `  ${modules.length} modules, ${fromNodeModules.length} from ` +
+      `node_modules, ${totalKb}kB of source`,
+  )
+  for (const { file, size } of modules.slice(0, 3)) {
+    logger.log(
+      `    ${Math.round(size / 1024)}kB  ${file.split('node_modules/').pop()}`,
+    )
   }
 }
 

--- a/src/rollup/input.ts
+++ b/src/rollup/input.ts
@@ -106,6 +106,14 @@ export async function buildInputConfig(
   exportCondition: ParsedExportCondition,
   buildContext: BuildContext,
   dts: boolean,
+  /**
+   * When set, every entry in the map is an input of one shared rollup build
+   * instead of `entry` being the only one. Sibling entries then live in the
+   * same module graph, so they must not be externalized and rollup emits the
+   * cross-entry imports itself — which is what the alias plugin does by hand
+   * on the per-entry path.
+   */
+  mergedInputs?: Record<string, string>,
 ): Promise<CustomRollupInputOptions> {
   const {
     entries,
@@ -116,6 +124,8 @@ export async function buildInputConfig(
     pluginContext,
   } = buildContext
   const isBinEntry = isBinExportPath(exportCondition.name)
+  const isMerged = mergedInputs != null
+  const mergedSources = new Set(Object.values(mergedInputs ?? {}))
 
   const hasNoExternal = bundleConfig.external === null
   const externals = hasNoExternal
@@ -129,10 +139,16 @@ export async function buildInputConfig(
   for (const [exportImportPath, exportCondition] of Object.entries(entries)) {
     const entryFilePath = exportCondition.source
     if (entryFilePath !== entry) {
+      // Self-referencing subpath imports (`<pkg>/<subpath>`) stay external in
+      // both modes — rollup cannot resolve them and Node picks the condition.
       externals.push(
         posix.join(pkg.name || '', normalizeExportPath(exportImportPath)),
       )
-      externals.push(entryFilePath)
+      // The source path is only external when the sibling is built separately.
+      // In a merged build it is an input of this same graph.
+      if (!mergedSources.has(entryFilePath)) {
+        externals.push(entryFilePath)
+      }
     }
   }
 
@@ -208,8 +224,10 @@ export async function buildInputConfig(
   })
   const commonPlugins = [json(), sizePlugin]
 
-  const typesPlugins = [
-    aliasPlugin,
+  const typesPlugins: (Plugin | false)[] = [
+    // In a merged build every entry is an input, so rollup resolves the
+    // cross-entry references natively and the alias rewrite is redundant.
+    isMerged ? (false as const) : aliasPlugin,
     ...commonPlugins,
     inlineCss({ skip: true }),
   ]
@@ -234,7 +252,7 @@ export async function buildInputConfig(
       : [
           ...commonPlugins,
           preserveDirectives(),
-          aliasPlugin,
+          isMerged ? (false as const) : aliasPlugin,
           inlineCss({ exclude: /node_modules/ }),
           rawContent({ exclude: /node_modules/ }),
           nativeAddon(),
@@ -269,7 +287,7 @@ export async function buildInputConfig(
   ).filter(isNotNull<Plugin>)
 
   return {
-    input: entry,
+    input: mergedInputs ?? entry,
     external(id: string) {
       return externals.some((name) => id === name || id.startsWith(name + '/'))
     },

--- a/src/rollup/input.ts
+++ b/src/rollup/input.ts
@@ -9,7 +9,7 @@ import {
 import { isBinExportPath, isESModulePackage, isNotNull } from '../utils'
 import { normalizeExportPath } from '../entries'
 import { getDefinedInlineVariables } from '../env'
-import { posix } from 'path'
+import { dirname, posix } from 'path'
 import { wasm } from '@rollup/plugin-wasm'
 import { swc } from 'rollup-plugin-swc3'
 import commonjs from '@rollup/plugin-commonjs'
@@ -25,7 +25,10 @@ import { aliasEntries } from '../plugins/alias-plugin'
 import { prependShebang } from '../plugins/prepend-shebang'
 import { swcHelpersWarningPlugin } from '../plugins/swc-helpers-warning-plugin'
 import { memoizeByKey } from '../lib/memoize'
-import { convertCompilerOptions } from '../typescript'
+import {
+  convertCompilerOptions,
+  isTsConfigAutoDiscoverable,
+} from '../typescript'
 import {
   availableESExtensionsRegex,
   disabledWarnings,
@@ -49,6 +52,12 @@ async function createDtsPlugin(
   tsConfigPath: string | undefined,
   respectExternal: boolean | undefined,
   cwd: string,
+  /**
+   * Set when the plugin would find this tsconfig on its own, in which case not
+   * naming it is both equivalent and much faster — see
+   * `isTsConfigAutoDiscoverable`.
+   */
+  autoDiscoverable: boolean,
 ) {
   const enableIncrementalWithoutBuildInfo =
     tsCompilerOptions?.incremental && !tsCompilerOptions?.tsBuildInfoFile
@@ -90,7 +99,7 @@ async function createDtsPlugin(
   const dtsPlugin = (
     require('rollup-plugin-dts') as typeof import('rollup-plugin-dts')
   ).default({
-    tsconfig: tsConfigPath,
+    tsconfig: autoDiscoverable ? undefined : tsConfigPath,
     compilerOptions: overrideResolvedTsOptions,
     respectExternal,
   })
@@ -124,6 +133,13 @@ export async function buildInputConfig(
     pluginContext,
   } = buildContext
   const isBinEntry = isBinExportPath(exportCondition.name)
+  // A merged build can hold bin and non-bin entries at once, so the shebang is
+  // driven by which of its inputs are bin sources rather than by one entry.
+  const binSources = new Set(
+    Object.entries(entries)
+      .filter(([exportPath]) => isBinExportPath(exportPath))
+      .map(([, condition]) => condition.source),
+  )
   const isMerged = mergedInputs != null
   const mergedSources = new Set(Object.values(mergedInputs ?? {}))
 
@@ -237,12 +253,17 @@ export async function buildInputConfig(
     // Each process should be unique
     // Each package build should be unique
     // Composing above factors into a unique cache key to retrieve the memoized dts plugin with tsconfigs
-    const uniqueProcessId = 'dts-plugin:' + process.pid + tsConfigPath
+    const autoDiscoverable = isTsConfigAutoDiscoverable(cwd, tsConfigPath, [
+      ...new Set(Object.values(entries).map((e) => dirname(e.source))),
+    ])
+    const uniqueProcessId =
+      'dts-plugin:' + process.pid + tsConfigPath + autoDiscoverable
     const dtsPlugin = await memoizeDtsPluginByKey(uniqueProcessId)(
       tsCompilerOptions,
       tsConfigPath,
       bundleConfig.dts && bundleConfig.dts.respectExternal,
       cwd,
+      autoDiscoverable,
     )
     typesPlugins.push(dtsPlugin)
   }
@@ -257,7 +278,9 @@ export async function buildInputConfig(
           inlineCss({ exclude: /node_modules/ }),
           rawContent({ exclude: /node_modules/ }),
           nativeAddon(),
-          isBinEntry && prependShebang(entry),
+          isMerged
+            ? binSources.size > 0 && prependShebang(binSources)
+            : isBinEntry && prependShebang(entry),
           replace({
             values: inlineDefinedValues,
             preventAssignment: true,
@@ -266,7 +289,7 @@ export async function buildInputConfig(
             preferBuiltins: runtime === 'node',
             extensions: nodeResolveExtensions,
           }),
-          bundleConfig.format === 'esm' && esmShim(),
+          esmShim(),
           wasm(),
           swc({
             include: availableESExtensionsRegex,

--- a/src/rollup/input.ts
+++ b/src/rollup/input.ts
@@ -221,13 +221,14 @@ export async function buildInputConfig(
     exportCondition,
     dts,
     cwd,
+    // In a merged build the plugin only rewrites references to entries this
+    // build does not own; rollup emits the rest as chunk imports.
+    mergedSources: isMerged ? mergedSources : undefined,
   })
   const commonPlugins = [json(), sizePlugin]
 
   const typesPlugins: (Plugin | false)[] = [
-    // In a merged build every entry is an input, so rollup resolves the
-    // cross-entry references natively and the alias rewrite is redundant.
-    isMerged ? (false as const) : aliasPlugin,
+    aliasPlugin,
     ...commonPlugins,
     inlineCss({ skip: true }),
   ]
@@ -252,7 +253,7 @@ export async function buildInputConfig(
       : [
           ...commonPlugins,
           preserveDirectives(),
-          isMerged ? (false as const) : aliasPlugin,
+          aliasPlugin,
           inlineCss({ exclude: /node_modules/ }),
           rawContent({ exclude: /node_modules/ }),
           nativeAddon(),

--- a/src/rollup/merged-config.ts
+++ b/src/rollup/merged-config.ts
@@ -1,0 +1,298 @@
+import { dirname, relative, resolve, sep } from 'path'
+import { readFile } from 'fs/promises'
+import { glob } from 'tinyglobby'
+import type {
+  BuildContext,
+  BundleConfig,
+  Entries,
+  MergedRollupConfig,
+  ParsedExportCondition,
+  bundleEntryOptions,
+} from '../types'
+import type { ExportOutput } from '../exports'
+import { buildInputConfig } from './input'
+import { buildOutputConfigs } from './output'
+import { getEntryBundleOutputs } from '../build-config'
+import { isBinExportPath, normalizePath } from '../utils'
+import {
+  availableExtensions,
+  specialExportConventions,
+  TESTS_GLOB_PATTERN,
+} from '../constants'
+import { getDefinedInlineVariables } from '../env'
+import { logger } from '../logger'
+
+type GroupItem = {
+  exportPath: string
+  exportCondition: ParsedExportCondition
+  output: ExportOutput
+}
+
+type Group = {
+  /** Debug label; also the map key that collects the group. */
+  key: string
+  items: GroupItem[]
+}
+
+const BOUNDARY_DIRECTIVE_REGEX =
+  /^\s*(?:\/\*[\s\S]*?\*\/|\/\/.*\n)*\s*['"]use (client|server)['"]/
+
+/**
+ * Whether the package uses `'use client'` / `'use server'` boundaries.
+ *
+ * A per-entry build decides where a directive module lands separately for each
+ * entry, so the same module can be inlined into one output and split into its
+ * own chunk in another. One shared graph only gets to make that call once, so
+ * merging cannot reproduce the existing chunk layout for these packages —
+ * see `test/integration/server-components`. Detect it and stay on the
+ * per-entry path.
+ *
+ * Conservative on purpose: a false positive only means the build keeps working
+ * the way it does today.
+ */
+async function hasBoundaryDirectives(entries: Entries): Promise<boolean> {
+  const sourceDirs = new Set(
+    Object.values(entries).map((entry) => dirname(entry.source)),
+  )
+  const extensions = [...availableExtensions].join(',')
+  const files = new Set<string>()
+  for (const dir of sourceDirs) {
+    const found = await glob(`**/*.{${extensions}}`, {
+      cwd: dir,
+      absolute: true,
+      ignore: [TESTS_GLOB_PATTERN, '**/node_modules/**'],
+    })
+    for (const file of found) files.add(file)
+  }
+
+  for (const file of files) {
+    // Directives are the first statement, so only the head matters.
+    const handle = await readFile(file, 'utf8').catch(() => '')
+    if (BOUNDARY_DIRECTIVE_REGEX.test(handle.slice(0, 512))) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * Whether every entry can share one module graph.
+ *
+ * This merges all-or-nothing. Partial merging is possible but a standalone
+ * entry importing a merged one has to go back through the alias plugin for its
+ * `<pkg>/<subpath>` rewrite, and that interaction wants designing on its own.
+ */
+export async function canMergeEntries(
+  entries: Entries,
+  bundleConfig: BundleConfig,
+  isFromCli: boolean,
+): Promise<boolean> {
+  const reason = await findMergeBlocker(entries, bundleConfig, isFromCli)
+  if (reason && process.env.DEBUG) {
+    logger.log(`Not merging entries into shared rollup instances: ${reason}`)
+  }
+  return reason == null
+}
+
+/** Why this package cannot be merged, or `undefined` if it can. */
+async function findMergeBlocker(
+  entries: Entries,
+  bundleConfig: BundleConfig,
+  isFromCli: boolean,
+): Promise<string | undefined> {
+  // A CLI `-o` build has a single explicit output; nothing to merge.
+  if (isFromCli || bundleConfig.file) return 'building a single CLI output'
+  // Watch mode drives one rollup watcher per config; merging it is separate work.
+  if (bundleConfig.watch) return 'watch mode'
+
+  const exportPaths = Object.keys(entries)
+  if (exportPaths.length < 2) {
+    return `only ${exportPaths.length} entry resolved`
+  }
+
+  for (const [exportPath, exportCondition] of Object.entries(entries)) {
+    // `prependShebang` is bound to one specific entry file.
+    if (isBinExportPath(exportPath)) {
+      return `"${exportPath}" is a bin entry`
+    }
+    for (const target of exportCondition.targets) {
+      // Runtime/optimize conditions (`react-server`, `browser`, `development`,
+      // …) change the inlined env and which sibling bundle an import should
+      // resolve to, which the alias plugin decides per entry.
+      const special = target.conditions.find((condition) =>
+        specialExportConventions.has(condition),
+      )
+      if (special) {
+        return `"${exportPath}" uses the "${special}" condition`
+      }
+    }
+  }
+
+  if (await hasBoundaryDirectives(entries)) {
+    return `package uses 'use client' / 'use server' boundaries`
+  }
+
+  return undefined
+}
+
+/** `.` -> `index`, `./a` -> `a`, `./foo/bar` -> `foo/bar` */
+function toInputName(exportPath: string): string {
+  return exportPath === '.' ? 'index' : exportPath.replace(/^\.\//, '')
+}
+
+function outputExtension(file: string): string {
+  const match = /\.d\.(m|c)?ts$|\.(m|c)?js$/.exec(file)
+  return match ? match[0] : ''
+}
+
+/** Deepest directory containing every one of `dirs`. */
+function commonRootDir(dirs: string[]): string {
+  const [first, ...rest] = dirs.map((dir) => dir.split(sep))
+  let end = first.length
+  for (const parts of rest) {
+    let i = 0
+    while (i < end && i < parts.length && parts[i] === first[i]) i++
+    end = i
+  }
+  return first.slice(0, end).join(sep) || sep
+}
+
+/**
+ * One rollup config per group of entries that can share a module graph.
+ *
+ * Entries group by everything that changes the *input* graph — the inlined env
+ * values — plus the output format and extension, which decide the shape of the
+ * generate step. Within a group entries differ only by which file they land
+ * in, and `entryFileNames` resolves that per chunk.
+ *
+ * The `occurrence` part of the key keeps an entry that emits two files of the
+ * same format and extension in two different groups: one input name cannot map
+ * to two output paths.
+ */
+export async function buildMergedConfigs(
+  bundleConfig: BundleConfig,
+  buildContext: BuildContext,
+  bundleEntryOptions: bundleEntryOptions,
+): Promise<MergedRollupConfig[]> {
+  const { entries } = buildContext
+  const { dts } = bundleEntryOptions
+
+  const groups = new Map<string, Group>()
+  for (const [exportPath, exportCondition] of Object.entries(entries)) {
+    const outputs = await getEntryBundleOutputs(
+      bundleConfig,
+      exportCondition,
+      buildContext,
+      bundleEntryOptions,
+    )
+    const env = getDefinedInlineVariables(
+      bundleConfig.env || [],
+      exportCondition,
+    )
+    const seen = new Map<string, number>()
+    for (const output of outputs) {
+      const shape = [
+        dts ? 'dts' : 'js',
+        output.format,
+        outputExtension(output.file),
+        JSON.stringify(env),
+      ].join('|')
+      const occurrence = seen.get(shape) ?? 0
+      seen.set(shape, occurrence + 1)
+
+      const key = occurrence === 0 ? shape : `${shape}|#${occurrence}`
+      let group = groups.get(key)
+      if (!group) {
+        group = { key, items: [] }
+        groups.set(key, group)
+      }
+      group.items.push({ exportPath, exportCondition, output })
+    }
+  }
+
+  if (process.env.DEBUG) {
+    for (const { key, items } of groups.values()) {
+      logger.log(`Merged group "${key}": ${items.length} entries`)
+    }
+  }
+
+  const configs: MergedRollupConfig[] = []
+  for (const group of groups.values()) {
+    configs.push(
+      await buildMergedConfig(group, bundleConfig, buildContext, dts),
+    )
+  }
+  return configs
+}
+
+async function buildMergedConfig(
+  group: Group,
+  bundleConfig: BundleConfig,
+  buildContext: BuildContext,
+  dts: boolean,
+): Promise<MergedRollupConfig> {
+  const { cwd } = buildContext
+  const { items } = group
+
+  const input: Record<string, string> = {}
+  /** input name -> absolute output file */
+  const outputFiles = new Map<string, string>()
+  for (const item of items) {
+    const name = toInputName(item.exportPath)
+    input[name] = item.exportCondition.source
+    outputFiles.set(name, resolve(cwd, item.output.file))
+  }
+
+  // The first entry stands in for the group when building the options shared
+  // across it: format, sourcemap, interop, chunk naming.
+  const [representative] = items
+  const representativeCondition: ParsedExportCondition = {
+    ...representative.exportCondition,
+    targets: [representative.output.target],
+  }
+  const representativeBundleConfig: BundleConfig = {
+    ...bundleConfig,
+    file: representative.output.file,
+    format: representative.output.format,
+  }
+
+  const { input: _entryInput, ...inputOptions } = await buildInputConfig(
+    representative.exportCondition.source,
+    representativeBundleConfig,
+    representativeCondition,
+    buildContext,
+    dts,
+    input,
+  )
+
+  const outputOptions = await buildOutputConfigs(
+    representativeBundleConfig,
+    representativeCondition,
+    buildContext,
+    dts,
+  )
+
+  const dir = commonRootDir([...outputFiles.values()].map((f) => dirname(f)))
+
+  return {
+    ...inputOptions,
+    input,
+    outputs: [
+      {
+        ...outputOptions,
+        dir,
+        // Each entry keeps the exact path its export condition declares, which
+        // the per-entry path gets for free from a single `output.file`.
+        entryFileNames(chunk) {
+          const file = outputFiles.get(chunk.name)
+          if (!file) {
+            throw new Error(
+              `bunchee: no output file mapped for merged entry "${chunk.name}"`,
+            )
+          }
+          return normalizePath(relative(dir, file))
+        },
+      },
+    ],
+  }
+}

--- a/src/rollup/merged-config.ts
+++ b/src/rollup/merged-config.ts
@@ -245,11 +245,15 @@ export function typeShardCount(entryCount: number, cores: number): number {
   const override = Number(process.env.BUNCHEE_DTS_SHARDS)
   if (Number.isFinite(override) && override > 0) return Math.floor(override)
 
-  // Below this a shard spends longer starting a program than emitting types.
-  const MIN_ENTRIES_PER_SHARD = 8
-  return Math.max(
-    1,
-    Math.min(4, cores, Math.floor(entryCount / MIN_ENTRIES_PER_SHARD)),
+  // Past four the wall-clock barely moves while each extra program keeps
+  // costing CPU: on 57 entries, eight shards bought 50ms over four and spent
+  // another 7s of CPU doing it.
+  const MAX_SHARDS = 4
+  const MIN_ENTRIES_PER_SHARD = 4
+  return Math.min(
+    MAX_SHARDS,
+    cores,
+    Math.max(1, Math.ceil(entryCount / MIN_ENTRIES_PER_SHARD)),
   )
 }
 

--- a/src/rollup/merged-config.ts
+++ b/src/rollup/merged-config.ts
@@ -1,6 +1,4 @@
 import { dirname, relative, resolve, sep } from 'path'
-import { readFile } from 'fs/promises'
-import { glob } from 'tinyglobby'
 import type {
   BuildContext,
   BundleConfig,
@@ -13,12 +11,8 @@ import type { ExportOutput } from '../exports'
 import { buildInputConfig } from './input'
 import { buildOutputConfigs } from './output'
 import { getEntryBundleOutputs } from '../build-config'
-import { isBinExportPath, normalizePath } from '../utils'
-import {
-  availableExtensions,
-  specialExportConventions,
-  TESTS_GLOB_PATTERN,
-} from '../constants'
+import { normalizePath } from '../utils'
+import { getSpecialExportTypeFromConditionNames } from '../entries'
 import { getDefinedInlineVariables } from '../env'
 import { logger } from '../logger'
 
@@ -32,47 +26,8 @@ type Group = {
   /** Debug label; also the map key that collects the group. */
   key: string
   items: GroupItem[]
-}
-
-const BOUNDARY_DIRECTIVE_REGEX =
-  /^\s*(?:\/\*[\s\S]*?\*\/|\/\/.*\n)*\s*['"]use (client|server)['"]/
-
-/**
- * Whether the package uses `'use client'` / `'use server'` boundaries.
- *
- * A per-entry build decides where a directive module lands separately for each
- * entry, so the same module can be inlined into one output and split into its
- * own chunk in another. One shared graph only gets to make that call once, so
- * merging cannot reproduce the existing chunk layout for these packages —
- * see `test/integration/server-components`. Detect it and stay on the
- * per-entry path.
- *
- * Conservative on purpose: a false positive only means the build keeps working
- * the way it does today.
- */
-async function hasBoundaryDirectives(entries: Entries): Promise<boolean> {
-  const sourceDirs = new Set(
-    Object.values(entries).map((entry) => dirname(entry.source)),
-  )
-  const extensions = [...availableExtensions].join(',')
-  const files = new Set<string>()
-  for (const dir of sourceDirs) {
-    const found = await glob(`**/*.{${extensions}}`, {
-      cwd: dir,
-      absolute: true,
-      ignore: [TESTS_GLOB_PATTERN, '**/node_modules/**'],
-    })
-    for (const file of found) files.add(file)
-  }
-
-  for (const file of files) {
-    // Directives are the first statement, so only the head matters.
-    const handle = await readFile(file, 'utf8').catch(() => '')
-    if (BOUNDARY_DIRECTIVE_REGEX.test(handle.slice(0, 512))) {
-      return true
-    }
-  }
-  return false
+  /** Absolute output file -> the source that claimed it. */
+  claimed: Map<string, string>
 }
 
 /**
@@ -108,28 +63,6 @@ async function findMergeBlocker(
   const exportPaths = Object.keys(entries)
   if (exportPaths.length < 2) {
     return `only ${exportPaths.length} entry resolved`
-  }
-
-  for (const [exportPath, exportCondition] of Object.entries(entries)) {
-    // `prependShebang` is bound to one specific entry file.
-    if (isBinExportPath(exportPath)) {
-      return `"${exportPath}" is a bin entry`
-    }
-    for (const target of exportCondition.targets) {
-      // Runtime/optimize conditions (`react-server`, `browser`, `development`,
-      // …) change the inlined env and which sibling bundle an import should
-      // resolve to, which the alias plugin decides per entry.
-      const special = target.conditions.find((condition) =>
-        specialExportConventions.has(condition),
-      )
-      if (special) {
-        return `"${exportPath}" uses the "${special}" condition`
-      }
-    }
-  }
-
-  if (await hasBoundaryDirectives(entries)) {
-    return `package uses 'use client' / 'use server' boundaries`
   }
 
   return undefined
@@ -204,16 +137,45 @@ export async function buildMergedConfigs(
         output.format,
         outputExtension(output.file),
         JSON.stringify(env),
+        // Which sibling bundle an import resolves to is decided per runtime or
+        // optimize condition, so entries only share a graph with entries that
+        // resolve the same way.
+        getSpecialExportTypeFromConditionNames(
+          new Set(output.target.conditions),
+        ),
       ].join('|')
       const occurrence = seen.get(shape) ?? 0
       seen.set(shape, occurrence + 1)
 
-      const key = occurrence === 0 ? shape : `${shape}|#${occurrence}`
-      let group = groups.get(key)
-      if (!group) {
-        group = { key, items: [] }
-        groups.set(key, group)
+      // Two entries can resolve to the same output file — `./a` picking up the
+      // `workerd` condition and `./a.workerd` both land on `a.workerd.js`.
+      // Built one at a time they overwrite each other; in one graph they are
+      // two inputs, and rollup would keep both by numbering the second.
+      const file = resolve(buildContext.cwd, output.file)
+      let group: Group | undefined
+      for (let attempt = occurrence; ; attempt++) {
+        const key = attempt === 0 ? shape : `${shape}|#${attempt}`
+        const candidate = groups.get(key) ?? {
+          key,
+          items: [],
+          claimed: new Map(),
+        }
+        groups.set(key, candidate)
+        const claimedBy = candidate.claimed.get(file)
+        if (claimedBy === exportCondition.source) {
+          // The same source writing the same file: nothing to add.
+          group = undefined
+          break
+        }
+        if (claimedBy == null) {
+          group = candidate
+          break
+        }
+        // A different source wants this file. Keep them in separate graphs so
+        // the later one still overwrites, exactly as it does today.
       }
+      if (!group) continue
+      group.claimed.set(file, exportCondition.source)
       group.items.push({ exportPath, exportCondition, output })
     }
   }
@@ -280,10 +242,18 @@ async function buildMergedConfig(
   const input: Record<string, string> = {}
   /** input name -> absolute output file */
   const outputFiles = new Map<string, string>()
+  /**
+   * Same, keyed by source. Rollup sanitises an input name before it reaches
+   * `chunk.name` — a bin entry's `$binary` arrives as `_binary` — so the source
+   * behind the chunk is the reliable way back to its output path.
+   */
+  const outputFilesBySource = new Map<string, string>()
   for (const item of items) {
     const name = toInputName(item.exportPath)
+    const file = resolve(cwd, item.output.file)
     input[name] = item.exportCondition.source
-    outputFiles.set(name, resolve(cwd, item.output.file))
+    outputFiles.set(name, file)
+    outputFilesBySource.set(item.exportCondition.source, file)
   }
 
   // The first entry stands in for the group when building the options shared
@@ -313,6 +283,7 @@ async function buildMergedConfig(
     representativeCondition,
     buildContext,
     dts,
+    true,
   )
 
   const dir = commonRootDir([...outputFiles.values()].map((f) => dirname(f)))
@@ -320,22 +291,23 @@ async function buildMergedConfig(
   return {
     ...inputOptions,
     input,
-    outputs: [
-      {
-        ...outputOptions,
-        dir,
-        // Each entry keeps the exact path its export condition declares, which
-        // the per-entry path gets for free from a single `output.file`.
-        entryFileNames(chunk) {
-          const file = outputFiles.get(chunk.name)
-          if (!file) {
-            throw new Error(
-              `bunchee: no output file mapped for merged entry "${chunk.name}"`,
-            )
-          }
-          return normalizePath(relative(dir, file))
-        },
+    output: {
+      ...outputOptions,
+      dir,
+      // Each entry keeps the exact path its export condition declares, which
+      // the per-entry path gets for free from a single `output.file`.
+      entryFileNames(chunk) {
+        const file =
+          (chunk.facadeModuleId &&
+            outputFilesBySource.get(chunk.facadeModuleId)) ||
+          outputFiles.get(chunk.name)
+        if (!file) {
+          throw new Error(
+            `bunchee: no output file mapped for merged entry "${chunk.name}"`,
+          )
+        }
+        return normalizePath(relative(dir, file))
       },
-    ],
+    },
   }
 }

--- a/src/rollup/merged-config.ts
+++ b/src/rollup/merged-config.ts
@@ -179,6 +179,14 @@ export async function buildMergedConfigs(
 
   const groups = new Map<string, Group>()
   for (const [exportPath, exportCondition] of Object.entries(entries)) {
+    // A shard owns a subset of the entries. The rest stay in `entries` so the
+    // alias plugin can still resolve references to them as externals.
+    if (
+      bundleConfig._entryFilter &&
+      !bundleConfig._entryFilter.includes(exportPath)
+    ) {
+      continue
+    }
     const outputs = await getEntryBundleOutputs(
       bundleConfig,
       exportCondition,
@@ -223,6 +231,37 @@ export async function buildMergedConfigs(
     )
   }
   return configs
+}
+
+/**
+ * How many ways to split the types work across workers.
+ *
+ * Declaration emit is linear in entry count and one shared graph cannot
+ * amortise it, so the only lever is running several at once — and only in
+ * separate heaps. Four was the floor on a 57-entry package; past that each
+ * extra TypeScript program costs more than the parallelism it buys.
+ */
+export function typeShardCount(entryCount: number, cores: number): number {
+  const override = Number(process.env.BUNCHEE_DTS_SHARDS)
+  if (Number.isFinite(override) && override > 0) return Math.floor(override)
+
+  // Below this a shard spends longer starting a program than emitting types.
+  const MIN_ENTRIES_PER_SHARD = 8
+  return Math.max(
+    1,
+    Math.min(4, cores, Math.floor(entryCount / MIN_ENTRIES_PER_SHARD)),
+  )
+}
+
+/** Split into `count` contiguous groups of near-equal size. */
+export function shardEntries(names: string[], count: number): string[][] {
+  if (count <= 1) return [names]
+  const groups: string[][] = []
+  const size = Math.ceil(names.length / count)
+  for (let i = 0; i < names.length; i += size) {
+    groups.push(names.slice(i, i + size))
+  }
+  return groups
 }
 
 async function buildMergedConfig(

--- a/src/rollup/output.ts
+++ b/src/rollup/output.ts
@@ -13,6 +13,7 @@ export async function buildOutputConfigs(
   exportCondition: ParsedExportCondition,
   buildContext: BuildContext,
   dts: boolean,
+  merged: boolean = false,
 ): Promise<OutputOptions> {
   const { format } = bundleConfig
   const {
@@ -61,6 +62,7 @@ export async function buildOutputConfigs(
     manualChunks: createSplitChunks(
       pluginContext.moduleDirectiveLayerMap,
       entryFiles,
+      merged,
     ),
     chunkFileNames() {
       const isCjsFormat = format === 'cjs'

--- a/src/rollup/split-chunks.ts
+++ b/src/rollup/split-chunks.ts
@@ -107,6 +107,14 @@ function getImporterLayers(
 export function createSplitChunks(
   dependencyGraphMap: Map<string, Set<[string, string | undefined]>>,
   entryFiles: Set<string>,
+  /**
+   * One graph holding every entry only gets to place a directive module once,
+   * where a build per entry decides separately each time — so it cannot inline
+   * the module into a same-layer entry and split it out of a different-layer
+   * one. Giving every directive module its own chunk keeps the boundary
+   * explicit for all of them, and costs one chunk instead of a copy per entry.
+   */
+  merged: boolean = false,
 ): GetManualChunk {
   // If there's existing chunk being splitted, and contains a layer { <id>: <chunkGroup> }
   const splitChunksGroupMap = new Map<string, string>()
@@ -164,6 +172,14 @@ export function createSplitChunks(
         splitChunksGroupMap.set(id, chunkGroup)
         return chunkGroup
       }
+    }
+
+    if (merged && moduleLayer && !isEntry) {
+      const existing = splitChunksGroupMap.get(id)
+      if (existing) return existing
+      const chunkGroup = `${path.basename(id, path.extname(id))}-${hashTo3Char(moduleLayer)}`
+      splitChunksGroupMap.set(id, chunkGroup)
+      return chunkGroup
     }
 
     // If current module has a layer, and it's not an entry

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,14 @@ type BundleConfig = {
   mergeEntries?: boolean
 
   /*
+   * Build only the type declarations, skipping the JS assets. Set when merged
+   * rollup instances have already produced the JS on the main thread and the
+   * workers are left with the types.
+   * @internal
+   */
+  _typesOnly?: boolean
+
+  /*
    * Only build the entries with these export paths (e.g. ['./foo']).
    * Set by the worker pool to assign one entry per worker.
    * @internal

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,13 +118,10 @@ type BuncheeRollupConfig = CustomRollupInputOptions & {
   output: OutputOptions
 }
 
-/**
- * One rollup build shared by many entries: a single module graph written once
- * per output format.
- */
+/** One rollup build shared by many entries: a single module graph, one output. */
 type MergedRollupConfig = CustomRollupInputOptions & {
   input: Record<string, string>
-  outputs: OutputOptions[]
+  output: OutputOptions
 }
 
 type CliArgs = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,14 @@ type BundleConfig = {
   tsconfig?: string
   onSuccess?: string | (() => void | Promise<void>)
 
+  /**
+   * Build every entry through a few shared rollup instances — one module graph
+   * per group of entries that can share one — instead of one per entry/output
+   * pair. Experimental: shared code becomes a chunk rather than being copied
+   * into each entry that uses it.
+   */
+  mergeEntries?: boolean
+
   /*
    * Only build the entries with these export paths (e.g. ['./foo']).
    * Set by the worker pool to assign one entry per worker.
@@ -102,11 +110,21 @@ type CustomRollupInputOptions = Pick<
   InputOptions,
   'external' | 'plugins' | 'treeshake' | 'onwarn'
 > & {
-  input: string
+  /** A single entry, or `{ <entry name>: <source path> }` for a merged build. */
+  input: string | Record<string, string>
 }
 
 type BuncheeRollupConfig = CustomRollupInputOptions & {
   output: OutputOptions
+}
+
+/**
+ * One rollup build shared by many entries: a single module graph written once
+ * per output format.
+ */
+type MergedRollupConfig = CustomRollupInputOptions & {
+  input: Record<string, string>
+  outputs: OutputOptions[]
 }
 
 type CliArgs = {
@@ -127,6 +145,7 @@ type CliArgs = {
   runtime?: string
   prepare?: boolean
   clean?: boolean
+  mergeEntries?: boolean
   tsconfig?: string
   onSuccess?: string
 }
@@ -179,6 +198,7 @@ export type {
   PackageMetadata,
   FullExportCondition,
   BuncheeRollupConfig,
+  MergedRollupConfig,
   PackageType,
   ParsedExportCondition,
   Entries,

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,15 +49,6 @@ type BundleConfig = {
   tsconfig?: string
   onSuccess?: string | (() => void | Promise<void>)
 
-  /**
-   * Build every entry through a few shared rollup instances — one module graph
-   * per group of entries that can share one — instead of one per entry/output
-   * pair. On by default; set to `false` to keep one rollup instance per
-   * entry/output, which copies shared code into each entry instead of emitting
-   * it as a chunk.
-   */
-  mergeEntries?: boolean
-
   /*
    * Build only the type declarations, skipping the JS assets. Set when merged
    * rollup instances have already produced the JS on the main thread and the
@@ -154,7 +145,6 @@ type CliArgs = {
   runtime?: string
   prepare?: boolean
   clean?: boolean
-  mergeEntries?: boolean
   tsconfig?: string
   onSuccess?: string
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,8 +52,9 @@ type BundleConfig = {
   /**
    * Build every entry through a few shared rollup instances — one module graph
    * per group of entries that can share one — instead of one per entry/output
-   * pair. Experimental: shared code becomes a chunk rather than being copied
-   * into each entry that uses it.
+   * pair. On by default; set to `false` to keep one rollup instance per
+   * entry/output, which copies shared code into each entry instead of emitting
+   * it as a chunk.
    */
   mergeEntries?: boolean
 

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -153,6 +153,32 @@ export function resolveTsConfig(
   return result
 }
 
+/**
+ * Whether `rollup-plugin-dts` would find this exact tsconfig on its own from
+ * every one of `entryDirs`.
+ *
+ * Worth knowing because passing the path explicitly is slower. The plugin
+ * rewrites its per-input directory key to the tsconfig's directory only when
+ * its config cache misses, and an explicit path makes the cache hit for every
+ * input after the first — so the rest keep their own directory and each gets
+ * its own TypeScript program. Letting the plugin discover the file keeps every
+ * lookup a miss, which lands every input in one program. A package whose
+ * entries each sit in their own directory pays for that difference per entry.
+ */
+export function isTsConfigAutoDiscoverable(
+  cwd: string,
+  tsConfigPath: string | undefined,
+  entryDirs: string[],
+): boolean {
+  if (!tsConfigPath) return false
+  const ts = resolveTypescript(cwd)
+  const resolved = resolve(tsConfigPath)
+  return entryDirs.every((dir) => {
+    const found = ts.findConfigFile(dir, ts.sys.fileExists)
+    return Boolean(found) && resolve(found as string) === resolved
+  })
+}
+
 export async function convertCompilerOptions(
   cwd: string,
   json: any,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5,7 +5,8 @@ import bundle from './bundle'
 export type EntryWorkerTask = {
   cwd: string
   cliEntryPath: string
-  entryName: string
+  /** The entries this worker owns; more than one when the caller sharded. */
+  entryNames: string[]
   options: BundleConfig
 }
 
@@ -57,7 +58,7 @@ function toTransferableError(error: any): Error {
 export async function buildEntryInWorker({
   cwd,
   cliEntryPath,
-  entryName,
+  entryNames,
   options,
 }: EntryWorkerTask): Promise<SizeStats> {
   let buildContext: BuildContext | undefined
@@ -73,7 +74,7 @@ export async function buildEntryInWorker({
       // entries are dispatched; workers run concurrently and must not remove
       // each other's output.
       clean: false,
-      _entryFilter: [entryName],
+      _entryFilter: entryNames,
       _callbacks: {
         onBuildStart(context: BuildContext) {
           buildContext = context

--- a/test/integration/default-default-export-different-ext/index.test.ts
+++ b/test/integration/default-default-export-different-ext/index.test.ts
@@ -29,19 +29,14 @@ describe('integration - default-default-export-different-ext', () => {
     }
     expect(contents).toMatchInlineSnapshot(`
       {
-        "a.cjs": "var b_cjs = require('./b.cjs');
+        "a.cjs": "var b = require('./b.cjs');
 
       const a = 'a';
 
+      exports.b = b.b;
       exports.a = a;
-      Object.keys(b_cjs).forEach(function (k) {
-      	if (k !== 'default' && !Object.prototype.hasOwnProperty.call(exports, k)) Object.defineProperty(exports, k, {
-      		enumerable: true,
-      		get: function () { return b_cjs[k]; }
-      	});
-      });
       ",
-        "a.js": "export * from './b.js';
+        "a.js": "export { b } from './b.js';
 
       const a = 'a';
 
@@ -55,9 +50,9 @@ describe('integration - default-default-export-different-ext', () => {
 
       export { b };
       ",
-        "c.cjs": "var a_cjs = require('./a.cjs');
+        "c.cjs": "var a = require('./a.cjs');
 
-      const c = \`c\${a_cjs.a}\`;
+      const c = \`c\${a.a}\`;
 
       exports.c = c;
       ",

--- a/test/integration/default-default-export/index.test.ts
+++ b/test/integration/default-default-export/index.test.ts
@@ -21,21 +21,16 @@ describe('integration - default-default-export', () => {
     ])
     const contents = await getFileContents(distDir)
     expect(contents['a.cjs']).toMatchInlineSnapshot(`
-      "var b_cjs = require('./b.cjs');
+      "var b = require('./b.cjs');
 
       const a = 'a';
 
+      exports.b = b.b;
       exports.a = a;
-      Object.keys(b_cjs).forEach(function (k) {
-      	if (k !== 'default' && !Object.prototype.hasOwnProperty.call(exports, k)) Object.defineProperty(exports, k, {
-      		enumerable: true,
-      		get: function () { return b_cjs[k]; }
-      	});
-      });
       "
     `)
     expect(contents['a.js']).toMatchInlineSnapshot(`
-      "export * from './b.js';
+      "export { b } from './b.js';
 
       const a = 'a';
 

--- a/test/integration/exports-order/index.test.ts
+++ b/test/integration/exports-order/index.test.ts
@@ -48,24 +48,19 @@ describe('integration exports-order', () => {
     `)
 
     expect(contents['index.cjs']).toMatchInlineSnapshot(`
-      "var a_cjs = require('./a.cjs');
+      "var a = require('./a.cjs');
 
 
 
-      Object.keys(a_cjs).forEach(function (k) {
-      	if (k !== 'default' && !Object.prototype.hasOwnProperty.call(exports, k)) Object.defineProperty(exports, k, {
-      		enumerable: true,
-      		get: function () { return a_cjs[k]; }
-      	});
-      });
+      exports.foo = a.foo;
       "
     `)
     expect(contents['index.edge-light.js']).toMatchInlineSnapshot(`
-      "export * from './a.edge-light.js';
+      "export { foo } from './a.edge-light.js';
       "
     `)
     expect(contents['index.js']).toMatchInlineSnapshot(`
-      "export * from './a.js';
+      "export { foo } from './a.js';
       "
     `)
   })

--- a/test/integration/many-entries/index.test.ts
+++ b/test/integration/many-entries/index.test.ts
@@ -78,15 +78,18 @@ describe('integration - many-entries', () => {
   }, 240_000)
 
   describe('--merge-entries', () => {
-    it('should build every entry through two shared rollup instances', async () => {
+    it('should build the JS through shared rollup instances and shard the types', async () => {
       const merged = await build({ DEBUG: '1' }, ['--merge-entries'])
 
-      // Nine entries, each with a types output, is 18 rollup instances on the
-      // per-entry path. Merged it is one graph for the JS and one for the types.
+      // Nine entries with a types output each is 18 rollup instances on the
+      // per-entry path. Merged, the JS collapses to one graph per format and
+      // the types go to the workers in shards rather than one worker per entry.
       expect(merged.stdout).toMatch(
-        /Building 9 entries in 2 shared rollup instances/,
+        /Building 9 entries in 1 shared rollup instances/,
       )
-      expect(merged.stdout).not.toContain('worker threads')
+      expect(merged.stdout).toMatch(
+        /Building 9 entries in \d+ worker threads \(\d+ shards of ~\d+\)/,
+      )
     }, 120_000)
 
     it('should keep a sibling entry external instead of inlining it', async () => {

--- a/test/integration/many-entries/index.test.ts
+++ b/test/integration/many-entries/index.test.ts
@@ -12,9 +12,9 @@ import { executeBunchee } from '../../testing-utils/shared'
 const dir = __dirname
 const distDir = path.join(dir, 'dist')
 
-async function build(env: NodeJS.ProcessEnv = {}) {
+async function build(env: NodeJS.ProcessEnv = {}, args: string[] = []) {
   await removeDirectory(distDir)
-  const result = await executeBunchee(['--cwd', dir], { env })
+  const result = await executeBunchee(['--cwd', dir, ...args], { env })
   expect(result.stderr).toBe('')
   expect(result.code).toBe(0)
   return {
@@ -76,4 +76,58 @@ describe('integration - many-entries', () => {
     expect(inProcess.files).toEqual(workers.files)
     expect(inProcess.contents).toEqual(workers.contents)
   }, 240_000)
+
+  describe('--merge-entries', () => {
+    it('should build every entry through two shared rollup instances', async () => {
+      const merged = await build({ DEBUG: '1' }, ['--merge-entries'])
+
+      // Nine entries, each with a types output, is 18 rollup instances on the
+      // per-entry path. Merged it is one graph for the JS and one for the types.
+      expect(merged.stdout).toMatch(
+        /Building 9 entries in 2 shared rollup instances/,
+      )
+      expect(merged.stdout).not.toContain('worker threads')
+    }, 120_000)
+
+    it('should keep a sibling entry external instead of inlining it', async () => {
+      const merged = await build({}, ['--merge-entries'])
+
+      // Rollup resolves cross-entry references itself once both are inputs of
+      // the same graph, so this has to hold without the alias plugin.
+      expect(merged.contents['index.js']).toContain(`from './a.js'`)
+      expect(merged.contents['index.js']).not.toContain(`'a:'`)
+    }, 120_000)
+
+    it('should emit shared code as one chunk instead of copying it per entry', async () => {
+      const perEntry = await build()
+      const merged = await build({}, ['--merge-entries'])
+
+      // `shared.ts` is not an entry and every entry imports it, so the
+      // per-entry path duplicates it into all nine outputs.
+      const copies = Object.entries(perEntry.contents).filter(
+        ([file, content]) =>
+          file.endsWith('.js') && content.includes(`const shared = 'shared'`),
+      )
+      expect(copies).toHaveLength(9)
+
+      const chunk = merged.files.find((file) => file.startsWith('shared-'))
+      expect(chunk).toBeDefined()
+      expect(merged.contents['a.js']).toContain(`from './${chunk}'`)
+      expect(merged.contents['a.js']).not.toContain(`const shared = 'shared'`)
+    }, 180_000)
+
+    it('should produce identical type declarations', async () => {
+      const perEntry = await build()
+      const merged = await build({}, ['--merge-entries'])
+
+      const declarations = (contents: Record<string, string>) =>
+        Object.fromEntries(
+          Object.entries(contents).filter(([file]) => file.endsWith('.d.ts')),
+        )
+
+      expect(declarations(merged.contents)).toEqual(
+        declarations(perEntry.contents),
+      )
+    }, 180_000)
+  })
 })

--- a/test/integration/many-entries/index.test.ts
+++ b/test/integration/many-entries/index.test.ts
@@ -8,7 +8,7 @@ import {
 import { executeBunchee } from '../../testing-utils/shared'
 
 // Nine entries, above MIN_ENTRIES_FOR_WORKERS, with no directive layers: this
-// is the fixture that takes the worker pool path.
+// is the fixture that merges the JS into one graph and shards the types.
 const dir = __dirname
 const distDir = path.join(dir, 'dist')
 
@@ -23,6 +23,11 @@ async function build(env: NodeJS.ProcessEnv = {}, args: string[] = []) {
     contents: await getFileContents(distDir),
   }
 }
+
+const declarations = (contents: Record<string, string>) =>
+  Object.fromEntries(
+    Object.entries(contents).filter(([file]) => file.endsWith('.d.ts')),
+  )
 
 describe('integration - many-entries', () => {
   afterAll(async () => {
@@ -54,83 +59,80 @@ describe('integration - many-entries', () => {
         "h.js",
         "index.d.ts",
         "index.js",
+        "shared-BMJTKie0.js",
       ]
     `)
-    // The entry that imports a sibling entry keeps it external instead of
-    // inlining it, which the worker has to get right from its own copy of the
-    // full entries map.
+    // The entry that imports a sibling entry references it instead of inlining
+    // it, which rollup resolves itself once both are inputs of one graph.
     expect(contents['index.js']).toContain(`from './a.js'`)
     expect(contents['index.js']).not.toContain(`'a:'`)
   }, 120_000)
 
-  it('should produce the same output as an in-process build', async () => {
-    const workers = await build({ DEBUG: '1' })
-    const inProcess = await build({ DEBUG: '1', TEST_NO_WORKERS: '1' })
+  it('should build the JS as one graph and shard the types', async () => {
+    const { stdout } = await build({ DEBUG: '1' })
 
-    // Guard the comparison: it only means anything if the first build really
-    // did fan out. Runs from source and from dist resolve the worker file
-    // differently, so this has to hold for both.
-    expect(workers.stdout).toMatch(/Building 9 entries in \d+ worker threads/)
-    expect(inProcess.stdout).not.toContain('worker threads')
+    // Nine entries with a types output each is 18 rollup instances when every
+    // entry is built on its own.
+    expect(stdout).toMatch(/Building 9 entries in 1 shared rollup instances/)
+    expect(stdout).toMatch(
+      /Building 9 entries in \d+ worker threads \(\d+ shards of ~\d+\)/,
+    )
+  }, 120_000)
 
-    expect(inProcess.files).toEqual(workers.files)
-    expect(inProcess.contents).toEqual(workers.contents)
-  }, 240_000)
+  it('should emit shared code as one chunk instead of copying it per entry', async () => {
+    const perEntry = await build({}, ['--no-merge-entries'])
+    const merged = await build()
 
-  describe('--merge-entries', () => {
-    it('should build the JS through shared rollup instances and shard the types', async () => {
-      const merged = await build({ DEBUG: '1' }, ['--merge-entries'])
+    // `shared.ts` is not an entry and every entry imports it, so building each
+    // entry on its own duplicates it into all nine outputs.
+    const copies = Object.entries(perEntry.contents).filter(
+      ([file, content]) =>
+        file.endsWith('.js') && content.includes(`const shared = 'shared'`),
+    )
+    expect(copies).toHaveLength(9)
 
-      // Nine entries with a types output each is 18 rollup instances on the
-      // per-entry path. Merged, the JS collapses to one graph per format and
-      // the types go to the workers in shards rather than one worker per entry.
-      expect(merged.stdout).toMatch(
-        /Building 9 entries in 1 shared rollup instances/,
-      )
-      expect(merged.stdout).toMatch(
-        /Building 9 entries in \d+ worker threads \(\d+ shards of ~\d+\)/,
-      )
+    const chunk = merged.files.find((file) => file.startsWith('shared-'))
+    expect(chunk).toBeDefined()
+    expect(merged.contents['a.js']).toContain(`from './${chunk}'`)
+    expect(merged.contents['a.js']).not.toContain(`const shared = 'shared'`)
+  }, 180_000)
+
+  it('should emit the same declarations either way', async () => {
+    const perEntry = await build({}, ['--no-merge-entries'])
+    const merged = await build()
+
+    expect(declarations(merged.contents)).toEqual(
+      declarations(perEntry.contents),
+    )
+  }, 180_000)
+
+  describe('--no-merge-entries', () => {
+    it('should build every entry in its own rollup instance', async () => {
+      const { stdout, files, contents } = await build({ DEBUG: '1' }, [
+        '--no-merge-entries',
+      ])
+
+      expect(stdout).toMatch(/Building 9 entries in \d+ worker threads/)
+      expect(stdout).not.toContain('shared rollup instances')
+      // No cross-entry chunk: each entry carries its own copy of `shared`.
+      expect(files.some((file) => file.startsWith('shared-'))).toBe(false)
+      expect(contents['index.js']).toContain(`from './a.js'`)
     }, 120_000)
 
-    it('should keep a sibling entry external instead of inlining it', async () => {
-      const merged = await build({}, ['--merge-entries'])
+    it('should produce the same output as an in-process build', async () => {
+      const workers = await build({ DEBUG: '1' }, ['--no-merge-entries'])
+      const inProcess = await build({ DEBUG: '1', TEST_NO_WORKERS: '1' }, [
+        '--no-merge-entries',
+      ])
 
-      // Rollup resolves cross-entry references itself once both are inputs of
-      // the same graph, so this has to hold without the alias plugin.
-      expect(merged.contents['index.js']).toContain(`from './a.js'`)
-      expect(merged.contents['index.js']).not.toContain(`'a:'`)
-    }, 120_000)
+      // Guard the comparison: it only means anything if the first build really
+      // did fan out. Runs from source and from dist resolve the worker file
+      // differently, so this has to hold for both.
+      expect(workers.stdout).toMatch(/Building 9 entries in \d+ worker threads/)
+      expect(inProcess.stdout).not.toContain('worker threads')
 
-    it('should emit shared code as one chunk instead of copying it per entry', async () => {
-      const perEntry = await build()
-      const merged = await build({}, ['--merge-entries'])
-
-      // `shared.ts` is not an entry and every entry imports it, so the
-      // per-entry path duplicates it into all nine outputs.
-      const copies = Object.entries(perEntry.contents).filter(
-        ([file, content]) =>
-          file.endsWith('.js') && content.includes(`const shared = 'shared'`),
-      )
-      expect(copies).toHaveLength(9)
-
-      const chunk = merged.files.find((file) => file.startsWith('shared-'))
-      expect(chunk).toBeDefined()
-      expect(merged.contents['a.js']).toContain(`from './${chunk}'`)
-      expect(merged.contents['a.js']).not.toContain(`const shared = 'shared'`)
-    }, 180_000)
-
-    it('should produce identical type declarations', async () => {
-      const perEntry = await build()
-      const merged = await build({}, ['--merge-entries'])
-
-      const declarations = (contents: Record<string, string>) =>
-        Object.fromEntries(
-          Object.entries(contents).filter(([file]) => file.endsWith('.d.ts')),
-        )
-
-      expect(declarations(merged.contents)).toEqual(
-        declarations(perEntry.contents),
-      )
-    }, 180_000)
+      expect(inProcess.files).toEqual(workers.files)
+      expect(inProcess.contents).toEqual(workers.contents)
+    }, 240_000)
   })
 })

--- a/test/integration/many-entries/index.test.ts
+++ b/test/integration/many-entries/index.test.ts
@@ -12,9 +12,9 @@ import { executeBunchee } from '../../testing-utils/shared'
 const dir = __dirname
 const distDir = path.join(dir, 'dist')
 
-async function build(env: NodeJS.ProcessEnv = {}, args: string[] = []) {
+async function build(env: NodeJS.ProcessEnv = {}) {
   await removeDirectory(distDir)
-  const result = await executeBunchee(['--cwd', dir, ...args], { env })
+  const result = await executeBunchee(['--cwd', dir], { env })
   expect(result.stderr).toBe('')
   expect(result.code).toBe(0)
   return {
@@ -24,10 +24,7 @@ async function build(env: NodeJS.ProcessEnv = {}, args: string[] = []) {
   }
 }
 
-const declarations = (contents: Record<string, string>) =>
-  Object.fromEntries(
-    Object.entries(contents).filter(([file]) => file.endsWith('.d.ts')),
-  )
+const ENTRIES = ['index', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']
 
 describe('integration - many-entries', () => {
   afterAll(async () => {
@@ -71,68 +68,51 @@ describe('integration - many-entries', () => {
   it('should build the JS as one graph and shard the types', async () => {
     const { stdout } = await build({ DEBUG: '1' })
 
-    // Nine entries with a types output each is 18 rollup instances when every
-    // entry is built on its own.
+    // Nine entries with a types output each would be 18 rollup instances if
+    // every entry were built on its own.
     expect(stdout).toMatch(/Building 9 entries in 1 shared rollup instances/)
     expect(stdout).toMatch(
       /Building 9 entries in \d+ worker threads \(\d+ shards of ~\d+\)/,
     )
   }, 120_000)
 
-  it('should emit shared code as one chunk instead of copying it per entry', async () => {
-    const perEntry = await build({}, ['--no-merge-entries'])
-    const merged = await build()
+  it('should emit code shared between entries as a single chunk', async () => {
+    const { files, contents } = await build()
 
-    // `shared.ts` is not an entry and every entry imports it, so building each
-    // entry on its own duplicates it into all nine outputs.
-    const copies = Object.entries(perEntry.contents).filter(
-      ([file, content]) =>
-        file.endsWith('.js') && content.includes(`const shared = 'shared'`),
-    )
-    expect(copies).toHaveLength(9)
+    // `shared.ts` is not an entry and all nine entries import it, so it lands
+    // in one chunk that every entry references rather than a copy per entry.
+    const chunks = files.filter((file) => file.startsWith('shared-'))
+    expect(chunks).toHaveLength(1)
 
-    const chunk = merged.files.find((file) => file.startsWith('shared-'))
-    expect(chunk).toBeDefined()
-    expect(merged.contents['a.js']).toContain(`from './${chunk}'`)
-    expect(merged.contents['a.js']).not.toContain(`const shared = 'shared'`)
-  }, 180_000)
+    for (const entry of ENTRIES) {
+      expect(contents[`${entry}.js`]).toContain(`from './${chunks[0]}'`)
+      expect(contents[`${entry}.js`]).not.toContain(`const shared = 'shared'`)
+    }
+    expect(contents[chunks[0]]).toContain(`const shared = 'shared'`)
+  }, 120_000)
 
-  it('should emit the same declarations either way', async () => {
-    const perEntry = await build({}, ['--no-merge-entries'])
-    const merged = await build()
+  it('should emit a declaration file per entry', async () => {
+    const { contents } = await build()
 
-    expect(declarations(merged.contents)).toEqual(
-      declarations(perEntry.contents),
-    )
-  }, 180_000)
+    // The types are sharded across workers, so this is what catches a shard
+    // dropping the entries it was handed.
+    for (const entry of ENTRIES) {
+      expect(contents[`${entry}.d.ts`]).toContain(`declare const ${entry}`)
+    }
+  }, 120_000)
 
-  describe('--no-merge-entries', () => {
-    it('should build every entry in its own rollup instance', async () => {
-      const { stdout, files, contents } = await build({ DEBUG: '1' }, [
-        '--no-merge-entries',
-      ])
+  it('should produce the same output as an in-process build', async () => {
+    const workers = await build({ DEBUG: '1' })
+    const inProcess = await build({ DEBUG: '1', TEST_NO_WORKERS: '1' })
 
-      expect(stdout).toMatch(/Building 9 entries in \d+ worker threads/)
-      expect(stdout).not.toContain('shared rollup instances')
-      // No cross-entry chunk: each entry carries its own copy of `shared`.
-      expect(files.some((file) => file.startsWith('shared-'))).toBe(false)
-      expect(contents['index.js']).toContain(`from './a.js'`)
-    }, 120_000)
+    // Guard the comparison: it only means anything if the first build really
+    // did fan out. Runs from source and from dist resolve the worker file
+    // differently, so this has to hold for both.
+    expect(workers.stdout).toMatch(/Building 9 entries in \d+ worker threads/)
+    expect(inProcess.stdout).not.toContain('worker threads')
 
-    it('should produce the same output as an in-process build', async () => {
-      const workers = await build({ DEBUG: '1' }, ['--no-merge-entries'])
-      const inProcess = await build({ DEBUG: '1', TEST_NO_WORKERS: '1' }, [
-        '--no-merge-entries',
-      ])
-
-      // Guard the comparison: it only means anything if the first build really
-      // did fan out. Runs from source and from dist resolve the worker file
-      // differently, so this has to hold for both.
-      expect(workers.stdout).toMatch(/Building 9 entries in \d+ worker threads/)
-      expect(inProcess.stdout).not.toContain('worker threads')
-
-      expect(inProcess.files).toEqual(workers.files)
-      expect(inProcess.contents).toEqual(workers.contents)
-    }, 240_000)
-  })
+    // Types sharded across workers against one merged graph in this process.
+    expect(inProcess.files).toEqual(workers.files)
+    expect(inProcess.contents).toEqual(workers.contents)
+  }, 240_000)
 })

--- a/test/integration/merge-entries-boundary/index.test.ts
+++ b/test/integration/merge-entries-boundary/index.test.ts
@@ -44,7 +44,7 @@ describe('integration - merge-entries-boundary', () => {
   }, 120_000)
 
   it('should not merge a package with boundary directives', async () => {
-    const merged = await build({ DEBUG: '1' }, ['--merge-entries'])
+    const merged = await build({ DEBUG: '1' })
 
     expect(merged.stdout).toContain(
       `Not merging entries into shared rollup instances: package uses 'use client' / 'use server' boundaries`,
@@ -54,9 +54,9 @@ describe('integration - merge-entries-boundary', () => {
     )
   }, 120_000)
 
-  it('should produce the same output with and without --merge-entries', async () => {
-    const perEntry = await build()
-    const merged = await build({}, ['--merge-entries'])
+  it('should produce the same output with and without --no-merge-entries', async () => {
+    const perEntry = await build({}, ['--no-merge-entries'])
+    const merged = await build()
 
     expect(merged.files).toEqual(perEntry.files)
     expect(merged.contents).toEqual(perEntry.contents)

--- a/test/integration/merge-entries-boundary/index.test.ts
+++ b/test/integration/merge-entries-boundary/index.test.ts
@@ -11,13 +11,13 @@ import { executeBunchee } from '../../testing-utils/shared'
 // entry (`.`) and a client-layer one (`./ui`). A per-entry build decides where
 // it lands once per entry, so it is inlined into `ui.js` and split into its own
 // boundary chunk for `index.js`. One shared graph only gets to decide once, so
-// `--merge-entries` has to fall back here rather than flatten the boundary.
+// bunchee has to fall back for this package rather than flatten the boundary.
 const dir = __dirname
 const distDir = path.join(dir, 'dist')
 
-async function build(env: NodeJS.ProcessEnv = {}, args: string[] = []) {
+async function build(env: NodeJS.ProcessEnv = {}) {
   await removeDirectory(distDir)
-  const result = await executeBunchee(['--cwd', dir, ...args], { env })
+  const result = await executeBunchee(['--cwd', dir], { env })
   expect(result.stderr).toBe('')
   expect(result.code).toBe(0)
   return {
@@ -53,12 +53,4 @@ describe('integration - merge-entries-boundary', () => {
       /Building \d+ entries in \d+ shared rollup instances/,
     )
   }, 120_000)
-
-  it('should produce the same output with and without --no-merge-entries', async () => {
-    const perEntry = await build({}, ['--no-merge-entries'])
-    const merged = await build()
-
-    expect(merged.files).toEqual(perEntry.files)
-    expect(merged.contents).toEqual(perEntry.contents)
-  }, 180_000)
 })

--- a/test/integration/merge-entries-boundary/index.test.ts
+++ b/test/integration/merge-entries-boundary/index.test.ts
@@ -1,0 +1,64 @@
+import path from 'path'
+import { afterAll, describe, expect, it } from 'vitest'
+import {
+  getFileContents,
+  getFileNamesFromDirectory,
+  removeDirectory,
+} from '../../testing-utils'
+import { executeBunchee } from '../../testing-utils/shared'
+
+// `widget.ts` carries `'use client'` and is reached from both a server-layer
+// entry (`.`) and a client-layer one (`./ui`). A per-entry build decides where
+// it lands once per entry, so it is inlined into `ui.js` and split into its own
+// boundary chunk for `index.js`. One shared graph only gets to decide once, so
+// `--merge-entries` has to fall back here rather than flatten the boundary.
+const dir = __dirname
+const distDir = path.join(dir, 'dist')
+
+async function build(env: NodeJS.ProcessEnv = {}, args: string[] = []) {
+  await removeDirectory(distDir)
+  const result = await executeBunchee(['--cwd', dir, ...args], { env })
+  expect(result.stderr).toBe('')
+  expect(result.code).toBe(0)
+  return {
+    stdout: result.stdout,
+    files: await getFileNamesFromDirectory(distDir),
+    contents: await getFileContents(distDir),
+  }
+}
+
+describe('integration - merge-entries-boundary', () => {
+  afterAll(async () => {
+    if (!process.env.TEST_NOT_CLEANUP) {
+      await removeDirectory(distDir)
+    }
+  })
+
+  it('should keep the client module in its own boundary chunk', async () => {
+    const { files, contents } = await build()
+
+    const chunk = files.find((file) => file.startsWith('widget-'))
+    expect(chunk).toBeDefined()
+    expect(contents[chunk!]).toContain(`'use client'`)
+    expect(contents['index.js']).toContain(`from './${chunk}'`)
+  }, 120_000)
+
+  it('should not merge a package with boundary directives', async () => {
+    const merged = await build({ DEBUG: '1' }, ['--merge-entries'])
+
+    expect(merged.stdout).toContain(
+      `Not merging entries into shared rollup instances: package uses 'use client' / 'use server' boundaries`,
+    )
+    expect(merged.stdout).not.toMatch(
+      /Building \d+ entries in \d+ shared rollup instances/,
+    )
+  }, 120_000)
+
+  it('should produce the same output with and without --merge-entries', async () => {
+    const perEntry = await build()
+    const merged = await build({}, ['--merge-entries'])
+
+    expect(merged.files).toEqual(perEntry.files)
+    expect(merged.contents).toEqual(perEntry.contents)
+  }, 180_000)
+})

--- a/test/integration/merge-entries-boundary/index.test.ts
+++ b/test/integration/merge-entries-boundary/index.test.ts
@@ -8,10 +8,10 @@ import {
 import { executeBunchee } from '../../testing-utils/shared'
 
 // `widget.ts` carries `'use client'` and is reached from both a server-layer
-// entry (`.`) and a client-layer one (`./ui`). A per-entry build decides where
-// it lands once per entry, so it is inlined into `ui.js` and split into its own
-// boundary chunk for `index.js`. One shared graph only gets to decide once, so
-// bunchee has to fall back for this package rather than flatten the boundary.
+// entry (`.`) and a client-layer one (`./ui`). One graph holding both entries
+// only gets to place that module once, so it has to land in its own chunk for
+// the boundary to survive — inlining it into `ui` would leave the server entry
+// importing client code directly.
 const dir = __dirname
 const distDir = path.join(dir, 'dist')
 
@@ -39,18 +39,27 @@ describe('integration - merge-entries-boundary', () => {
 
     const chunk = files.find((file) => file.startsWith('widget-'))
     expect(chunk).toBeDefined()
-    expect(contents[chunk!]).toContain(`'use client'`)
+    // The chunk has to carry the directive, or the boundary is lost.
+    expect(contents[chunk!]).toMatch(/^'use client'/)
+    // Neither entry inlines it; both reach it through the chunk.
     expect(contents['index.js']).toContain(`from './${chunk}'`)
+    expect(contents['ui.js']).toContain(`from './${chunk}'`)
+    expect(contents['index.js']).not.toContain('function Widget')
+    expect(contents['ui.js']).not.toContain('function Widget')
   }, 120_000)
 
-  it('should not merge a package with boundary directives', async () => {
-    const merged = await build({ DEBUG: '1' })
+  it('should not put a directive on the server-layer entry', async () => {
+    const { contents } = await build()
 
-    expect(merged.stdout).toContain(
-      `Not merging entries into shared rollup instances: package uses 'use client' / 'use server' boundaries`,
-    )
-    expect(merged.stdout).not.toMatch(
-      /Building \d+ entries in \d+ shared rollup instances/,
-    )
+    // `index.ts` has no directive of its own and must not pick one up from the
+    // client module it re-exports.
+    expect(contents['index.js']).not.toContain(`'use client'`)
+    expect(contents['ui.js']).toMatch(/^'use client'/)
+  }, 120_000)
+
+  it('should build both entries as one graph', async () => {
+    const { stdout } = await build({ DEBUG: '1' })
+
+    expect(stdout).toMatch(/Building 2 entries in \d+ shared rollup instances/)
   }, 120_000)
 })

--- a/test/integration/merge-entries-boundary/package.json
+++ b/test/integration/merge-entries-boundary/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "merge-entries-boundary",
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./ui": {
+      "types": "./dist/ui.d.ts",
+      "import": "./dist/ui.js"
+    }
+  }
+}

--- a/test/integration/merge-entries-boundary/src/index.ts
+++ b/test/integration/merge-entries-boundary/src/index.ts
@@ -1,0 +1,2 @@
+export { Widget } from './widget'
+export const server = 'server'

--- a/test/integration/merge-entries-boundary/src/ui.ts
+++ b/test/integration/merge-entries-boundary/src/ui.ts
@@ -1,0 +1,3 @@
+'use client'
+
+export { Widget } from './widget'

--- a/test/integration/merge-entries-boundary/src/widget.ts
+++ b/test/integration/merge-entries-boundary/src/widget.ts
@@ -1,0 +1,5 @@
+'use client'
+
+export function Widget() {
+  return 'widget'
+}

--- a/test/integration/merge-entries-groups/index.test.ts
+++ b/test/integration/merge-entries-groups/index.test.ts
@@ -1,0 +1,69 @@
+import path from 'path'
+import { afterAll, describe, expect, it } from 'vitest'
+import {
+  getFileContents,
+  getFileNamesFromDirectory,
+  removeDirectory,
+} from '../../testing-utils'
+import { executeBunchee } from '../../testing-utils/shared'
+
+// A bin entry and an `edge-light` condition alongside plain ones. Neither rules
+// merging out: the bin is just another input whose own module gets the shebang,
+// and the condition puts its entry in a separate group because it resolves
+// sibling imports differently.
+const dir = __dirname
+const distDir = path.join(dir, 'dist')
+
+async function build(env: NodeJS.ProcessEnv = {}) {
+  await removeDirectory(distDir)
+  const result = await executeBunchee(['--cwd', dir], { env })
+  expect(result.stderr).toBe('')
+  expect(result.code).toBe(0)
+  return {
+    stdout: result.stdout,
+    files: await getFileNamesFromDirectory(distDir),
+    contents: await getFileContents(distDir),
+  }
+}
+
+describe('integration - merge-entries-groups', () => {
+  afterAll(async () => {
+    if (!process.env.TEST_NOT_CLEANUP) {
+      await removeDirectory(distDir)
+    }
+  })
+
+  it('should merge rather than fall back to one instance per entry', async () => {
+    const { stdout } = await build({ DEBUG: '1' })
+
+    expect(stdout).not.toContain('Not merging entries')
+    expect(stdout).toMatch(/shared rollup instances/)
+  }, 120_000)
+
+  it('should group the edge-light entry apart from the default ones', async () => {
+    const { stdout } = await build({ DEBUG: '1' })
+
+    // The condition is part of the group key, so its entry cannot end up in a
+    // graph that resolves siblings as the default condition does.
+    expect(stdout).toMatch(/Merged group ".*\|default": \d+ entries/)
+    expect(stdout).toMatch(/Merged group ".*\|edge-light": \d+ entries/)
+  }, 120_000)
+
+  it('should give only the bin output a shebang', async () => {
+    const { contents } = await build()
+
+    expect(contents['bin/index.js']).toMatch(/^#!\/usr\/bin\/env node/)
+    expect(contents['index.js']).not.toContain('#!/usr/bin/env node')
+    expect(contents['edge.js']).not.toContain('#!/usr/bin/env node')
+  }, 120_000)
+
+  it('should still build every declared output', async () => {
+    const { files } = await build()
+
+    expect(files).toContain('index.js')
+    expect(files).toContain('edge.js')
+    expect(files).toContain('edge.edge-light.js')
+    expect(files).toContain('bin/index.js')
+    expect(files).toContain('index.d.ts')
+  }, 120_000)
+})

--- a/test/integration/merge-entries-groups/package.json
+++ b/test/integration/merge-entries-groups/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "merge-entries-groups",
+  "version": "0.0.0",
+  "type": "module",
+  "bin": "./dist/bin/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./edge": {
+      "edge-light": "./dist/edge.edge-light.js",
+      "import": "./dist/edge.js"
+    }
+  }
+}

--- a/test/integration/merge-entries-groups/src/bin/index.ts
+++ b/test/integration/merge-entries-groups/src/bin/index.ts
@@ -1,0 +1,3 @@
+import { shared } from '../shared'
+
+console.log('cli:' + shared)

--- a/test/integration/merge-entries-groups/src/edge.ts
+++ b/test/integration/merge-entries-groups/src/edge.ts
@@ -1,0 +1,3 @@
+import { shared } from './shared'
+
+export const edge = 'edge:' + shared

--- a/test/integration/merge-entries-groups/src/index.ts
+++ b/test/integration/merge-entries-groups/src/index.ts
@@ -1,0 +1,3 @@
+import { shared } from './shared'
+
+export const index = 'index:' + shared

--- a/test/integration/merge-entries-groups/src/shared.ts
+++ b/test/integration/merge-entries-groups/src/shared.ts
@@ -1,0 +1,1 @@
+export const shared = 'shared-value'

--- a/test/integration/merge-entries-shards/index.test.ts
+++ b/test/integration/merge-entries-shards/index.test.ts
@@ -49,5 +49,12 @@ describe('integration - merge-entries-shards', () => {
 
     expect(oneShard).toEqual(perEntry)
     expect(manyShards).toEqual(perEntry)
+
+    // A specifier is posix on every platform. Comparing the three runs to each
+    // other would not catch a Windows path leaking in, since all three would
+    // carry it.
+    for (const content of Object.values(manyShards)) {
+      expect(content).not.toMatch(/from '[^']*\\/)
+    }
   }, 240_000)
 })

--- a/test/integration/merge-entries-shards/index.test.ts
+++ b/test/integration/merge-entries-shards/index.test.ts
@@ -10,9 +10,9 @@ import { executeBunchee } from '../../testing-utils/shared'
 const dir = __dirname
 const distDir = path.join(dir, 'dist')
 
-async function build(env: NodeJS.ProcessEnv = {}, args: string[] = []) {
+async function build(env: NodeJS.ProcessEnv = {}) {
   await removeDirectory(distDir)
-  const result = await executeBunchee(['--cwd', dir, ...args], { env })
+  const result = await executeBunchee(['--cwd', dir], { env })
   expect(result.stderr).toBe('')
   expect(result.code).toBe(0)
   return await getFileContents(distDir)
@@ -41,14 +41,14 @@ describe('integration - merge-entries-shards', () => {
   }, 120_000)
 
   it('should emit the same declarations however the types are sharded', async () => {
-    const perEntry = declarations(await build({}, ['--no-merge-entries']))
     const oneShard = declarations(await build({ BUNCHEE_DTS_SHARDS: '1' }))
     // More shards than entries, so every entry lands in a shard of its own and
     // every cross-entry reference has to cross a shard boundary.
     const manyShards = declarations(await build({ BUNCHEE_DTS_SHARDS: '8' }))
 
-    expect(oneShard).toEqual(perEntry)
-    expect(manyShards).toEqual(perEntry)
+    // One graph holding every entry, against every entry in a shard of its own
+    // so each cross-entry reference crosses a boundary.
+    expect(manyShards).toEqual(oneShard)
 
     // A specifier is posix on every platform. Comparing the three runs to each
     // other would not catch a Windows path leaking in, since all three would

--- a/test/integration/merge-entries-shards/index.test.ts
+++ b/test/integration/merge-entries-shards/index.test.ts
@@ -1,0 +1,57 @@
+import path from 'path'
+import { afterAll, describe, expect, it } from 'vitest'
+import { getFileContents, removeDirectory } from '../../testing-utils'
+import { executeBunchee } from '../../testing-utils/shared'
+
+// Four entries at different depths whose declarations reference each other. When
+// the types are split across shards, a sibling in another shard is external and
+// its specifier has to be relative to the importing chunk — `../mid/index.js`
+// from `top/`, but `../../mid/index.js` from `nest/deep/`.
+const dir = __dirname
+const distDir = path.join(dir, 'dist')
+
+async function build(env: NodeJS.ProcessEnv = {}, args: string[] = []) {
+  await removeDirectory(distDir)
+  const result = await executeBunchee(['--cwd', dir, ...args], { env })
+  expect(result.stderr).toBe('')
+  expect(result.code).toBe(0)
+  return await getFileContents(distDir)
+}
+
+function declarations(contents: Record<string, string>) {
+  return Object.fromEntries(
+    Object.entries(contents).filter(([file]) => file.endsWith('.d.ts')),
+  )
+}
+
+describe('integration - merge-entries-shards', () => {
+  afterAll(async () => {
+    if (!process.env.TEST_NOT_CLEANUP) {
+      await removeDirectory(distDir)
+    }
+  })
+
+  it('should resolve cross-entry type references relative to each entry', async () => {
+    const contents = await build()
+
+    expect(contents['top/index.d.ts']).toContain(`from '../mid/index.js'`)
+    expect(contents['nest/deep/index.d.ts']).toContain(
+      `from '../../mid/index.js'`,
+    )
+  }, 120_000)
+
+  it('should emit the same declarations however the types are sharded', async () => {
+    const perEntry = declarations(await build())
+    const oneShard = declarations(
+      await build({ BUNCHEE_DTS_SHARDS: '1' }, ['--merge-entries']),
+    )
+    // More shards than entries, so every entry lands in a shard of its own and
+    // every cross-entry reference has to cross a shard boundary.
+    const manyShards = declarations(
+      await build({ BUNCHEE_DTS_SHARDS: '8' }, ['--merge-entries']),
+    )
+
+    expect(oneShard).toEqual(perEntry)
+    expect(manyShards).toEqual(perEntry)
+  }, 240_000)
+})

--- a/test/integration/merge-entries-shards/index.test.ts
+++ b/test/integration/merge-entries-shards/index.test.ts
@@ -41,15 +41,11 @@ describe('integration - merge-entries-shards', () => {
   }, 120_000)
 
   it('should emit the same declarations however the types are sharded', async () => {
-    const perEntry = declarations(await build())
-    const oneShard = declarations(
-      await build({ BUNCHEE_DTS_SHARDS: '1' }, ['--merge-entries']),
-    )
+    const perEntry = declarations(await build({}, ['--no-merge-entries']))
+    const oneShard = declarations(await build({ BUNCHEE_DTS_SHARDS: '1' }))
     // More shards than entries, so every entry lands in a shard of its own and
     // every cross-entry reference has to cross a shard boundary.
-    const manyShards = declarations(
-      await build({ BUNCHEE_DTS_SHARDS: '8' }, ['--merge-entries']),
-    )
+    const manyShards = declarations(await build({ BUNCHEE_DTS_SHARDS: '8' }))
 
     expect(oneShard).toEqual(perEntry)
     expect(manyShards).toEqual(perEntry)

--- a/test/integration/merge-entries-shards/package.json
+++ b/test/integration/merge-entries-shards/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "merge-entries-shards",
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    "./base": {
+      "types": "./dist/base/index.d.ts",
+      "import": "./dist/base/index.js"
+    },
+    "./mid": {
+      "types": "./dist/mid/index.d.ts",
+      "import": "./dist/mid/index.js"
+    },
+    "./nest/deep": {
+      "types": "./dist/nest/deep/index.d.ts",
+      "import": "./dist/nest/deep/index.js"
+    },
+    "./top": {
+      "types": "./dist/top/index.d.ts",
+      "import": "./dist/top/index.js"
+    }
+  }
+}

--- a/test/integration/merge-entries-shards/src/base/index.ts
+++ b/test/integration/merge-entries-shards/src/base/index.ts
@@ -1,0 +1,3 @@
+export type BaseShape = { id: string; tag: 'base' }
+
+export const makeBase = (): BaseShape => ({ id: 'b', tag: 'base' })

--- a/test/integration/merge-entries-shards/src/mid/index.ts
+++ b/test/integration/merge-entries-shards/src/mid/index.ts
@@ -1,0 +1,5 @@
+import type { BaseShape } from '../base'
+
+export type MidShape = { base: BaseShape; level: number }
+
+export const makeMid = (base: BaseShape): MidShape => ({ base, level: 1 })

--- a/test/integration/merge-entries-shards/src/nest/deep/index.ts
+++ b/test/integration/merge-entries-shards/src/nest/deep/index.ts
@@ -1,0 +1,5 @@
+import type { MidShape } from '../../mid'
+
+export type DeepShape = { mid: MidShape; deep: true }
+
+export { type BaseShape } from '../../base'

--- a/test/integration/merge-entries-shards/src/top/index.ts
+++ b/test/integration/merge-entries-shards/src/top/index.ts
@@ -1,0 +1,5 @@
+import type { DeepShape } from '../nest/deep'
+
+export type TopShape = { deep: DeepShape }
+
+export { makeMid } from '../mid'

--- a/test/integration/multi-exports-ts/index.test.ts
+++ b/test/integration/multi-exports-ts/index.test.ts
@@ -18,10 +18,10 @@ describe('integration multi-exports', () => {
       export { fooIndex, index };
       export type { FooIndex };
       ",
-        "cjs/index.js": "var index_js = require('../../foo/cjs/index.js');
+        "cjs/index.js": "var foo = require('../../foo/cjs/index.js');
 
       const index = 'index';
-      const fooIndex = index_js.foo;
+      const fooIndex = foo.foo;
 
       exports.fooIndex = fooIndex;
       exports.index = index;
@@ -60,10 +60,10 @@ describe('integration multi-exports', () => {
       export { fooIndex, index };
       export type { FooIndex };
       ",
-        "index.js": "var index_js = require('../../foo/cjs/index.js');
+        "index.js": "var foo = require('../../foo/cjs/index.js');
 
       const index = 'index';
-      const fooIndex = index_js.foo;
+      const fooIndex = foo.foo;
 
       exports.fooIndex = fooIndex;
       exports.index = index;

--- a/test/integration/server-components/index.test.ts
+++ b/test/integration/server-components/index.test.ts
@@ -14,6 +14,11 @@ describe('integration server-components', () => {
       'index.js',
       'mod_actions-12x-B4EBPs-d.js',
       'mod_actions-12x-DtrEcTfm.cjs',
+      // `mod_asset` carries 'use client' and is reached from `ui` only, but one
+      // graph places it once, so it gets a boundary chunk rather than being
+      // inlined into that entry.
+      'mod_asset-12s--5vqDwxI.cjs',
+      'mod_asset-12s-Bq1vQakb.js',
       'mod_client-12s-BO96FYFA.js',
       'mod_client-12s-DAeHkA4H.cjs',
       'ui.cjs',

--- a/test/integration/split-common-chunks/split-common-chunks.test.ts
+++ b/test/integration/split-common-chunks/split-common-chunks.test.ts
@@ -16,11 +16,8 @@ describe('integration - split-common-chunks', () => {
       [
         "bar.cjs",
         "bar.js",
-        "cc-BU0zEyYq.js",
-        "cc-CJkp5Pfh.js",
-        "cc-CL7GPi9B.js",
-        "cc-CTtQaxE0.cjs",
-        "cc-CjnJhNSE.cjs",
+        "cc-B-HjsW7A.js",
+        "cc-DPkwN2Gw.cjs",
         "foo.js",
         "index.cjs",
         "index.js",
@@ -28,7 +25,7 @@ describe('integration - split-common-chunks', () => {
     `)
     expect(fileContents).toMatchInlineSnapshot(`
       {
-        "bar.cjs": "var cc = require('./cc-CTtQaxE0.cjs');
+        "bar.cjs": "var cc = require('./cc-DPkwN2Gw.cjs');
 
       class Bar {
           method() {
@@ -58,7 +55,7 @@ describe('integration - split-common-chunks', () => {
 
       exports.Bar = Bar;
       ",
-        "bar.js": "import { _ as __addDisposableResource, a as __disposeResources } from './cc-CL7GPi9B.js';
+        "bar.js": "import { _ as __addDisposableResource, a as __disposeResources } from './cc-B-HjsW7A.js';
 
       class Bar {
           method() {
@@ -88,36 +85,71 @@ describe('integration - split-common-chunks', () => {
 
       export { Bar };
       ",
-        "cc-BU0zEyYq.js": "function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) {
-          try {
-              var info = gen[key](arg);
-              var value = info.value;
-          } catch (error) {
-              reject(error);
-              return;
-          }
-          if (info.done) resolve(value);
-          else Promise.resolve(value).then(_next, _throw);
-      }
-      function _async_to_generator(fn) {
-          return function() {
-              var self = this, args = arguments;
-              return new Promise(function(resolve, reject) {
-                  var gen = fn.apply(self, args);
-                  function _next(value) {
-                      asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value);
+        "cc-B-HjsW7A.js": "function __addDisposableResource(env, value, async) {
+          if (value !== null && value !== void 0) {
+              if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
+              var dispose, inner;
+              if (async) {
+                  if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+                  dispose = value[Symbol.asyncDispose];
+              }
+              if (dispose === void 0) {
+                  if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+                  dispose = value[Symbol.dispose];
+                  if (async) inner = dispose;
+              }
+              if (typeof dispose !== "function") throw new TypeError("Object not disposable.");
+              if (inner) dispose = function() {
+                  try {
+                      inner.call(this);
+                  } catch (e) {
+                      return Promise.reject(e);
                   }
-                  function _throw(err) {
-                      asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err);
-                  }
-                  _next(undefined);
+              };
+              env.stack.push({
+                  value: value,
+                  dispose: dispose,
+                  async: async
               });
-          };
+          } else if (async) {
+              env.stack.push({
+                  async: true
+              });
+          }
+          return value;
+      }
+      var _SuppressedError = typeof SuppressedError === "function" ? SuppressedError : function(error, suppressed, message) {
+          var e = new Error(message);
+          return e.name = "SuppressedError", e.error = error, e.suppressed = suppressed, e;
+      };
+      function __disposeResources(env) {
+          function fail(e) {
+              env.error = env.hasError ? new _SuppressedError(e, env.error, "An error was suppressed during disposal.") : e;
+              env.hasError = true;
+          }
+          var r, s = 0;
+          function next() {
+              while(r = env.stack.pop()){
+                  try {
+                      if (!r.async && s === 1) return s = 0, env.stack.push(r), Promise.resolve().then(next);
+                      if (r.dispose) {
+                          var result = r.dispose.call(r.value);
+                          if (r.async) return s |= 2, Promise.resolve(result).then(next, function(e) {
+                              fail(e);
+                              return next();
+                          });
+                      } else s |= 1;
+                  } catch (e) {
+                      fail(e);
+                  }
+              }
+              if (s === 1) return env.hasError ? Promise.reject(env.error) : Promise.resolve();
+              if (env.hasError) throw env.error;
+          }
+          return next();
       }
 
-      export { _async_to_generator as _ };
-      ",
-        "cc-CJkp5Pfh.js": "function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) {
+      function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) {
           try {
               var info = gen[key](arg);
               var value = info.value;
@@ -155,9 +187,9 @@ describe('integration - split-common-chunks', () => {
           return _extends.apply(this, arguments);
       }
 
-      export { _async_to_generator as _, _extends as a };
+      export { __addDisposableResource as _, __disposeResources as a, _async_to_generator as b, _extends as c };
       ",
-        "cc-CL7GPi9B.js": "function __addDisposableResource(env, value, async) {
+        "cc-DPkwN2Gw.cjs": "function __addDisposableResource(env, value, async) {
           if (value !== null && value !== void 0) {
               if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
               var dispose, inner;
@@ -221,117 +253,50 @@ describe('integration - split-common-chunks', () => {
           return next();
       }
 
-      export { __addDisposableResource as _, __disposeResources as a };
-      ",
-        "cc-CTtQaxE0.cjs": "function __addDisposableResource(env, value, async) {
-          if (value !== null && value !== void 0) {
-              if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-              var dispose, inner;
-              if (async) {
-                  if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
-                  dispose = value[Symbol.asyncDispose];
-              }
-              if (dispose === void 0) {
-                  if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
-                  dispose = value[Symbol.dispose];
-                  if (async) inner = dispose;
-              }
-              if (typeof dispose !== "function") throw new TypeError("Object not disposable.");
-              if (inner) dispose = function() {
-                  try {
-                      inner.call(this);
-                  } catch (e) {
-                      return Promise.reject(e);
-                  }
-              };
-              env.stack.push({
-                  value: value,
-                  dispose: dispose,
-                  async: async
-              });
-          } else if (async) {
-              env.stack.push({
-                  async: true
-              });
+      function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) {
+          try {
+              var info = gen[key](arg);
+              var value = info.value;
+          } catch (error) {
+              reject(error);
+              return;
           }
-          return value;
+          if (info.done) resolve(value);
+          else Promise.resolve(value).then(_next, _throw);
       }
-      var _SuppressedError = typeof SuppressedError === "function" ? SuppressedError : function(error, suppressed, message) {
-          var e = new Error(message);
-          return e.name = "SuppressedError", e.error = error, e.suppressed = suppressed, e;
-      };
-      function __disposeResources(env) {
-          function fail(e) {
-              env.error = env.hasError ? new _SuppressedError(e, env.error, "An error was suppressed during disposal.") : e;
-              env.hasError = true;
-          }
-          var r, s = 0;
-          function next() {
-              while(r = env.stack.pop()){
-                  try {
-                      if (!r.async && s === 1) return s = 0, env.stack.push(r), Promise.resolve().then(next);
-                      if (r.dispose) {
-                          var result = r.dispose.call(r.value);
-                          if (r.async) return s |= 2, Promise.resolve(result).then(next, function(e) {
-                              fail(e);
-                              return next();
-                          });
-                      } else s |= 1;
-                  } catch (e) {
-                      fail(e);
+      function _async_to_generator(fn) {
+          return function() {
+              var self = this, args = arguments;
+              return new Promise(function(resolve, reject) {
+                  var gen = fn.apply(self, args);
+                  function _next(value) {
+                      asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value);
                   }
+                  function _throw(err) {
+                      asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err);
+                  }
+                  _next(undefined);
+              });
+          };
+      }
+
+      function _extends() {
+          _extends = Object.assign || function assign(target) {
+              for(var i = 1; i < arguments.length; i++){
+                  var source = arguments[i];
+                  for(var key in source)if (Object.prototype.hasOwnProperty.call(source, key)) target[key] = source[key];
               }
-              if (s === 1) return env.hasError ? Promise.reject(env.error) : Promise.resolve();
-              if (env.hasError) throw env.error;
-          }
-          return next();
+              return target;
+          };
+          return _extends.apply(this, arguments);
       }
 
       exports.__addDisposableResource = __addDisposableResource;
       exports.__disposeResources = __disposeResources;
-      ",
-        "cc-CjnJhNSE.cjs": "function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) {
-          try {
-              var info = gen[key](arg);
-              var value = info.value;
-          } catch (error) {
-              reject(error);
-              return;
-          }
-          if (info.done) resolve(value);
-          else Promise.resolve(value).then(_next, _throw);
-      }
-      function _async_to_generator(fn) {
-          return function() {
-              var self = this, args = arguments;
-              return new Promise(function(resolve, reject) {
-                  var gen = fn.apply(self, args);
-                  function _next(value) {
-                      asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value);
-                  }
-                  function _throw(err) {
-                      asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err);
-                  }
-                  _next(undefined);
-              });
-          };
-      }
-
-      function _extends() {
-          _extends = Object.assign || function assign(target) {
-              for(var i = 1; i < arguments.length; i++){
-                  var source = arguments[i];
-                  for(var key in source)if (Object.prototype.hasOwnProperty.call(source, key)) target[key] = source[key];
-              }
-              return target;
-          };
-          return _extends.apply(this, arguments);
-      }
-
       exports._async_to_generator = _async_to_generator;
       exports._extends = _extends;
       ",
-        "foo.js": "import { _ as _async_to_generator } from './cc-BU0zEyYq.js';
+        "foo.js": "import { b as _async_to_generator } from './cc-B-HjsW7A.js';
 
       class Foo {
           foo() {
@@ -343,7 +308,7 @@ describe('integration - split-common-chunks', () => {
 
       export { Foo };
       ",
-        "index.cjs": "var cc = require('./cc-CjnJhNSE.cjs');
+        "index.cjs": "var cc = require('./cc-DPkwN2Gw.cjs');
 
       class Index {
           method() {
@@ -362,7 +327,7 @@ describe('integration - split-common-chunks', () => {
 
       exports.Index = Index;
       ",
-        "index.js": "import { _ as _async_to_generator, a as _extends } from './cc-CJkp5Pfh.js';
+        "index.js": "import { b as _async_to_generator, c as _extends } from './cc-B-HjsW7A.js';
 
       class Index {
           method() {

--- a/test/testing-utils/helpers.ts
+++ b/test/testing-utils/helpers.ts
@@ -63,7 +63,9 @@ export async function getFileContents(dir: string, filePaths?: string[]) {
         continue
       }
       const content = await fsp.readFile(fullPath, { encoding: 'utf-8' })
-      results[file.replace(/\\/, '/')] = content
+      // Every separator, not just the first: on Windows `readdir` returns
+      // `nest\deep\index.d.ts` and callers key off posix paths.
+      results[file.replace(/\\/g, '/')] = content
     }
   }
   return results


### PR DESCRIPTION
Refs #732. Draft.

## Problem

bunchee builds each entry in isolation — one rollup instance per entry/output pair. A package with 50 exports in two formats plus types builds through 150 of them.

Nothing is shared between those builds, so:

- **Code shared between entries is copied into each one.** Every entry that imports a helper gets its own copy, and every entry gets its own `@swc/helpers` chunk.
- **Cross-entry imports are externalised by hand.** Each build marks the other entries' sources as external and a plugin rewrites the specifier to the sibling's output path.
- **Peak memory scales with entry count.** An in-process build of a 57-entry package dies with `FATAL ERROR: Reached heap limit` at 4GB, which is what the worker pool works around.

And it is nearly all overhead rather than work. Widening a single rollup build from 1 entry to 56 barely costs anything:

```
JS    1 entry → 16ms     56 entries → 59ms
```

## Change

**bunchee now builds a full module graph across entries.** Entries that can share one are grouped, and each group is a single rollup build with every entry as an input.

Because rollup sees the whole package at once:

- Shared code becomes a chunk instead of a copy per entry — for any module, not just `_`-prefixed ones, and only when it is genuinely shared. A module reached by one entry stays inlined in it.
- Cross-entry imports are emitted by rollup itself rather than externalised and rewritten. The alias plugin is only needed where a reference leaves the graph.
- Peak memory no longer scales with entry count.

Each entry still lands on the exact path its export condition declares: `entryFileNames` is a function, and `output.dir` is the entries' common root.

Declaration emit is the one part that stays linear in entry count and cannot be collapsed by sharing a graph, so types are split into shards that each build a merged graph in their own worker.

## Result

Synthetic packages, dual format + types, output verified, best of three, 12-core machine:

| exports | before | after | wall | cpu |
|---|---|---|---|---|
| 4  | 1.035s · 1.9s  | **0.432s · 0.8s** | 2.40× | 2.37× |
| 8  | 1.065s · 8.5s  | **0.647s · 1.8s** | 1.65× | 4.72× |
| 16 | 1.675s · 13.2s | **0.862s · 3.8s** | 1.94× | 3.47× |
| 32 | 2.754s · 21.4s | **0.974s · 4.3s** | 2.83× | 4.98× |
| 64 | 4.489s · 34.9s | **1.039s · 4.6s** | 4.32× | 7.59× |

The gain grows with entry count because build time is now nearly flat in it — 0.43s at 4 entries against 1.04s at 64, where before it scaled linearly.

Those put each entry in its own directory, which is the layout bunchee's convention encourages. With every entry side by side in `src/` the win is smaller but still large: 1.33× / 3.64× at 8 entries, 3.74× / 5.80× at 64.

A real 57-entry package, both builds verified to produce the same 114 JS and 57 declaration files: **3.840s → 1.338s wall, 28.9s → 4.9s CPU.**

### The dts programs

Most of what remained turned out to be a `rollup-plugin-dts` detail. It rewrites its per-input directory key to the tsconfig's directory only when its config cache misses, and naming the tsconfig explicitly makes that cache hit for every input after the first — so the rest keep their own directory, and `createPrograms` starts a separate TypeScript program for each.

That is invisible when a build has a single input, which is why it never showed up before: it only bites once one build holds many entries. Letting the plugin discover the tsconfig keeps every lookup a miss and puts every input in one program, so bunchee omits the path when it is the one that would be found anyway. On a 57-entry package that alone is worth ~1.7s.

## What changes in the output

1. **Shared code becomes a chunk**, so `dist` gains chunk files. The `@swc/helpers` chunk is emitted once per format rather than once per entry, taking `split-common-chunks` from 10 files / 40kB to 7 / 28kB.
2. **Re-exports of a sibling entry** are emitted as `export { b } from './b.js'` rather than `export * from './b.js'`, because the sibling's exports are known. Live bindings are preserved — rollup keeps a getter where the binding is reassignable, verified at runtime.
3. **`'use client'` / `'use server'` modules always get their own chunk.** Building each entry separately can inline a directive module into a same-layer entry and split it out of a different-layer one; one graph places it once, so it goes in a chunk and the boundary is explicit for every entry that reaches it.
4. **CJS locals take the entry's name** — `var index_js$3` becomes `var abortError`.

## What still builds one entry at a time

Only a package with a single entry, a single `-o` output, or watch mode. Runtime and `development`/`production` conditions take part in the group key rather than ruling merging out, and `bin` entries merge too — `prependShebang` takes every bin source instead of the one entry being built. Across the fixture suite, 34 of 42 multi-export fixtures merge and the remaining 8 resolve to a single entry.

ESM and CJS stay separate graphs by design.

## Tests

`118 files / 209 tests` pass, Linux and Windows. Snapshots updated for the output changes above. New fixtures:

- `merge-entries-groups` — a bin entry and an `edge-light` condition together: asserts the package merges, that the condition lands in its own group, and that only the bin output gets a shebang.
- `merge-entries-shards` — four entries at different depths whose declarations reference each other, asserting the `.d.ts` output is identical whether types are built as one graph or in more shards than there are entries, and that no specifier carries a Windows separator.
- `merge-entries-boundary` — a `'use client'` module reached from both a server-layer and a client-layer entry, asserting it lands in a chunk carrying the directive and that neither entry inlines it.
- `many-entries` — group and shard layout, shared code landing in exactly one chunk all nine entries reference, a declaration file per entry.

## Notes

- Sharding types only helps in separate heaps. Several TypeScript programs in one isolate spend their time in GC — in-process, 64 entries went from 8.5s at one shard to 12.2s at four. Past four workers each extra program costs more than the parallelism it buys, so the heuristic caps there; `BUNCHEE_DTS_SHARDS` overrides it.
- Two entries can resolve to the same output file — one picking up a runtime condition and one named for it both land on the same path. Built separately they overwrite each other; as two inputs of one graph rollup kept both by numbering the second, so grouping tracks which output file a source claimed.
- References that leave the graph cannot use rollup's own relativisation of absolute external ids: it resolves against the chunk's relative file name, not the output directory. The alias plugin parks the target behind a marker and rewrites it in `renderChunk`, where the chunk's name is known.
- Merging bunchee's own bin with its main entry moved their shared code into a chunk, which broke the worker pool — it handed piscina the file it was running from, and a chunk exports nothing by name.

## Follow-up, worth its own issue

The private-module convention globs every `_`-prefixed source file into its own entry. A `_`-prefixed build-time script therefore becomes a published output, and any heavy dev-only dependency it imports gets bundled into it — a package can ship tens of megabytes for a file nothing consumes. That behaviour predates this PR and is unchanged by it.

It is worth revisiting now, because the convention existed so shared internals got one output instead of a copy per entry, and the full graph does that automatically for any module.
