### PR TITLE
test: restore each test fixture directory automatically

### DIFF
--- a/test/cli/basic/index.test.ts
+++ b/test/cli/basic/index.test.ts
@@ -1,13 +1,8 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import fs from 'fs'
 import { runCli } from '../../testing-utils'
 
 describe('cli', () => {
-  afterEach(() => {
-    // remove dist folder
-    fs.rmdirSync(__dirname + '/dist', { recursive: true })
-  })
-
   it(`cli basic should work properly`, async () => {
     const { code, distFile } = await runCli({
       directory: __dirname,
@@ -59,7 +54,7 @@ describe('cli', () => {
   it(`should enable sourcemap when enable minify by default`, async () => {
     const { code, distFile } = await runCli({
       directory: __dirname,
-      args: ['hello.js', '-m', '--sourcemap', '-o', 'dist/hello.js'],
+      args: ['hello.js', '-m', '--sourcemap', '-o', 'dist/hello.minify.js'],
     })
     expect(fs.existsSync(distFile)).toBe(true)
     expect(fs.existsSync(distFile + '.map')).toBe(true)
@@ -74,7 +69,9 @@ describe('cli', () => {
   it(`should be able to opt out sourcemap when minify`, async () => {
     const { code, distFile } = await runCli({
       directory: __dirname,
-      args: ['hello.js', '-m', '--no-sourcemap', '-o', 'dist/hello.js'],
+      // Its own output file: a `.map` left behind by another case in this dist
+      // directory would make this assertion pass or fail for the wrong reason.
+      args: ['hello.js', '-m', '--no-sourcemap', '-o', 'dist/hello.no-map.js'],
     })
     expect(fs.existsSync(distFile)).toBe(true)
     expect(fs.existsSync(distFile + '.map')).toBe(false)

--- a/test/cli/dts-bundle/index.test.ts
+++ b/test/cli/dts-bundle/index.test.ts
@@ -1,8 +1,8 @@
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { beforeAll, describe, expect, it } from 'vitest'
 import fs from 'fs'
 import fsp from 'fs/promises'
 import { join } from 'path'
-import { runCli, deleteFile } from '../../testing-utils'
+import { runCli } from '../../testing-utils'
 
 describe('cli', () => {
   const dir = __dirname
@@ -11,9 +11,6 @@ describe('cli', () => {
       join(dir, './package.json'),
       '{ "name": "prepare-ts-with-pkg-json", "devDependencies": { "@swc/types": "*" } }',
     )
-  })
-  afterAll(async () => {
-    await deleteFile(join(dir, './package.json'))
   })
 
   it(`cli dts-bundle option should work properly`, async () => {

--- a/test/compile.test.ts
+++ b/test/compile.test.ts
@@ -1,12 +1,16 @@
 import { expect, it } from 'vitest'
 import fs, { promises as fsp } from 'fs'
 import { resolve, dirname, extname } from 'path'
-import { existsFile, fullExtension } from './testing-utils'
+import { existsFile, fullExtension, trackFixtureDir } from './testing-utils'
 
 const assetPath = process.env.POST_BUILD ? '..' : '../src/index.ts'
 
 const baseUnitTestDir = resolve(__dirname, 'compile')
 const unitTestDirs = fs.readdirSync(baseUnitTestDir)
+
+// This file lives at the test root, so the fixtures it builds into have to be
+// declared for auto-cleanup instead of being inferred from its location.
+trackFixtureDir(baseUnitTestDir)
 
 type CompareFn = (
   a: string,

--- a/test/integration/many-entries-cli/index.test.ts
+++ b/test/integration/many-entries-cli/index.test.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { afterAll, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import {
   getFileNamesFromDirectory,
   removeDirectory,
@@ -31,12 +31,6 @@ async function build(env: NodeJS.ProcessEnv = {}) {
 }
 
 describe('integration - many-entries-cli', () => {
-  afterAll(async () => {
-    if (!process.env.TEST_NOT_CLEANUP) {
-      await removeDirectory(distDir)
-    }
-  })
-
   it('should build the entry file passed on the command line', async () => {
     const { files, stdout } = await build()
 

--- a/test/integration/many-entries/index.test.ts
+++ b/test/integration/many-entries/index.test.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { afterAll, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import {
   getFileContents,
   getFileNamesFromDirectory,
@@ -27,12 +27,6 @@ async function build(env: NodeJS.ProcessEnv = {}) {
 const ENTRIES = ['index', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']
 
 describe('integration - many-entries', () => {
-  afterAll(async () => {
-    if (!process.env.TEST_NOT_CLEANUP) {
-      await removeDirectory(distDir)
-    }
-  })
-
   it('should build every entry', async () => {
     const { files, contents } = await build()
 

--- a/test/integration/merge-entries-boundary/index.test.ts
+++ b/test/integration/merge-entries-boundary/index.test.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { afterAll, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import {
   getFileContents,
   getFileNamesFromDirectory,
@@ -28,12 +28,6 @@ async function build(env: NodeJS.ProcessEnv = {}) {
 }
 
 describe('integration - merge-entries-boundary', () => {
-  afterAll(async () => {
-    if (!process.env.TEST_NOT_CLEANUP) {
-      await removeDirectory(distDir)
-    }
-  })
-
   it('should keep the client module in its own boundary chunk', async () => {
     const { files, contents } = await build()
 

--- a/test/integration/merge-entries-groups/index.test.ts
+++ b/test/integration/merge-entries-groups/index.test.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { afterAll, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import {
   getFileContents,
   getFileNamesFromDirectory,
@@ -27,12 +27,6 @@ async function build(env: NodeJS.ProcessEnv = {}) {
 }
 
 describe('integration - merge-entries-groups', () => {
-  afterAll(async () => {
-    if (!process.env.TEST_NOT_CLEANUP) {
-      await removeDirectory(distDir)
-    }
-  })
-
   it('should merge rather than fall back to one instance per entry', async () => {
     const { stdout } = await build({ DEBUG: '1' })
 

--- a/test/integration/merge-entries-shards/index.test.ts
+++ b/test/integration/merge-entries-shards/index.test.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { afterAll, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { getFileContents, removeDirectory } from '../../testing-utils'
 import { executeBunchee } from '../../testing-utils/shared'
 
@@ -25,12 +25,6 @@ function declarations(contents: Record<string, string>) {
 }
 
 describe('integration - merge-entries-shards', () => {
-  afterAll(async () => {
-    if (!process.env.TEST_NOT_CLEANUP) {
-      await removeDirectory(distDir)
-    }
-  })
-
   it('should resolve cross-entry type references relative to each entry', async () => {
     const contents = await build()
 

--- a/test/integration/no-clean/index.test.ts
+++ b/test/integration/no-clean/index.test.ts
@@ -1,7 +1,6 @@
 import { beforeAll, describe, expect, it } from 'vitest'
 import fsp from 'fs/promises'
 import { join } from 'path'
-import { execSync } from 'child_process'
 import {
   assertContainFiles,
   assertFilesContent,
@@ -12,7 +11,7 @@ import { existsSync } from 'fs'
 describe('integration - no-clean flag', () => {
   const distDir = join(__dirname, 'dist')
   beforeAll(async () => {
-    execSync(`rm -rf ${distDir}`)
+    await fsp.rm(distDir, { recursive: true, force: true })
     await fsp.mkdir(distDir)
     await fsp.writeFile(join(distDir, 'no-clean.json'), '{}')
   })
@@ -37,7 +36,7 @@ describe('integration - no-clean default', () => {
   const distDir = join(__dirname, 'dist')
 
   beforeAll(async () => {
-    execSync(`rm -rf ${distDir}`)
+    await fsp.rm(distDir, { recursive: true, force: true })
     await fsp.mkdir(distDir)
     await fsp.writeFile(join(distDir, 'no-clean.json'), '{}')
   })

--- a/test/integration/prepare-no-src/index.test.ts
+++ b/test/integration/prepare-no-src/index.test.ts
@@ -1,26 +1,13 @@
-import { beforeAll, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import fsp from 'fs/promises'
 import { join } from 'path'
 import {
   assertContainFiles,
   createJob,
-  deleteFile,
   stripANSIColor,
 } from '../../testing-utils'
 
 describe('integration prepare-no-src', () => {
-  beforeAll(async () => {
-    await deleteFile(join(__dirname, './package.json'))
-    await deleteFile(join(__dirname, './tsconfig.json'))
-    // Remove src folder if it exists
-    const srcDir = join(__dirname, './src')
-    try {
-      await fsp.rm(srcDir, { recursive: true, force: true })
-    } catch {
-      // Ignore errors if src doesn't exist
-    }
-  })
-
   const { dir, job } = createJob({
     args: ['prepare'],
     directory: __dirname,

--- a/test/integration/prepare-ts-esm/index.test.ts
+++ b/test/integration/prepare-ts-esm/index.test.ts
@@ -4,7 +4,6 @@ import { join } from 'path'
 import {
   assertContainFiles,
   createJob,
-  deleteFile,
   stripANSIColor,
 } from '../../testing-utils'
 
@@ -14,7 +13,6 @@ describe('integration prepare-ts-esm', () => {
       join(__dirname, './package.json'),
       '{ "type": "commonjs" }',
     )
-    await deleteFile(join(__dirname, 'tsconfig.json'))
   })
 
   const { dir, job } = createJob({

--- a/test/integration/prepare-ts-with-pkg-json/index.test.ts
+++ b/test/integration/prepare-ts-with-pkg-json/index.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, describe, expect, it } from 'vitest'
 import fsp from 'fs/promises'
 import { join } from 'path'
-import { assertContainFiles, createJob, deleteFile } from '../../testing-utils'
+import { assertContainFiles, createJob } from '../../testing-utils'
 
 describe('integration prepare-ts-with-pkg-json', () => {
   const dir = __dirname
@@ -12,7 +12,6 @@ describe('integration prepare-ts-with-pkg-json', () => {
         join(dir, './package.json'),
         JSON.stringify({ name: 'prepare-ts-with-pkg-json' }, null, 2),
       )
-      await deleteFile(join(dir, './tsconfig.json'))
     })
     createJob({
       directory: __dirname,
@@ -47,7 +46,6 @@ describe('integration prepare-ts-with-pkg-json', () => {
           2,
         ),
       )
-      await deleteFile(join(dir, './tsconfig.json'))
     })
     createJob({
       directory: __dirname,

--- a/test/integration/prepare-ts-with-private-file/index.test.ts
+++ b/test/integration/prepare-ts-with-private-file/index.test.ts
@@ -1,14 +1,10 @@
-import { beforeAll, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import fsp from 'fs/promises'
 import { join } from 'path'
-import { assertContainFiles, createJob, deleteFile } from '../../testing-utils'
+import { assertContainFiles, createJob } from '../../testing-utils'
 
 describe('integration prepare-ts-with-private-file', () => {
   const dir = __dirname
-  beforeAll(async () => {
-    await deleteFile(join(dir, './package.json'))
-    await deleteFile(join(dir, './tsconfig.json'))
-  })
   createJob({
     args: ['prepare'],
     directory: __dirname,

--- a/test/integration/prepare-ts-with-test-file/index.test.ts
+++ b/test/integration/prepare-ts-with-test-file/index.test.ts
@@ -1,14 +1,10 @@
-import { beforeAll, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import fsp from 'fs/promises'
 import { join } from 'path'
-import { assertContainFiles, createJob, deleteFile } from '../../testing-utils'
+import { assertContainFiles, createJob } from '../../testing-utils'
 
 describe('integration prepare-ts-with-test-file', () => {
   const dir = __dirname
-  beforeAll(async () => {
-    await deleteFile(join(dir, './package.json'))
-    await deleteFile(join(dir, './tsconfig.json'))
-  })
   createJob({
     args: ['prepare'],
     directory: __dirname,

--- a/test/integration/prepare-ts/index.test.ts
+++ b/test/integration/prepare-ts/index.test.ts
@@ -1,19 +1,13 @@
-import { beforeAll, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import fsp from 'fs/promises'
 import { join } from 'path'
 import {
   assertContainFiles,
   createJob,
-  deleteFile,
   stripANSIColor,
 } from '../../testing-utils'
 
 describe('integration prepare-ts', () => {
-  beforeAll(async () => {
-    await deleteFile(join(__dirname, './package.json'))
-    await deleteFile(join(__dirname, './tsconfig.json'))
-  })
-
   const { dir, job } = createJob({
     args: ['prepare'],
     directory: __dirname,

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,24 @@
+import { afterAll, beforeAll, expect } from 'vitest'
+import {
+  type FixtureSnapshot,
+  restoreFixtures,
+  snapshotFixtures,
+} from './testing-utils/fixture-state'
+
+// Loaded through `setupFiles`, so this hook pair wraps every test file: the
+// fixture directory is captured before the first build runs and put back
+// afterwards. That is why no test suite removes its own `dist`, deletes the
+// tsconfig.json a build wrote next to its fixture, or reverts the package.json
+// `bunchee prepare` rewrote — anything a run creates or changes in there is
+// undone here.
+let snapshots: FixtureSnapshot[] = []
+
+beforeAll(async () => {
+  snapshots = await snapshotFixtures(expect.getState().testPath)
+})
+
+afterAll(async () => {
+  // Escape hatch for inspecting build output after a run.
+  if (process.env.TEST_NOT_CLEANUP) return
+  await restoreFixtures(snapshots)
+})

--- a/test/testing-utils/fixture-state.ts
+++ b/test/testing-utils/fixture-state.ts
@@ -1,0 +1,174 @@
+import { execFile } from 'child_process'
+import fsp from 'fs/promises'
+import path from 'path'
+import * as debug from './debug'
+
+const TEST_ROOT = path.resolve(__dirname, '..')
+const REPO_ROOT = path.resolve(TEST_ROOT, '..')
+
+// Never walked, never cleaned. `node_modules` under a fixture is a checked-in
+// dependency of that fixture, and `__snapshot__` holds output snapshots a test
+// writes on purpose with TEST_UPDATE_SNAPSHOT.
+const PRESERVED_DIRS = new Set([
+  '.git',
+  '__snapshot__',
+  '__snapshots__',
+  'node_modules',
+])
+
+// Inline snapshots live in the test file itself, so `vitest -u` writes into the
+// very directory being restored.
+const isTestFile = (name: string) => /\.test\.[cm]?[jt]sx?$/.test(name)
+
+const trackedDirs = new Set<string>()
+
+/**
+ * Auto-cleanup covers the directory the test file sits in. A test file that
+ * builds fixtures elsewhere — `test/compile.test.ts` drives every directory
+ * under `test/compile` — declares those at module scope with this.
+ */
+export function trackFixtureDir(dir: string) {
+  trackedDirs.add(path.resolve(dir))
+}
+
+export type FixtureSnapshot = {
+  dir: string
+  files: Map<string, Buffer>
+  dirs: Set<string>
+}
+
+type Tree = Pick<FixtureSnapshot, 'files' | 'dirs'>
+
+async function readTree(dir: string, rel = '', tree?: Tree): Promise<Tree> {
+  const result: Tree = tree ?? { files: new Map(), dirs: new Set() }
+  let entries
+  try {
+    entries = await fsp.readdir(path.join(dir, rel), { withFileTypes: true })
+  } catch (error: any) {
+    if (error.code === 'ENOENT') return result
+    throw error
+  }
+
+  for (const entry of entries) {
+    const relPath = rel ? path.join(rel, entry.name) : entry.name
+    if (entry.isDirectory()) {
+      if (PRESERVED_DIRS.has(entry.name)) continue
+      result.dirs.add(relPath)
+      await readTree(dir, relPath, result)
+    } else if (entry.isFile() && !isTestFile(entry.name)) {
+      result.files.set(relPath, await fsp.readFile(path.join(dir, relPath)))
+    }
+  }
+  return result
+}
+
+let ignoredPaths: Promise<string[]> | undefined
+
+/**
+ * Everything under `test/` that git treats as generated: `dist` directories,
+ * the tsconfig.json a build writes when a fixture has none, the package.json
+ * `bunchee prepare` creates. Untracked files that are *not* ignored are left
+ * alone — those are fixture files someone is still writing.
+ */
+function listIgnoredPaths() {
+  ignoredPaths ??= new Promise<string[]>((resolve) => {
+    execFile(
+      'git',
+      [
+        'ls-files',
+        '-z',
+        '--others',
+        '--ignored',
+        '--exclude-standard',
+        '--directory',
+        '--',
+        'test',
+      ],
+      { cwd: REPO_ROOT, maxBuffer: 64 * 1024 * 1024 },
+      (error, stdout) => {
+        if (error) {
+          debug.error(`Could not list generated test files: ${error}`)
+          resolve([])
+          return
+        }
+        resolve(
+          stdout
+            .split('\0')
+            .filter(Boolean)
+            .map((file) => path.resolve(REPO_ROOT, file)),
+        )
+      },
+    )
+  })
+  return ignoredPaths
+}
+
+/**
+ * Leftovers from a run that was interrupted before it could restore itself, so
+ * a local run starts from the same state as a fresh checkout.
+ */
+async function removeStaleArtifacts(dir: string) {
+  const ignored = await listIgnoredPaths()
+  for (const target of ignored) {
+    if (!target.startsWith(dir + path.sep)) continue
+    const segments = path.relative(dir, target).split(path.sep)
+    if (segments.some((segment) => PRESERVED_DIRS.has(segment))) continue
+    debug.log(`Remove stale ${target}`)
+    await fsp.rm(target, { recursive: true, force: true })
+  }
+}
+
+export async function snapshotFixtures(testPath: string | undefined) {
+  const dirs = new Set(trackedDirs)
+  // A test file directly under `test/` (`compile.test.ts`) would otherwise
+  // claim the whole test tree; it tracks its fixture root explicitly instead.
+  if (testPath) {
+    const dir = path.dirname(path.resolve(testPath))
+    if (dir !== TEST_ROOT) dirs.add(dir)
+  }
+
+  const snapshots: FixtureSnapshot[] = []
+  for (const dir of dirs) {
+    await removeStaleArtifacts(dir)
+    snapshots.push({ dir, ...(await readTree(dir)) })
+  }
+  return snapshots
+}
+
+export async function restoreFixtures(snapshots: FixtureSnapshot[]) {
+  for (const snapshot of snapshots) {
+    await restoreFixture(snapshot)
+  }
+}
+
+async function restoreFixture({ dir, files, dirs }: FixtureSnapshot) {
+  const current = await readTree(dir)
+
+  // Deepest first, so a nested directory is gone before its parent is removed.
+  const added = [...current.dirs]
+    .filter((rel) => !dirs.has(rel))
+    .sort((a, b) => b.length - a.length)
+  for (const rel of added) {
+    debug.log(`Clean up ${path.join(dir, rel)}`)
+    await fsp.rm(path.join(dir, rel), { recursive: true, force: true })
+  }
+
+  for (const rel of current.files.keys()) {
+    if (files.has(rel)) continue
+    await fsp.rm(path.join(dir, rel), { force: true })
+  }
+
+  for (const rel of dirs) {
+    if (current.dirs.has(rel)) continue
+    await fsp.mkdir(path.join(dir, rel), { recursive: true })
+  }
+
+  // A build that rewrote a fixture file in place — `bunchee prepare` fills in
+  // package.json — gets reverted to what the fixture ships.
+  for (const [rel, content] of files) {
+    const existing = current.files.get(rel)
+    if (existing?.equals(content)) continue
+    await fsp.mkdir(path.dirname(path.join(dir, rel)), { recursive: true })
+    await fsp.writeFile(path.join(dir, rel), content)
+  }
+}

--- a/test/testing-utils/helpers.ts
+++ b/test/testing-utils/helpers.ts
@@ -111,9 +111,3 @@ export function getChunkFileNamesFromLog(log: string) {
     return line.replace(/\s*\d+ K?B\s*/, '').trim()
   })
 }
-
-export async function deleteFile(f: string) {
-  if (await existsFile(f)) {
-    await fsp.unlink(f)
-  }
-}

--- a/test/testing-utils/index.ts
+++ b/test/testing-utils/index.ts
@@ -7,6 +7,7 @@ export * from './helpers'
 
 export { runCli } from './cli'
 export { createJob } from './integration'
+export { trackFixtureDir } from './fixture-state'
 
 export async function getFileNamesFromDirectory(directory: string) {
   const files = await glob(

--- a/test/testing-utils/shared.ts
+++ b/test/testing-utils/shared.ts
@@ -1,29 +1,26 @@
-import { afterAll, beforeAll } from 'vitest'
+import { beforeAll } from 'vitest'
 import { fork } from 'child_process'
-import { CreateTestResultExtra, removeDirectory } from './helpers'
+import { CreateTestResultExtra } from './helpers'
 import path from 'path'
 import * as debug from './debug'
 
-export async function createAsyncTest<T>(
-  {
-    args,
-    options,
-    directory,
-    abortTimeout,
-    run,
-  }: {
-    args: string[]
-    options: { env?: NodeJS.ProcessEnv }
-    directory: string
-    abortTimeout?: number
-    run: (
-      args: string[],
-      options: { env?: NodeJS.ProcessEnv },
-      processOptions?: { abortTimeout?: number },
-    ) => Promise<T>
-  },
-  testFn?: (context: T & CreateTestResultExtra) => void,
-) {
+export async function createAsyncTest<T>({
+  args,
+  options,
+  directory,
+  abortTimeout,
+  run,
+}: {
+  args: string[]
+  options: { env?: NodeJS.ProcessEnv }
+  directory: string
+  abortTimeout?: number
+  run: (
+    args: string[],
+    options: { env?: NodeJS.ProcessEnv },
+    processOptions?: { abortTimeout?: number },
+  ) => Promise<T>
+}) {
   const fixturesDir = directory
   const distDir = path.join(fixturesDir, './dist')
   let distFile = ''
@@ -37,22 +34,12 @@ export async function createAsyncTest<T>(
   }
 
   const result = await run(args, options, { abortTimeout })
-  const build = {
+  return {
     ...result,
     dir: directory,
     distDir,
     distFile,
   }
-  if (testFn) {
-    try {
-      await testFn(build)
-    } finally {
-      if (!process.env.TEST_NOT_CLEANUP) {
-        await removeDirectory(distDir)
-      }
-    }
-  }
-  return build
 }
 
 export function createSyncTest<T>({
@@ -94,11 +81,6 @@ export function createSyncTest<T>({
   beforeAll(async () => {
     // execute the job
     result = await run(args, options, { abortTimeout })
-  }, hookTimeout)
-  afterAll(async () => {
-    if (!process.env.TEST_NOT_CLEANUP) {
-      await removeDirectory(distDir)
-    }
   }, hookTimeout)
 
   return {

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -15,6 +15,7 @@
     }
   },
   "include": [
+    "./setup.ts",
     "./**/*.test.ts",
     "./**/*.test.tsx",
     "./**/helpers.ts",

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -4,6 +4,9 @@ export default defineConfig({
   test: {
     environment: 'node',
 
+    // Snapshots and restores each test file's fixture directory around the run.
+    setupFiles: ['./test/setup.ts'],
+
     alias: {
       '^bunchee$': '/src/index.ts', // Adjusted to use absolute paths
     },


### PR DESCRIPTION
## Summary

Every suite had to clean up after itself, and the boilerplate was both repetitive and incomplete. Suites removed their own `dist`, deleted the `tsconfig.json` a build wrote next to the fixture, deleted the `package.json` that `bunchee prepare` created — each wrapped in its own `if (!process.env.TEST_NOT_CLEANUP)` check. The ones that forgot left the tree dirty: after a full run there were 86 generated paths under `test/`, masked by `.gitignore` globs and a dozen fixture-local `.gitignore` files. `runCli` suites never cleaned up at all, because the cleanup hung off a `testFn` argument of `createAsyncTest` that no caller ever passed.

`test/setup.ts`, registered through `setupFiles`, now wraps every test file in one hook pair: snapshot the fixture directory before the run, restore it after. Anything a build creates, rewrites, or deletes in there is undone centrally, so a new test needs no cleanup code.

- Stale artifacts from an interrupted run are removed before the snapshot, so a local run starts from the same state as a fresh checkout. "Stale" means git-*ignored* — files the repo already declares as generated. Untracked-but-unignored files are left alone, so an uncommitted fixture file in progress is never deleted. `node_modules`, `__snapshot__`/`__snapshots__`, and `*.test.*` are never touched, keeping `TEST_UPDATE_SNAPSHOT=1` and `vitest -u` working. `TEST_NOT_CLEANUP=1` still skips the restore.
- The fixture directory is inferred from the test file's location. `test/compile.test.ts` sits at the test root and builds elsewhere, so it declares its root explicitly with `trackFixtureDir()`.
- Removed the now-dead cleanup: five `afterAll` blocks with `TEST_NOT_CLEANUP` guards, six `prepare` suites' delete-the-leftovers `beforeAll` blocks, `cli/basic`'s `afterEach`, `dts-bundle`'s `afterAll`, two `execSync('rm -rf')` calls, the `deleteFile` helper, and the unused `testFn` branch.

Two things this surfaced:

- `cli/basic` had three cases all writing to `dist/hello.js`; the `afterEach` wipe was hiding the collision, and the `--no-sourcemap` case only passed because the directory was emptied between tests. Each case now writes its own output file.
- `test/integration/many-entries-directives/` held only a `dist` and a generated tsconfig, with no source or test file — a leftover from the rename in #746. Removed.