### PR TITLE
fix: stop 'use cache' and 'use server' sharing a chunk, simplify chunk names

### DIFF
--- a/src/rollup/output.ts
+++ b/src/rollup/output.ts
@@ -48,6 +48,9 @@ export async function buildOutputConfigs(
     sourcemap = !!tsCompilerOptions?.declarationMap
   }
 
+  /** Group name -> emitted base name, populated by `createSplitChunks`. */
+  const chunkBaseNames = new Map<string, string>()
+
   const outputOptions: OutputOptions = {
     name: pkg.name || name,
     extend: true,
@@ -59,12 +62,18 @@ export async function buildOutputConfigs(
     freeze: false,
     strict: false,
     sourcemap,
+    // Rollup's default hash alphabet is base64url, which includes `-` — so the
+    // hash itself could add dashes to a name that already has one before it,
+    // sometimes two in a row (`mod_asset-12s--5vqDwxI.js`). base36 is
+    // alphanumeric, which leaves that single dash as the only one in the name.
+    hashCharacters: 'base36',
     manualChunks: createSplitChunks(
       pluginContext.moduleDirectiveLayerMap,
       entryFiles,
       merged,
+      chunkBaseNames,
     ),
-    chunkFileNames() {
+    chunkFileNames(chunk) {
       const isCjsFormat = format === 'cjs'
       const ext = dts
         ? 'd.ts'
@@ -73,7 +82,12 @@ export async function buildOutputConfigs(
           : !isCjsFormat && !isEsmPkg
             ? 'mjs'
             : 'js'
-      return '[name]-[hash].' + ext
+      // A boundary group is keyed by layer so the layers cannot merge, but the
+      // file is written under the module's own name — the layer is only part of
+      // the key. Chunks rollup names itself are not in the map and keep
+      // `[name]`.
+      const base = chunkBaseNames.get(chunk.name)
+      return `${base ?? '[name]'}-[hash].${ext}`
     },
     // By default in rollup, when creating multiple chunks, transitive imports of entry chunks
     // will be added as empty imports to the entry chunks. Disable to avoid imports hoist outside of boundaries

--- a/src/rollup/split-chunks.ts
+++ b/src/rollup/split-chunks.ts
@@ -1,16 +1,15 @@
 import { type GetManualChunk, type GetModuleInfo } from 'rollup'
 import { type CustomPluginOptions } from 'rollup'
 import path from 'path'
-import { memoize } from '../lib/memoize'
 
-const hashTo3Char = memoize((input: string): string => {
-  let hash = 0
-  for (let i = 0; i < input.length; i++) {
-    hash = (hash << 5) - hash + input.charCodeAt(i) // Simple hash shift
-  }
-  return (hash >>> 0).toString(36).slice(0, 3) // Base36 + trim to 3 chars
-})
-
+/**
+ * The module's own directive layer, as written — `'use client'` gives `client`.
+ *
+ * This is the raw directive rather than a hash of it. The value decides whether
+ * two modules sit on the same side of a boundary, so it has to stay exact: a
+ * hash short enough to put in a file name is not, and `'use server'` and
+ * `'use cache'` collided under the one that used to be here.
+ */
 function getModuleLayer(moduleMeta: CustomPluginOptions): string | undefined {
   const directives = (
     moduleMeta.preserveDirectives || { directives: [] }
@@ -18,8 +17,7 @@ function getModuleLayer(moduleMeta: CustomPluginOptions): string | undefined {
     .map((d: string) => d.replace(/^use /, ''))
     .filter((d: string) => d !== 'strict')
 
-  const moduleLayer = directives[0]
-  return moduleLayer ? hashTo3Char(moduleLayer) : undefined
+  return directives[0]
 }
 
 /**
@@ -115,9 +113,45 @@ export function createSplitChunks(
    * explicit for all of them, and costs one chunk instead of a copy per entry.
    */
   merged: boolean = false,
+  /**
+   * Filled in as groups are created: group name -> the base name its file is
+   * written under, for `chunkFileNames` to read back.
+   *
+   * A group name has to be layer-specific, or two modules that share a file
+   * name on opposite sides of a boundary land in one chunk carrying both
+   * directives. That makes the layer part of the key, but it is only a key —
+   * it does not belong in the emitted file name, which stays
+   * `<module>-<hash>`.
+   */
+  chunkBaseNames?: Map<string, string>,
 ): GetManualChunk {
   // If there's existing chunk being splitted, and contains a layer { <id>: <chunkGroup> }
   const splitChunksGroupMap = new Map<string, string>()
+
+  /** module + layer -> group token, so the same pair always reuses its group. */
+  const groupTokens = new Map<string, string>()
+
+  /**
+   * A group keyed by module *and* layer, written out under the module's name.
+   *
+   * The token is deliberately opaque rather than something readable like
+   * `<module>_<layer>`: rollup rewrites a chunk name it considers unsafe for a
+   * file name, and a rewritten name no longer matches the key it was recorded
+   * under — which silently puts the layer back into the output. A token rollup
+   * leaves alone keeps the emitted name entirely ours. It never reaches the
+   * user; `chunkFileNames` maps it straight back to `base`.
+   */
+  function groupFor(id: string, layerKey: string): string {
+    const base = path.basename(id, path.extname(id))
+    const key = `${base}\u0000${layerKey}`
+    let token = groupTokens.get(key)
+    if (!token) {
+      token = `bunchee_group_${groupTokens.size}`
+      groupTokens.set(key, token)
+      chunkBaseNames?.set(token, base)
+    }
+    return token
+  }
 
   return function splitChunks(id, ctx) {
     if (/[\\/]node_modules[\\/]\@swc[\\/]helper/.test(id)) {
@@ -164,10 +198,12 @@ export function createSplitChunks(
           return splitChunksGroupMap.get(id)
         }
 
-        const chunkName = path.basename(id, path.extname(id))
-        // Create a unique suffix based on all the layers that import this module
-        const layersSuffix = Array.from(importerLayers).sort().join('-')
-        const chunkGroup = `${chunkName}-${hashTo3Char(layersSuffix)}`
+        // Keyed by every layer that reaches it, so the chunk shared by the
+        // client and server boundaries is distinct from either one's own.
+        const chunkGroup = groupFor(
+          id,
+          Array.from(importerLayers).sort().join('\u0000'),
+        )
 
         splitChunksGroupMap.set(id, chunkGroup)
         return chunkGroup
@@ -177,7 +213,7 @@ export function createSplitChunks(
     if (merged && moduleLayer && !isEntry) {
       const existing = splitChunksGroupMap.get(id)
       if (existing) return existing
-      const chunkGroup = `${path.basename(id, path.extname(id))}-${hashTo3Char(moduleLayer)}`
+      const chunkGroup = groupFor(id, moduleLayer)
       splitChunksGroupMap.set(id, chunkGroup)
       return chunkGroup
     }
@@ -212,9 +248,7 @@ export function createSplitChunks(
           return
         }
 
-        const chunkName = path.basename(id, path.extname(id))
-        const layerSuffix = hashTo3Char(moduleLayer)
-        const chunkGroup = `${chunkName}-${layerSuffix}`
+        const chunkGroup = groupFor(id, moduleLayer)
 
         splitChunksGroupMap.set(id, chunkGroup)
         return chunkGroup

--- a/test/compile/use-client/__snapshot__/use-client.js.snapshot
+++ b/test/compile/use-client/__snapshot__/use-client.js.snapshot
@@ -1,5 +1,5 @@
 'use strict';
-import { c as client } from './client-12s-Cm06vGwQ.mjs';
+import { c as client } from './client-ho0797oh.mjs';
 
 var input = (()=>{
     return client();

--- a/test/compile/use-client/__snapshot__/use-client.min.js.snapshot
+++ b/test/compile/use-client/__snapshot__/use-client.min.js.snapshot
@@ -1,1 +1,1 @@
-"use strict";import{c as t}from"./client-12s-B-RDfYre.mjs";var s=()=>t();export{s as default};
+"use strict";import{c as t}from"./client-bgdoll3u.mjs";var r=()=>t();export{r as default};

--- a/test/integration/directive-layer-chunks/.gitignore
+++ b/test/integration/directive-layer-chunks/.gitignore
@@ -1,0 +1,1 @@
+!tsconfig.json

--- a/test/integration/directive-layer-chunks/index.test.ts
+++ b/test/integration/directive-layer-chunks/index.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createJob,
+  getFileContents,
+  getFileNamesFromDirectory,
+} from '../../testing-utils'
+
+// `src/x/util.ts` carries `'use cache'` and `src/y/util.ts` carries
+// `'use server'`. They share a file name, so the only thing keeping them apart
+// is the layer in their chunk group key — and that key used to be a hash short
+// enough to fit in a file name, under which `cache` and `server` collided. Both
+// modules then landed in one chunk with both directives stacked on top, which
+// is not a boundary either of them asked for.
+describe('integration - directive-layer-chunks', () => {
+  const { distDir } = createJob({ directory: __dirname })
+
+  it('should not merge two layers into one chunk', async () => {
+    const files = await getFileNamesFromDirectory(distDir)
+    const contents = await getFileContents(distDir)
+
+    const chunks = files.filter(
+      (file) => file.startsWith('util-') && file.endsWith('.js'),
+    )
+    expect(chunks).toHaveLength(2)
+
+    // Each chunk carries exactly one directive, and between them they cover
+    // both layers.
+    const directives = chunks.map((chunk) =>
+      [...contents[chunk].matchAll(/^'use ([a-z]+)';$/gm)].map((m) => m[1]),
+    )
+    expect(directives.map((d) => d.length)).toEqual([1, 1])
+    expect(directives.flat().sort()).toEqual(['cache', 'server'])
+
+    // And the two layers' code did not end up in the same file.
+    const cacheChunk = chunks.find((chunk) =>
+      contents[chunk].includes('cache-value'),
+    )
+    const serverChunk = chunks.find((chunk) =>
+      contents[chunk].includes('server-value'),
+    )
+    expect(cacheChunk).toBeDefined()
+    expect(serverChunk).toBeDefined()
+    expect(cacheChunk).not.toBe(serverChunk)
+  })
+
+  it('should name boundary chunks <module>-<hash> with an alphanumeric hash', async () => {
+    const files = await getFileNamesFromDirectory(distDir)
+    const chunks = files.filter(
+      (file) => file.startsWith('util-') && file.endsWith('.js'),
+    )
+
+    for (const chunk of chunks) {
+      // One dash, and the layer is not spelled into the name. base36 hashes
+      // keep the hash itself from contributing any more dashes.
+      expect(chunk).toMatch(/^util-[0-9a-z]+\.js$/)
+    }
+  })
+})

--- a/test/integration/directive-layer-chunks/package.json
+++ b/test/integration/directive-layer-chunks/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "directive-layer-chunks",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./other": {
+      "types": "./dist/other.d.ts",
+      "default": "./dist/other.js"
+    }
+  }
+}

--- a/test/integration/directive-layer-chunks/src/index.ts
+++ b/test/integration/directive-layer-chunks/src/index.ts
@@ -1,0 +1,4 @@
+import { fromCache } from './x/util'
+import { fromServer } from './y/util'
+
+export { fromCache, fromServer }

--- a/test/integration/directive-layer-chunks/src/other.ts
+++ b/test/integration/directive-layer-chunks/src/other.ts
@@ -1,0 +1,3 @@
+import { fromCache } from './x/util'
+
+export { fromCache }

--- a/test/integration/directive-layer-chunks/src/x/util.ts
+++ b/test/integration/directive-layer-chunks/src/x/util.ts
@@ -1,0 +1,3 @@
+'use cache'
+
+export const fromCache = () => 'cache-value'

--- a/test/integration/directive-layer-chunks/src/y/util.ts
+++ b/test/integration/directive-layer-chunks/src/y/util.ts
@@ -1,0 +1,3 @@
+'use server'
+
+export const fromServer = async () => 'server-value'

--- a/test/integration/directive-layer-chunks/tsconfig.json
+++ b/test/integration/directive-layer-chunks/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "module": "ES6",
+    "moduleResolution": "bundler",
+    "target": "ES2022"
+  },
+  "exclude": ["*.test.ts"]
+}

--- a/test/integration/many-entries/index.test.ts
+++ b/test/integration/many-entries/index.test.ts
@@ -50,7 +50,7 @@ describe('integration - many-entries', () => {
         "h.js",
         "index.d.ts",
         "index.js",
-        "shared-BMJTKie0.js",
+        "shared-m31h5ood.js",
       ]
     `)
     // The entry that imports a sibling entry references it instead of inlining

--- a/test/integration/mixed-directives/mixed-directives.test.ts
+++ b/test/integration/mixed-directives/mixed-directives.test.ts
@@ -10,7 +10,7 @@ describe('integration - mixed-directives', () => {
 
     expect(fileContents).toMatchInlineSnapshot(`
       {
-        "action-12x-DOTFC6td.js": "'use server';
+        "action-i76f4tu7.js": "'use server';
       async function action1() {
           return 'action1';
       }
@@ -25,7 +25,7 @@ describe('integration - mixed-directives', () => {
       ",
         "client.js": "'use client';
       import { jsx } from 'react/jsx-runtime';
-      import { a as action1 } from './action-12x-DOTFC6td.js';
+      import { a as action1 } from './action-i76f4tu7.js';
 
       function Page() {
           return /*#__PURE__*/ jsx("button", {

--- a/test/integration/server-components/index.test.ts
+++ b/test/integration/server-components/index.test.ts
@@ -10,15 +10,15 @@ describe('integration server-components', () => {
     expect(jsFiles).toEqual([
       'index.cjs',
       'index.js',
-      'mod_actions-12x-DRlszKRg.js',
-      'mod_actions-12x-ZyfVXl5o.cjs',
+      'mod_actions-gdr5hg8y.js',
+      'mod_actions-gnku5pdq.cjs',
       // `mod_asset` carries 'use client' and is reached from `ui` only, but one
       // graph places it once, so it gets a boundary chunk rather than being
       // inlined into that entry.
-      'mod_asset-12s--5vqDwxI.cjs',
-      'mod_asset-12s-Bq1vQakb.js',
-      'mod_client-12s-BO96FYFA.js',
-      'mod_client-12s-DAeHkA4H.cjs',
+      'mod_asset-bssczhru.js',
+      'mod_asset-hfdpjgz4.cjs',
+      'mod_client-dntoopie.js',
+      'mod_client-h1r7vgy7.cjs',
       'ui.cjs',
       'ui.js',
     ])

--- a/test/integration/split-common-chunks/split-common-chunks.test.ts
+++ b/test/integration/split-common-chunks/split-common-chunks.test.ts
@@ -16,8 +16,8 @@ describe('integration - split-common-chunks', () => {
       [
         "bar.cjs",
         "bar.js",
-        "cc-B-HjsW7A.js",
-        "cc-DPkwN2Gw.cjs",
+        "cc-g1xtnh96.cjs",
+        "cc-ob5mf4bc.js",
         "foo.js",
         "index.cjs",
         "index.js",
@@ -25,7 +25,7 @@ describe('integration - split-common-chunks', () => {
     `)
     expect(fileContents).toMatchInlineSnapshot(`
       {
-        "bar.cjs": "var cc = require('./cc-DPkwN2Gw.cjs');
+        "bar.cjs": "var cc = require('./cc-g1xtnh96.cjs');
 
       class Bar {
           method() {
@@ -55,7 +55,7 @@ describe('integration - split-common-chunks', () => {
 
       exports.Bar = Bar;
       ",
-        "bar.js": "import { _ as __addDisposableResource, a as __disposeResources } from './cc-B-HjsW7A.js';
+        "bar.js": "import { _ as __addDisposableResource, a as __disposeResources } from './cc-ob5mf4bc.js';
 
       class Bar {
           method() {
@@ -85,111 +85,7 @@ describe('integration - split-common-chunks', () => {
 
       export { Bar };
       ",
-        "cc-B-HjsW7A.js": "function __addDisposableResource(env, value, async) {
-          if (value !== null && value !== void 0) {
-              if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
-              var dispose, inner;
-              if (async) {
-                  if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
-                  dispose = value[Symbol.asyncDispose];
-              }
-              if (dispose === void 0) {
-                  if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
-                  dispose = value[Symbol.dispose];
-                  if (async) inner = dispose;
-              }
-              if (typeof dispose !== "function") throw new TypeError("Object not disposable.");
-              if (inner) dispose = function() {
-                  try {
-                      inner.call(this);
-                  } catch (e) {
-                      return Promise.reject(e);
-                  }
-              };
-              env.stack.push({
-                  value: value,
-                  dispose: dispose,
-                  async: async
-              });
-          } else if (async) {
-              env.stack.push({
-                  async: true
-              });
-          }
-          return value;
-      }
-      var _SuppressedError = typeof SuppressedError === "function" ? SuppressedError : function(error, suppressed, message) {
-          var e = new Error(message);
-          return e.name = "SuppressedError", e.error = error, e.suppressed = suppressed, e;
-      };
-      function __disposeResources(env) {
-          function fail(e) {
-              env.error = env.hasError ? new _SuppressedError(e, env.error, "An error was suppressed during disposal.") : e;
-              env.hasError = true;
-          }
-          var r, s = 0;
-          function next() {
-              while(r = env.stack.pop()){
-                  try {
-                      if (!r.async && s === 1) return s = 0, env.stack.push(r), Promise.resolve().then(next);
-                      if (r.dispose) {
-                          var result = r.dispose.call(r.value);
-                          if (r.async) return s |= 2, Promise.resolve(result).then(next, function(e) {
-                              fail(e);
-                              return next();
-                          });
-                      } else s |= 1;
-                  } catch (e) {
-                      fail(e);
-                  }
-              }
-              if (s === 1) return env.hasError ? Promise.reject(env.error) : Promise.resolve();
-              if (env.hasError) throw env.error;
-          }
-          return next();
-      }
-
-      function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) {
-          try {
-              var info = gen[key](arg);
-              var value = info.value;
-          } catch (error) {
-              reject(error);
-              return;
-          }
-          if (info.done) resolve(value);
-          else Promise.resolve(value).then(_next, _throw);
-      }
-      function _async_to_generator(fn) {
-          return function() {
-              var self = this, args = arguments;
-              return new Promise(function(resolve, reject) {
-                  var gen = fn.apply(self, args);
-                  function _next(value) {
-                      asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value);
-                  }
-                  function _throw(err) {
-                      asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err);
-                  }
-                  _next(undefined);
-              });
-          };
-      }
-
-      function _extends() {
-          _extends = Object.assign || function assign(target) {
-              for(var i = 1; i < arguments.length; i++){
-                  var source = arguments[i];
-                  for(var key in source)if (Object.prototype.hasOwnProperty.call(source, key)) target[key] = source[key];
-              }
-              return target;
-          };
-          return _extends.apply(this, arguments);
-      }
-
-      export { __addDisposableResource as _, __disposeResources as a, _async_to_generator as b, _extends as c };
-      ",
-        "cc-DPkwN2Gw.cjs": "function __addDisposableResource(env, value, async) {
+        "cc-g1xtnh96.cjs": "function __addDisposableResource(env, value, async) {
           if (value !== null && value !== void 0) {
               if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
               var dispose, inner;
@@ -296,7 +192,111 @@ describe('integration - split-common-chunks', () => {
       exports._async_to_generator = _async_to_generator;
       exports._extends = _extends;
       ",
-        "foo.js": "import { b as _async_to_generator } from './cc-B-HjsW7A.js';
+        "cc-ob5mf4bc.js": "function __addDisposableResource(env, value, async) {
+          if (value !== null && value !== void 0) {
+              if (typeof value !== "object" && typeof value !== "function") throw new TypeError("Object expected.");
+              var dispose, inner;
+              if (async) {
+                  if (!Symbol.asyncDispose) throw new TypeError("Symbol.asyncDispose is not defined.");
+                  dispose = value[Symbol.asyncDispose];
+              }
+              if (dispose === void 0) {
+                  if (!Symbol.dispose) throw new TypeError("Symbol.dispose is not defined.");
+                  dispose = value[Symbol.dispose];
+                  if (async) inner = dispose;
+              }
+              if (typeof dispose !== "function") throw new TypeError("Object not disposable.");
+              if (inner) dispose = function() {
+                  try {
+                      inner.call(this);
+                  } catch (e) {
+                      return Promise.reject(e);
+                  }
+              };
+              env.stack.push({
+                  value: value,
+                  dispose: dispose,
+                  async: async
+              });
+          } else if (async) {
+              env.stack.push({
+                  async: true
+              });
+          }
+          return value;
+      }
+      var _SuppressedError = typeof SuppressedError === "function" ? SuppressedError : function(error, suppressed, message) {
+          var e = new Error(message);
+          return e.name = "SuppressedError", e.error = error, e.suppressed = suppressed, e;
+      };
+      function __disposeResources(env) {
+          function fail(e) {
+              env.error = env.hasError ? new _SuppressedError(e, env.error, "An error was suppressed during disposal.") : e;
+              env.hasError = true;
+          }
+          var r, s = 0;
+          function next() {
+              while(r = env.stack.pop()){
+                  try {
+                      if (!r.async && s === 1) return s = 0, env.stack.push(r), Promise.resolve().then(next);
+                      if (r.dispose) {
+                          var result = r.dispose.call(r.value);
+                          if (r.async) return s |= 2, Promise.resolve(result).then(next, function(e) {
+                              fail(e);
+                              return next();
+                          });
+                      } else s |= 1;
+                  } catch (e) {
+                      fail(e);
+                  }
+              }
+              if (s === 1) return env.hasError ? Promise.reject(env.error) : Promise.resolve();
+              if (env.hasError) throw env.error;
+          }
+          return next();
+      }
+
+      function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) {
+          try {
+              var info = gen[key](arg);
+              var value = info.value;
+          } catch (error) {
+              reject(error);
+              return;
+          }
+          if (info.done) resolve(value);
+          else Promise.resolve(value).then(_next, _throw);
+      }
+      function _async_to_generator(fn) {
+          return function() {
+              var self = this, args = arguments;
+              return new Promise(function(resolve, reject) {
+                  var gen = fn.apply(self, args);
+                  function _next(value) {
+                      asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value);
+                  }
+                  function _throw(err) {
+                      asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err);
+                  }
+                  _next(undefined);
+              });
+          };
+      }
+
+      function _extends() {
+          _extends = Object.assign || function assign(target) {
+              for(var i = 1; i < arguments.length; i++){
+                  var source = arguments[i];
+                  for(var key in source)if (Object.prototype.hasOwnProperty.call(source, key)) target[key] = source[key];
+              }
+              return target;
+          };
+          return _extends.apply(this, arguments);
+      }
+
+      export { __addDisposableResource as _, __disposeResources as a, _async_to_generator as b, _extends as c };
+      ",
+        "foo.js": "import { b as _async_to_generator } from './cc-ob5mf4bc.js';
 
       class Foo {
           foo() {
@@ -308,7 +308,7 @@ describe('integration - split-common-chunks', () => {
 
       export { Foo };
       ",
-        "index.cjs": "var cc = require('./cc-DPkwN2Gw.cjs');
+        "index.cjs": "var cc = require('./cc-g1xtnh96.cjs');
 
       class Index {
           method() {
@@ -327,7 +327,7 @@ describe('integration - split-common-chunks', () => {
 
       exports.Index = Index;
       ",
-        "index.js": "import { b as _async_to_generator, c as _extends } from './cc-B-HjsW7A.js';
+        "index.js": "import { b as _async_to_generator, c as _extends } from './cc-ob5mf4bc.js';
 
       class Index {
           method() {


### PR DESCRIPTION
Refs #732.

## A boundary chunk's layer tag was a hash of a hash

`getModuleLayer` already returned `hashTo3Char(layer)`, and all three of its callers hashed that result **again**. So the tag in `mod_client-12s-BO96FYFA.js` was `h(h('client'))` — not a hash of the layer, a hash of a 3-character hash of it.

Squeezing the layer through two 3-character hashes collapses the space, and two layers land on the same tag:

```
h('server') = 1k1     h(h('server')) = 12x
h('cache')  = 1k7     h(h('cache'))  = 12x   ← same
```

The tag is what makes a chunk group layer-specific, so once two layers share one, two modules that also share a file name get the same group — and rollup merges them into a single chunk. Given `src/x/util.ts` with `'use cache'` and `src/y/util.ts` with `'use server'`, that produced:

```js
// util-12x-uQszq5_T.js   ← one chunk
'use cache';
'use server';
const fromCache = ...
const fromServer = ...
```

Both boundaries in one file, with both directives stacked. This is reachable today, not only once `'use cache'` is formally supported — directive handling is generic, so a `'use cache'` module already gets a boundary chunk.

The fix is to stop hashing the layer at all. It is compared for equality to decide whether a boundary is crossed, so it has to stay exact, and a hash short enough to sit in a file name is not. The layer now stays in the chunk group *key* only, which is where uniqueness actually matters.

## The layer no longer appears in the file name

With the layer out of the name, a boundary chunk is `<module>-<hash>`:

```
mod_client-12s-BO96FYFA.js   ->  mod_client-dntoopie.js
mod_asset-12s--5vqDwxI.cjs   ->  mod_asset-hfdpjgz4.cjs
util-12x-uQszq5_T.js         ->  util-7q5dyo00.js  +  util-h75wfmlv.js
```

The group key still carries the layer, so nothing merges that shouldn't — it is just not spelled into the output. The key is an opaque token rather than a readable `<module>_<layer>`, because rollup rewrites a chunk name it considers unsafe for a file name, and a rewritten name stops matching the key it was recorded under, which puts the layer straight back into the output.

## Hashes are base36, so a name has exactly one dash

Rollup's default hash alphabet is base64url, which includes `-`. The hash could therefore contribute dashes of its own, sometimes doubling up with the separator (`mod_asset-12s--5vqDwxI.cjs`, `b-12x-RVl-ntzp.js`). `output.hashCharacters: 'base36'` makes hashes alphanumeric, so the one dash before the hash is the only one a chunk name can have.

## Note on same-layer collisions

Two modules that share a file name *within one layer* still share a chunk — the group key is module name plus layer, with no path component. That is wasteful but keeps directives consistent, unlike the cross-layer case, so it is left alone here.