### PR TITLE
perf: resolve externals via set and prefix lookup

### DIFF
--- a/src/rollup/input.ts
+++ b/src/rollup/input.ts
@@ -310,10 +310,32 @@ export async function buildInputConfig(
         ]
   ).filter(isNotNull<Plugin>)
 
+  // `externals` holds one entry per dependency plus one per sibling entry, and
+  // rollup asks about every specifier in the graph — so this is scanned tens of
+  // thousands of times. Precompute the exact-match set and the `<name>/` subpath
+  // prefixes once instead of rebuilding a prefix string per candidate per call,
+  // and memoize per specifier, since the same imports repeat across modules.
+  const externalNames = new Set(externals)
+  const externalPrefixes = externals.map((name) => name + '/')
+  const externalCache = new Map<string, boolean>()
+
+  function isExternal(id: string): boolean {
+    if (externalNames.has(id)) return true
+    for (let i = 0; i < externalPrefixes.length; i++) {
+      if (id.startsWith(externalPrefixes[i])) return true
+    }
+    return false
+  }
+
   return {
     input: mergedInputs ?? entry,
     external(id: string) {
-      return externals.some((name) => id === name || id.startsWith(name + '/'))
+      let cached = externalCache.get(id)
+      if (cached === undefined) {
+        cached = isExternal(id)
+        externalCache.set(id, cached)
+      }
+      return cached
     },
     plugins,
     treeshake: 'recommended',


### PR DESCRIPTION
`buildInputConfig`'s `external` callback scanned the entire externals list for every specifier rollup asked about, and rebuilt a `name + '/'` string for each candidate on each call:

```js
external(id) {
  return externals.some((name) => id === name || id.startsWith(name + '/'))
}
```

The externals list grows with the package — one entry per dependency, plus one `<pkg>/<subpath>` per sibling entry. On a generated 201-entry package it holds ~200 names and rollup calls `external` 30,034 times, which works out to 6,006,800 string comparisons and the same number of throwaway prefix strings. The cost is quadratic in entry count and lands on the critical path of every graph build, JS and declarations alike.

This precomputes the exact-match `Set` and the `<name>/` prefixes once per config instead of per call, and memoizes the result per specifier, since the same imports repeat across many modules in a graph.

Measured on that 201-entry package, median of 5 runs:

| | before | after |
|---|---|---|
| `--no-dts` | 1418ms | 1307ms |
| full build | 3832ms | 3609ms |

Roughly 8-10% off the JS side. Small packages are unaffected either way — the list has to be long before the scan shows up.