### PR TITLE
perf: stop over-sharding declaration emit

### DIFF
--- a/src/rollup/merged-config.ts
+++ b/src/rollup/merged-config.ts
@@ -198,20 +198,30 @@ export async function buildMergedConfigs(
 /**
  * How many ways to split the types work across workers.
  *
- * Declaration emit is linear in entry count and one shared graph cannot
- * amortise it, so the only lever is running several at once — and only in
- * separate heaps. Four was the floor on a 57-entry package; past that each
- * extra TypeScript program costs more than the parallelism it buys.
+ * Declaration emit splits into a fixed cost — standing up a TypeScript program,
+ * around 400ms — and a per-entry cost that grows as the program does. Sharding
+ * divides the second but pays the first once per shard, so it only wins once
+ * the per-entry side dominates: measured serially, declarations cost 573ms at
+ * 21 entries, 706ms at 42, and 3180ms at 201.
+ *
+ * That makes entry count, not core count, the thing worth gating on. A shard
+ * per 4 entries sent a 21-entry package straight to the cap and made it slower
+ * than not sharding at all.
  */
 export function typeShardCount(entryCount: number, cores: number): number {
   const override = Number(process.env.BUNCHEE_DTS_SHARDS)
   if (Number.isFinite(override) && override > 0) return Math.floor(override)
 
-  // Past four the wall-clock barely moves while each extra program keeps
-  // costing CPU: on 57 entries, eight shards bought 50ms over four and spent
-  // another 7s of CPU doing it.
-  const MAX_SHARDS = 4
-  const MIN_ENTRIES_PER_SHARD = 4
+  // Two is the setting that holds up in both directions. On an idle machine a
+  // third and fourth shard buy another 3% at 201 entries, but they cost a
+  // program each, and on a machine whose cores are already busy — CI, or a
+  // build sharing a laptop — that extra CPU comes straight back as wall clock:
+  // four shards ran 10% slower than two at 201 entries and 20% slower at 42.
+  //
+  // The second shard only starts paying for itself around 40 entries. Below 20
+  // it is a wash, so keep those on one program and one heap.
+  const MAX_SHARDS = 2
+  const MIN_ENTRIES_PER_SHARD = 20
   return Math.min(
     MAX_SHARDS,
     cores,


### PR DESCRIPTION
`typeShardCount` allocated one shard per 4 entries, capped at 4, which means almost every package that reaches the worker threshold lands on the cap:

| entries | shards before | shards after |
|---|---|---|
| 8 | 2 | 1 |
| 10 | 3 | 1 |
| 20 | 4 | 1 |
| 42 | 4 | 2 |
| 201 | 4 | 2 |

Each shard stands up its own TypeScript program in its own worker. That program is a fixed cost of roughly 400ms, and only the per-entry part of declaration emit is divisible — measured serially, declarations cost 573ms at 21 entries, 706ms at 42, and 3180ms at 201. So below roughly 40 entries the fixed cost dominates and each extra shard pays it again for very little to divide, which made small packages slower than not sharding at all.

Gating on entry count instead of cores, at one shard per 20 entries and at most 2. Measured on generated packages, median of 5 runs, both configurations on this branch:

| entries | before | after | |
|---|---|---|---|
| 10 | 1225ms | 1086ms | -11% |
| 20 | 1305ms | 1165ms | -11% |
| 42 | 1555ms | 1336ms | -14% |
| 201 | 3601ms | 3619ms | neutral |

CPU drops alongside it — 4.80s to 2.89s at 42 entries, 11.78s to 8.17s at 201.

The cap of 2 rather than 4 is the one deliberate trade. On an idle machine a third and fourth shard are worth another ~3% at 201 entries. But they cost a program each, and when the cores are already busy that CPU comes back as wall clock: saturating 10 of 12 cores to approximate a small CI runner, 4 shards ran 10% slower than 2 at 201 entries and 20% slower at 42. Two shards was the best or statistically tied option at every size measured, in both a quiet and a contended machine, so it is the setting that does not depend on where the build runs.

`BUNCHEE_DTS_SHARDS` still overrides, so anyone on a large package with cores to spare can opt back into 4.