### PR TITLE
feat: extend lint with publish-confidence rules

### DIFF
--- a/src/lint.ts
+++ b/src/lint.ts
@@ -10,11 +10,18 @@ import { PackageMetadata } from './types'
 import {
   getPackageMeta,
   hasCjsExtension,
+  hasPackageJson,
   isESModulePackage,
   isTypeFile,
   normalizePath,
 } from './utils'
 import { matchFile } from './lib/file-match'
+import {
+  conditionOrderRule,
+  outputsExistRule,
+  workspaceProtocolRule,
+  type LintIssue,
+} from './lint/rules'
 
 type BadExportItem = {
   value: boolean
@@ -68,10 +75,16 @@ function validateFilesField(packageJson: PackageMetadata) {
 }
 
 export async function lint(cwd: string) {
+  // Not package.json detected, skip package linting
+  if (!hasPackageJson(cwd)) {
+    return
+  }
+
   const pkg = await getPackageMeta(cwd)
   const { name, main, exports } = pkg
   const isESM = isESModulePackage(pkg.type)
   const parsedExports = await parseExports(pkg, cwd)
+  const pkgPath = path.resolve(cwd, 'package.json')
 
   if (!name) {
     logger.warn('Missing package name')
@@ -179,6 +192,14 @@ export async function lint(cwd: string) {
 
   const fieldState = validateFilesField(pkg)
 
+  // Rules added on top of the classic checks: condition order, outputs that
+  // are missing on disk, and workspace: ranges that would publish unrewritten.
+  const extraIssues: LintIssue[] = [
+    ...conditionOrderRule({ pkg, cwd, parsedExports, pkgPath }),
+    ...outputsExistRule({ pkg, cwd, parsedExports, pkgPath }),
+    ...workspaceProtocolRule({ pkg, cwd, parsedExports, pkgPath }),
+  ]
+
   const warningsCount =
     exportsState.badTypesExport.length +
     fieldState.missingFiles.length +
@@ -188,7 +209,8 @@ export async function lint(cwd: string) {
     exportsState.badEsmImportExport.paths.length +
     Number(exportsState.badMainExtension) +
     Number(exportsState.badMainExport) +
-    Number(exportsState.invalidExportsFieldType)
+    Number(exportsState.invalidExportsFieldType) +
+    extraIssues.length
 
   if (warningsCount) {
     logger.warn(`Lint: ${warningsCount} issues found.`)
@@ -264,5 +286,9 @@ export async function lint(cwd: string) {
         `Bad export types field with ${conditionKey(target)} in ${target.path}, use "types" export condition for it`,
       )
     })
+  }
+
+  for (const issue of extraIssues) {
+    logger.warn(issue.message)
   }
 }

--- a/src/lint/rules.ts
+++ b/src/lint/rules.ts
@@ -1,0 +1,125 @@
+import fs from 'fs'
+import path from 'path'
+import type { OutputTarget } from '../exports'
+import type { PackageMetadata } from '../types'
+
+export type LintContext = {
+  pkg: PackageMetadata & { packageManager?: string }
+  cwd: string
+  parsedExports: Map<string, OutputTarget[]>
+  pkgPath: string
+}
+
+export type LintIssue = {
+  message: string
+}
+
+export type LintRule = (context: LintContext) => LintIssue[]
+
+function checkConditionOrder(
+  exportKey: string,
+  value: Record<string, any>,
+  seen: Set<string>,
+): string[] {
+  const problems: string[] = []
+  const keys = Object.keys(value)
+  const orderKey = keys.join(',')
+  if (seen.has(orderKey)) {
+    return problems
+  }
+  seen.add(orderKey)
+
+  const typesIndex = keys.indexOf('types')
+  const defaultIndex = keys.indexOf('default')
+  if (typesIndex > 0) {
+    problems.push(`export "${exportKey}": "types" condition should come first`)
+  }
+  if (defaultIndex !== -1 && defaultIndex !== keys.length - 1) {
+    problems.push(`export "${exportKey}": "default" condition should come last`)
+  }
+  return problems
+}
+
+/**
+ * `types` must be the first condition and `default` the last one — resolvers
+ * pick the first matching key, so a `default` ahead of `types` shadows the
+ * declarations for TS consumers.
+ */
+export const conditionOrderRule: LintRule = ({ pkg }) => {
+  const issues: LintIssue[] = []
+  const exportsField = pkg.exports
+  if (!exportsField || typeof exportsField !== 'object') {
+    return issues
+  }
+
+  const seen = new Set<string>()
+  for (const exportKey of Object.keys(exportsField)) {
+    const value = exportsField[exportKey]
+    if (!value || typeof value !== 'object') {
+      continue
+    }
+    for (const problem of checkConditionOrder(exportKey, value, seen)) {
+      issues.push({ message: problem })
+    }
+  }
+  return issues
+}
+
+/**
+ * Declared outputs that are missing on disk. Only runs when a dist directory
+ * exists, so lint stays quiet on a fresh package before the first build.
+ */
+export const outputsExistRule: LintRule = ({ cwd, parsedExports }) => {
+  if (!fs.existsSync(path.resolve(cwd, 'dist'))) {
+    return []
+  }
+  const issues: LintIssue[] = []
+  const seen = new Set<string>()
+  parsedExports.forEach((targets) => {
+    for (const target of targets) {
+      if (seen.has(target.path) || target.path.includes('*')) {
+        continue
+      }
+      seen.add(target.path)
+      if (!fs.existsSync(path.resolve(cwd, target.path))) {
+        issues.push({
+          message: `Declared output does not exist on disk: ${target.path}`,
+        })
+      }
+    }
+  })
+  return issues
+}
+
+/**
+ * A `workspace:` range is only rewritten by pnpm publish/pack. With any other
+ * package manager the literal range ships to npm and breaks installs.
+ */
+export const workspaceProtocolRule: LintRule = ({ pkg }) => {
+  if (pkg.packageManager?.startsWith('pnpm@')) {
+    return []
+  }
+  const depFields = [
+    'dependencies',
+    'peerDependencies',
+    'optionalDependencies',
+  ] as const
+  const issues: LintIssue[] = []
+  for (const field of depFields) {
+    const deps = pkg[field]
+    if (!deps || typeof deps !== 'object') {
+      continue
+    }
+    for (const [name, range] of Object.entries(deps)) {
+      if (typeof range === 'string' && range.startsWith('workspace:')) {
+        issues.push({
+          message:
+            `"${field}.${name}": "${range}" uses the workspace: protocol — ` +
+            `publishing without pnpm will ship the literal range. ` +
+            `Rewrite it before publishing.`,
+        })
+      }
+    }
+  }
+  return issues
+}

--- a/test/integration/lint/condition-order/index.test.ts
+++ b/test/integration/lint/condition-order/index.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { createJob } from '../../../testing-utils'
+
+describe('integration lint condition-order', () => {
+  const { job } = createJob({
+    directory: __dirname,
+    args: ['lint'],
+  })
+
+  it('should warn that types should come first and default last', () => {
+    const { stderr } = job
+    expect(stderr).toContain('"types" condition should come first')
+    expect(stderr).toContain('"default" condition should come last')
+  })
+})

--- a/test/integration/lint/condition-order/package.json
+++ b/test/integration/lint/condition-order/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "condition-order",
+  "type": "module",
+  "exports": {
+    ".": {
+      "default": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  }
+}

--- a/test/integration/lint/condition-order/src/index.js
+++ b/test/integration/lint/condition-order/src/index.js
@@ -1,0 +1,1 @@
+export const index = 'index'

--- a/test/integration/lint/workspace-protocol/index.test.ts
+++ b/test/integration/lint/workspace-protocol/index.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { createJob } from '../../../testing-utils'
+
+describe('integration lint workspace-protocol', () => {
+  const { job } = createJob({
+    directory: __dirname,
+    args: ['lint'],
+  })
+
+  it('should warn that workspace: range will publish unrewritten', () => {
+    const { stderr } = job
+    expect(stderr).toContain('workspace: protocol')
+    expect(stderr).toContain('"dependencies.foo"')
+  })
+})

--- a/test/integration/lint/workspace-protocol/package.json
+++ b/test/integration/lint/workspace-protocol/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "workspace-protocol",
+  "type": "module",
+  "exports": "./dist/index.js",
+  "dependencies": {
+    "foo": "workspace:*"
+  }
+}

--- a/test/integration/lint/workspace-protocol/src/index.js
+++ b/test/integration/lint/workspace-protocol/src/index.js
@@ -1,0 +1,1 @@
+export const index = 'index'


### PR DESCRIPTION
## What

Extends `bunchee lint` from entry↔exports matching into a pre-publish confidence gate (v7 Track 1, plan in /tmp/bunchee-v7-plan.md).

## New rules

- **Condition order** — `types` must be the first condition, `default` the last. Resolvers pick the first matching key, so a `default` ahead of `types` shadows declarations for TS consumers.
- **Outputs exist** — every declared output path is checked on disk when a `dist/` directory exists (skipped on fresh packages before the first build).
- **workspace: protocol** — warns when a `workspace:*` range would be published unrewritten by npm/yarn (only pnpm rewrites it).

Existing checks and their warning messages are unchanged — all pre-existing lint test files pass unmodified.

## Tests

2 new integration test files (condition-order, workspace-protocol). All 8 lint test files pass.

Full suite: 213/214 pass; the 1 failure (swc-helpers-warning) also fails on main — pre-existing and unrelated.