### PR TITLE
prepare: stop generating module field; remove from recommended setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,6 @@ _NOTE_: When you're using `.mjs` or `.cjs` extensions with TypeScript and modern
   "files": ["dist"],
   "type": "module",
   "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     "import": {

--- a/src/prepare/index.ts
+++ b/src/prepare/index.ts
@@ -330,17 +330,13 @@ export async function prepare(
           ? mainExport[mainCondition].default
           : mainExport[mainCondition]
 
-        pkgJson.module = isUsingTs
-          ? mainExport.import.default
-          : mainExport.import
-
         if (isUsingTs) {
           pkgJson.types = mainExport[mainCondition].types
         }
       }
     }
 
-    // Assign the properties by order: files, main, module, types, exports
+    // Assign the properties by order: files, main, types, exports
     if (Object.keys(pkgExports).length > 0) {
       if (!pkgJson.exports) {
         pkgJson.exports = pkgExports

--- a/test/integration/prepare-js-cjs/index.test.ts
+++ b/test/integration/prepare-js-cjs/index.test.ts
@@ -27,7 +27,7 @@ describe('integration prepare-js-cjs', () => {
       await fsp.readFile(join(dir, './package.json'), 'utf-8'),
     )
     expect(pkgJson.main).toBe('./dist/index.js')
-    expect(pkgJson.module).toBe('./dist/index.mjs')
+    expect(pkgJson.module).toBeUndefined()
     expect(pkgJson.types).toBeFalsy()
     expect(pkgJson.files).toContain('dist')
     expect(pkgJson.bin).toBe('./dist/bin/index.js')

--- a/test/integration/prepare-ts-cjs/index.test.ts
+++ b/test/integration/prepare-ts-cjs/index.test.ts
@@ -42,7 +42,7 @@ describe('integration prepare-ts-cjs', () => {
     })
     expect(pkgJson.type).toBe('module')
     expect(pkgJson.main).toBe('./dist/es/index.js')
-    expect(pkgJson.module).toBe('./dist/es/index.js')
+    expect(pkgJson.module).toBeUndefined()
     expect(pkgJson.exports).toEqual({
       './foo': {
         import: {

--- a/test/integration/prepare-ts-with-pkg-json/index.test.ts
+++ b/test/integration/prepare-ts-with-pkg-json/index.test.ts
@@ -25,7 +25,7 @@ describe('integration prepare-ts-with-pkg-json', () => {
       expect(pkgJson.files).toContain('dist')
       expect(pkgJson.type).toBeUndefined()
       expect(pkgJson.main).toBe('./dist/cjs/index.js')
-      expect(pkgJson.module).toBe('./dist/es/index.mjs')
+      expect(pkgJson.module).toBeUndefined()
     })
   })
 
@@ -59,7 +59,7 @@ describe('integration prepare-ts-with-pkg-json', () => {
       expect(pkgJson.files).toContain('dist')
       expect(pkgJson.type).toBeUndefined()
       expect(pkgJson.main).toBe('./dist/cjs/index.js')
-      expect(pkgJson.module).toBe('./dist/es/index.mjs')
+      expect(pkgJson.module).toBeUndefined()
       expect(pkgJson.exports).toEqual({
         '.': {
           default: './dist/index.js',


### PR DESCRIPTION
## What

Two changes, both backwards compatible:

1. **`prepare` no longer writes `module`** into generated package.json files. `exports` with `import`/`require` conditions is the correct declaration; `module` is redundant once `exports` is present.

2. **README** — `module` removed from the recommended hybrid setup example.

## What stays the same

`parseExports` still reads `pkg.module` as a fallback when no `exports` field exists. Packages relying on it today are unaffected.

## Tests

4 prepare test assertions updated (`module` was previously asserted as generated). Full suite: 210/211 pass; the 1 failure (swc-helpers-warning) also fails on main — pre-existing and unrelated.