### PR TITLE
perf: stop building unreachable private modules, build one graph per module set

### DIFF
--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -16,6 +16,7 @@ import {
   removeOutputDir,
 } from './utils'
 import {
+  MIN_ENTRIES_FOR_MERGED_WORKERS,
   MIN_ENTRIES_FOR_WORKERS,
   availableCores,
   runEntriesInWorkers,
@@ -226,13 +227,17 @@ async function bundle(
     !process.env.TEST_NO_WORKERS &&
     entryNames.length >= MIN_ENTRIES_FOR_WORKERS
 
-  // Merging collapses the JS work to a couple of graphs, but declaration emit
-  // stays linear in entry count and one shared graph cannot amortise it. So
-  // above the worker threshold the two are combined: merged JS here, then the
-  // types split into shards that each build a merged graph in their own heap.
-  // Sharding them in this heap is slower, not faster — several TypeScript
-  // programs in one isolate spend their time in GC.
-  const useWorkers = workersAvailable && (!useMerged || generateTypes)
+  // The per-entry path grows its heap with the entry count, so it always fans
+  // out. A merged build is already a handful of graphs and only its declaration
+  // emit is left to split, which does not pay for the workers it would take
+  // until the entry count is large — see `MIN_ENTRIES_FOR_MERGED_WORKERS`. Below
+  // that, the pool cost more than it saved on every package measured, and below
+  // `typeShardCount`'s minimum it was pure overhead: one shard, so one worker,
+  // doing exactly what this process would have done.
+  const useWorkers =
+    workersAvailable &&
+    (!useMerged ||
+      (generateTypes && entryNames.length >= MIN_ENTRIES_FOR_MERGED_WORKERS))
 
   try {
     let assetJobs

--- a/src/entries.test.ts
+++ b/src/entries.test.ts
@@ -54,17 +54,16 @@ describe('findReachablePrivateFiles', () => {
     return sourceFolder
   }
 
-  /** The private files kept, given which of them are private and which are entries. */
+  /** The private files kept, given which of `files` are the private ones. */
   async function reachable(
     files: Record<string, string>,
     privateFiles: string[],
-    entries: string[],
   ): Promise<string[]> {
     const sourceFolder = writeSrc(files)
     const kept = await findReachablePrivateFiles(
       sourceFolder,
       privateFiles,
-      entries.map((entry) => path.join(sourceFolder, entry)),
+      Object.keys(files),
     )
     return [...kept].sort()
   }
@@ -77,7 +76,6 @@ describe('findReachablePrivateFiles', () => {
           '_util.ts': `export const util = 1`,
         },
         ['_util.ts'],
-        ['index.ts'],
       ),
     ).toEqual(['_util.ts'])
   })
@@ -92,7 +90,6 @@ describe('findReachablePrivateFiles', () => {
           '_build.ts': `import ts from 'typescript'\nexport const build = ts`,
         },
         ['_build.ts'],
-        ['index.ts'],
       ),
     ).toEqual([])
   })
@@ -107,7 +104,6 @@ describe('findReachablePrivateFiles', () => {
           '_orphan.ts': `export const b = 2`,
         },
         ['_deep.ts', '_orphan.ts'],
-        ['index.ts'],
       ),
     ).toEqual(['_deep.ts'])
   })
@@ -124,9 +120,25 @@ describe('findReachablePrivateFiles', () => {
           '_internal/_helper.ts': `export const helper = 1`,
         },
         ['_internal/index.ts', '_internal/_helper.ts'],
-        ['index/index.ts'],
       ),
     ).toEqual(['_internal/_helper.ts', '_internal/index.ts'])
+  })
+
+  it('should keep a private module its private sibling imports', async () => {
+    // Regression: `_internal/events` is named by its sibling as `'./events'`,
+    // which contains nothing of `_internal`. Deciding which files were worth
+    // reading from the underscore-prefixed segment alone skipped the importer
+    // and dropped both modules.
+    expect(
+      await reachable(
+        {
+          'index.ts': `export { internal } from './_internal'`,
+          '_internal/index.ts': `export * from './events'\nexport const internal = 1`,
+          '_internal/events.ts': `export const events = 2`,
+        },
+        ['_internal/index.ts', '_internal/events.ts'],
+      ),
+    ).toEqual(['_internal/events.ts', '_internal/index.ts'])
   })
 
   it('should keep every condition variant when one is reached', async () => {
@@ -140,7 +152,6 @@ describe('findReachablePrivateFiles', () => {
           '_internal/index.ts': `export const internal = 'default'`,
         },
         ['_internal/index.react-server.ts', '_internal/index.ts'],
-        ['index.react-server.ts'],
       ),
     ).toEqual(['_internal/index.react-server.ts', '_internal/index.ts'].sort())
   })
@@ -155,7 +166,6 @@ describe('findReachablePrivateFiles', () => {
           '_internal/index.ts': `export const internal = 1`,
         },
         ['_internal/index.ts'],
-        ['index.ts'],
       ),
     ).toEqual(['_internal/index.ts'])
   })
@@ -171,7 +181,6 @@ describe('findReachablePrivateFiles', () => {
           '_target.ts': `export const x = 1`,
         },
         ['_target.ts'],
-        ['index.ts'],
       ),
     ).toEqual([])
   })
@@ -185,12 +194,27 @@ describe('findReachablePrivateFiles', () => {
           '_b.ts': `export const b = 2`,
         },
         ['_a.ts', '_b.ts'],
-        ['index.ts'],
       ),
     ).toEqual(['_a.ts', '_b.ts'])
   })
 
-  it('should keep everything when a file cannot be parsed', async () => {
+  it('should keep everything when a file mentioning one cannot be parsed', async () => {
+    // Mentioning `_a` is what makes the file worth reading in the first place;
+    // once it cannot be parsed there is no telling whether it imports it.
+    expect(
+      await reachable(
+        {
+          'index.ts': `import { a } from './_a'\nthis is not ( valid ] <<<`,
+          '_a.ts': `export const a = 1`,
+        },
+        ['_a.ts'],
+      ),
+    ).toEqual(['_a.ts'])
+  })
+
+  it('should not read a file that cannot mention one', async () => {
+    // Unparseable, but its text does not contain `_a`, so no specifier in it
+    // could have named `_a` — there is nothing to be uncertain about.
     expect(
       await reachable(
         {
@@ -198,8 +222,7 @@ describe('findReachablePrivateFiles', () => {
           '_a.ts': `export const a = 1`,
         },
         ['_a.ts'],
-        ['index.ts'],
       ),
-    ).toEqual(['_a.ts'])
+    ).toEqual([])
   })
 })

--- a/src/entries.test.ts
+++ b/src/entries.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from 'vitest'
-import { normalizeExportPath } from './entries'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { findReachablePrivateFiles, normalizeExportPath } from './entries'
 
 describe('normalizeExportPath', () => {
   it('should strip export condition suffixes', () => {
@@ -27,5 +30,176 @@ describe('normalizeExportPath', () => {
     expect(normalizeExportPath('$binary')).toBe('$binary')
     expect(normalizeExportPath('$binary/index')).toBe('$binary')
     expect(normalizeExportPath('$binary/foo')).toBe('$binary/foo')
+  })
+})
+
+describe('findReachablePrivateFiles', () => {
+  const created: string[] = []
+
+  afterEach(() => {
+    while (created.length)
+      rmSync(created.pop()!, { recursive: true, force: true })
+  })
+
+  /** Writes `files` into a throwaway `src` directory, keyed by relative path. */
+  function writeSrc(files: Record<string, string>): string {
+    const root = mkdtempSync(path.join(tmpdir(), 'bunchee-reachable-'))
+    created.push(root)
+    const sourceFolder = path.join(root, 'src')
+    for (const [file, code] of Object.entries(files)) {
+      const target = path.join(sourceFolder, file)
+      mkdirSync(path.dirname(target), { recursive: true })
+      writeFileSync(target, code)
+    }
+    return sourceFolder
+  }
+
+  /** The private files kept, given which of them are private and which are entries. */
+  async function reachable(
+    files: Record<string, string>,
+    privateFiles: string[],
+    entries: string[],
+  ): Promise<string[]> {
+    const sourceFolder = writeSrc(files)
+    const kept = await findReachablePrivateFiles(
+      sourceFolder,
+      privateFiles,
+      entries.map((entry) => path.join(sourceFolder, entry)),
+    )
+    return [...kept].sort()
+  }
+
+  it('should keep a private module an export imports', async () => {
+    expect(
+      await reachable(
+        {
+          'index.ts': `export { util } from './_util'`,
+          '_util.ts': `export const util = 1`,
+        },
+        ['_util.ts'],
+        ['index.ts'],
+      ),
+    ).toEqual(['_util.ts'])
+  })
+
+  it('should skip a private module no export reaches', async () => {
+    // The case this exists for: a build-time script sitting in `src`, which
+    // nothing imports and whose own imports should not enter the graph.
+    expect(
+      await reachable(
+        {
+          'index.ts': `export const index = 1`,
+          '_build.ts': `import ts from 'typescript'\nexport const build = ts`,
+        },
+        ['_build.ts'],
+        ['index.ts'],
+      ),
+    ).toEqual([])
+  })
+
+  it('should reach a private module through another module', async () => {
+    expect(
+      await reachable(
+        {
+          'index.ts': `export { a } from './middle'`,
+          'middle.ts': `export { a } from './_deep'`,
+          '_deep.ts': `export const a = 1`,
+          '_orphan.ts': `export const b = 2`,
+        },
+        ['_deep.ts', '_orphan.ts'],
+        ['index.ts'],
+      ),
+    ).toEqual(['_deep.ts'])
+  })
+
+  it('should resolve a private directory to its index', async () => {
+    // `'../_internal'` names a directory, which exists — so a check that only
+    // asked whether the path existed would stop before reaching `index.ts` and
+    // never walk what it imports.
+    expect(
+      await reachable(
+        {
+          'index/index.ts': `export { internal } from '../_internal'`,
+          '_internal/index.ts': `export { helper as internal } from './_helper'`,
+          '_internal/_helper.ts': `export const helper = 1`,
+        },
+        ['_internal/index.ts', '_internal/_helper.ts'],
+        ['index/index.ts'],
+      ),
+    ).toEqual(['_internal/_helper.ts', '_internal/index.ts'])
+  })
+
+  it('should keep every condition variant when one is reached', async () => {
+    // The variants are alternative sources for one export path, and which one an
+    // importer means depends on the condition being built.
+    expect(
+      await reachable(
+        {
+          'index.react-server.ts': `export { internal } from './_internal/index.react-server'`,
+          '_internal/index.react-server.ts': `export const internal = 'rsc'`,
+          '_internal/index.ts': `export const internal = 'default'`,
+        },
+        ['_internal/index.react-server.ts', '_internal/index.ts'],
+        ['index.react-server.ts'],
+      ),
+    ).toEqual(['_internal/index.react-server.ts', '_internal/index.ts'].sort())
+  })
+
+  it('should keep a private module named through the package name', async () => {
+    // A self-reference resolves through the package's own exports, so nothing on
+    // disk answers the specifier — but it still spells the module's name.
+    expect(
+      await reachable(
+        {
+          'index.ts': `export { internal } from 'pkg/_internal'`,
+          '_internal/index.ts': `export const internal = 1`,
+        },
+        ['_internal/index.ts'],
+        ['index.ts'],
+      ),
+    ).toEqual(['_internal/index.ts'])
+  })
+
+  it('should not treat an import inside a string as an import', async () => {
+    // The entry generates code, so it holds an import statement in a literal.
+    // Reading that as its own is how a file appears to reach what it does not —
+    // and `_target` exists, so the specifier resolves and the mistake sticks.
+    expect(
+      await reachable(
+        {
+          'index.ts': "export const template = `import { x } from './_target'`",
+          '_target.ts': `export const x = 1`,
+        },
+        ['_target.ts'],
+        ['index.ts'],
+      ),
+    ).toEqual([])
+  })
+
+  it('should keep everything when a specifier is computed', async () => {
+    expect(
+      await reachable(
+        {
+          'index.ts': `export const load = (n: string) => import('./' + n)`,
+          '_a.ts': `export const a = 1`,
+          '_b.ts': `export const b = 2`,
+        },
+        ['_a.ts', '_b.ts'],
+        ['index.ts'],
+      ),
+    ).toEqual(['_a.ts', '_b.ts'])
+  })
+
+  it('should keep everything when a file cannot be parsed', async () => {
+    expect(
+      await reachable(
+        {
+          'index.ts': `this is not ( valid ] typescript <<<`,
+          '_a.ts': `export const a = 1`,
+        },
+        ['_a.ts'],
+        ['index.ts'],
+      ),
+    ).toEqual(['_a.ts'])
   })
 })

--- a/src/entries.ts
+++ b/src/entries.ts
@@ -2,6 +2,7 @@ import { existsSync, statSync } from 'fs'
 import fsp from 'fs/promises'
 import path, { posix } from 'path'
 import { glob } from 'tinyglobby'
+import { parseSync } from '@swc/core'
 import {
   getExportTypeFromFile,
   getOutputFormat,
@@ -382,9 +383,101 @@ export async function collectSourceEntriesByExportPath(
   }
 }
 
-/** `from '...'`, `import '...'`, `import('...')`, `require('...')`. */
-const MODULE_SPECIFIER_REGEX =
-  /(?:\bfrom\s*|\bimport\s*|\brequire\s*\(\s*|\bimport\s*\(\s*)['"]([^'"]+)['"]/g
+type CollectedSpecifiers = {
+  specifiers: string[]
+  /**
+   * An `import()` or `require()` whose argument is not a literal. Nothing can be
+   * concluded about what such a call reaches, so the caller stops concluding.
+   */
+  hasComputedSpecifier: boolean
+}
+
+/** Whatever `node` and everything under it imports. */
+function walkForSpecifiers(node: any, found: CollectedSpecifiers): void {
+  if (node == null || typeof node !== 'object') return
+  if (Array.isArray(node)) {
+    for (const child of node) walkForSpecifiers(child, found)
+    return
+  }
+
+  switch (node.type) {
+    // `import x from '...'`, `export * from '...'`, `export { x } from '...'`.
+    // A named export without a source is a local re-export and has none.
+    case 'ImportDeclaration':
+    case 'ExportAllDeclaration':
+    case 'ExportNamedDeclaration': {
+      if (node.source?.type === 'StringLiteral') {
+        found.specifiers.push(node.source.value)
+      }
+      break
+    }
+    // `import x = require('...')`
+    case 'TsImportEqualsDeclaration': {
+      const expression = node.moduleRef?.expression
+      if (expression?.type === 'StringLiteral') {
+        found.specifiers.push(expression.value)
+      }
+      break
+    }
+    case 'CallExpression': {
+      const callee = node.callee
+      const isImportCall = callee?.type === 'Import'
+      const isRequireCall =
+        callee?.type === 'Identifier' && callee.value === 'require'
+      if (isImportCall || isRequireCall) {
+        const argument = node.arguments?.[0]?.expression
+        if (argument?.type === 'StringLiteral') {
+          found.specifiers.push(argument.value)
+        } else if (argument != null) {
+          found.hasComputedSpecifier = true
+        }
+      }
+      break
+    }
+  }
+
+  for (const key in node) {
+    if (key === 'span') continue
+    walkForSpecifiers(node[key], found)
+  }
+}
+
+/**
+ * What `filePath` imports, or `null` if it could not be parsed.
+ *
+ * Parsed rather than matched, because a specifier has to be told apart from text
+ * that merely looks like one: a module that generates code has import statements
+ * inside its string literals, and reading those as its own imports is how a file
+ * appears to reach something it does not.
+ */
+function collectSpecifiers(
+  code: string,
+  filePath: string,
+): CollectedSpecifiers | null {
+  const found: CollectedSpecifiers = {
+    specifiers: [],
+    hasComputedSpecifier: false,
+  }
+  const isTs = isTypescriptFile(filePath)
+  const isJsxExtension = /\.[jt]sx$/.test(filePath)
+  // `tsx` and `jsx` change how `<` is read, and the extension does not always
+  // settle it — a `.ts` file can hold JSX, and a generic arrow function in one
+  // parsed as JSX fails. Whichever the extension suggests is tried first.
+  const variants = [isJsxExtension, !isJsxExtension]
+  for (const jsxEnabled of variants) {
+    try {
+      const ast = parseSync(code, {
+        syntax: isTs ? 'typescript' : 'ecmascript',
+        [isTs ? 'tsx' : 'jsx']: jsxEnabled,
+      } as any)
+      walkForSpecifiers(ast.body, found)
+      return found
+    } catch {
+      continue
+    }
+  }
+  return null
+}
 
 function isSourceFile(filePath: string): boolean {
   // A directory answers `existsSync`, and `./_internal` meaning
@@ -429,11 +522,11 @@ function resolveRelativeSpecifier(importer: string, specifier: string) {
  * measured against — into the package's module graph and into `dist`.
  *
  * Reachability is walked over relative specifiers, which is how a module inside
- * `src` is named. A private module referenced any other way — through a
- * tsconfig path alias, or a computed `import()` — has no relative specifier
- * pointing at it, so a specifier that cannot be resolved keeps every private
- * module it could have meant. The walk only ever removes one it has positively
- * shown to be unmentioned.
+ * `src` is named. The walk only ever removes a module it has positively shown to
+ * be unmentioned, so everything it cannot account for is kept: a bare specifier
+ * that could be a tsconfig path alias keeps every private module whose
+ * underscore-prefixed segment it spells, and a file that will not parse or that
+ * computes a specifier at runtime keeps all of them.
  *
  * Runtime-condition variants of one module (`_util.js` and
  * `_util.react-server.js`) are reached as a group: the variants are alternative
@@ -465,7 +558,10 @@ async function findReachablePrivateFiles(
   }
   for (const source of entrySources) enqueue(source)
 
-  while (queue.length > 0) {
+  /** Every private module is kept once nothing can be concluded any more. */
+  let keepAll = false
+
+  while (queue.length > 0 && !keepAll) {
     const importer = queue.pop()!
     let code: string
     try {
@@ -473,8 +569,14 @@ async function findReachablePrivateFiles(
     } catch {
       continue
     }
-    for (const match of code.matchAll(MODULE_SPECIFIER_REGEX)) {
-      const specifier = match[1]
+    const found = collectSpecifiers(code, importer)
+    if (found == null || found.hasComputedSpecifier) {
+      // A file that will not parse, or one importing a path it computes at
+      // runtime, could reach anything. Stop deciding rather than decide wrong.
+      keepAll = true
+      break
+    }
+    for (const specifier of found.specifiers) {
       let resolved: string | undefined
       if (specifier.startsWith('.')) {
         resolved = resolveRelativeSpecifier(importer, specifier).find(
@@ -507,6 +609,8 @@ async function findReachablePrivateFiles(
       }
     }
   }
+
+  if (keepAll) return new Set(privateFiles)
 
   const kept = new Set<string>()
   for (const { file, group } of privateByPath.values()) {

--- a/src/entries.ts
+++ b/src/entries.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'fs'
+import { existsSync, statSync } from 'fs'
 import fsp from 'fs/promises'
 import path, { posix } from 'path'
 import { glob } from 'tinyglobby'
@@ -382,6 +382,139 @@ export async function collectSourceEntriesByExportPath(
   }
 }
 
+/** `from '...'`, `import '...'`, `import('...')`, `require('...')`. */
+const MODULE_SPECIFIER_REGEX =
+  /(?:\bfrom\s*|\bimport\s*|\brequire\s*\(\s*|\bimport\s*\(\s*)['"]([^'"]+)['"]/g
+
+function isSourceFile(filePath: string): boolean {
+  // A directory answers `existsSync`, and `./_internal` meaning
+  // `_internal/index.ts` is exactly the case that matters here — so the
+  // candidate has to be a file before it counts as resolved.
+  return statSync(filePath, { throwIfNoEntry: false })?.isFile() ?? false
+}
+
+/**
+ * Which files `specifier`, written in `importer`, could mean.
+ *
+ * Relative specifiers only — a bare one cannot name a file inside `src`. The
+ * candidates cover the ways a source file is written versus imported: the path
+ * as-is, with each source extension appended, as a directory index, and with a
+ * declared output extension swapped back to a source one (`./_utils.js` in
+ * TypeScript means `_utils.ts`).
+ */
+function resolveRelativeSpecifier(importer: string, specifier: string) {
+  const base = path.resolve(path.dirname(importer), specifier)
+  const candidates = [base]
+  for (const ext of availableExtensions) {
+    candidates.push(`${base}.${ext}`)
+    candidates.push(path.join(base, `index.${ext}`))
+  }
+  const withoutJsExt = base.replace(/\.(m|c)?js$/, '')
+  if (withoutJsExt !== base) {
+    for (const ext of availableExtensions) {
+      candidates.push(`${withoutJsExt}.${ext}`)
+    }
+  }
+  return candidates
+}
+
+/**
+ * The private modules some declared export actually reaches.
+ *
+ * A private module exists so that entries built separately can share it through
+ * one emitted file instead of each inlining a copy. One that no export reaches
+ * shares nothing, and building it is not free: a codegen script sitting in
+ * `src` next to the module it generates pulls whatever it imports —
+ * a devDependency the size of the TypeScript compiler, in the case this was
+ * measured against — into the package's module graph and into `dist`.
+ *
+ * Reachability is walked over relative specifiers, which is how a module inside
+ * `src` is named. A private module referenced any other way — through a
+ * tsconfig path alias, or a computed `import()` — has no relative specifier
+ * pointing at it, so a specifier that cannot be resolved keeps every private
+ * module it could have meant. The walk only ever removes one it has positively
+ * shown to be unmentioned.
+ *
+ * Runtime-condition variants of one module (`_util.js` and
+ * `_util.react-server.js`) are reached as a group: the variants are alternative
+ * sources for a single export path, and the one an importer names depends on
+ * the condition being built, not on which file the specifier spells.
+ */
+async function findReachablePrivateFiles(
+  sourceFolderPath: string,
+  privateFiles: string[],
+  entrySources: Iterable<string>,
+): Promise<Set<string>> {
+  /** absolute path -> the glob-relative name, and the export path it serves. */
+  const privateByPath = new Map<string, { file: string; group: string }>()
+  for (const file of privateFiles) {
+    privateByPath.set(path.join(sourceFolderPath, file), {
+      file,
+      group: stripSpecialCondition(sourceFilenameToExportFullPath(file)),
+    })
+  }
+
+  const reachableGroups = new Set<string>()
+  const visited = new Set<string>()
+  const queue: string[] = []
+
+  const enqueue = (file: string) => {
+    if (visited.has(file)) return
+    visited.add(file)
+    queue.push(file)
+  }
+  for (const source of entrySources) enqueue(source)
+
+  while (queue.length > 0) {
+    const importer = queue.pop()!
+    let code: string
+    try {
+      code = await fsp.readFile(importer, 'utf8')
+    } catch {
+      continue
+    }
+    for (const match of code.matchAll(MODULE_SPECIFIER_REGEX)) {
+      const specifier = match[1]
+      let resolved: string | undefined
+      if (specifier.startsWith('.')) {
+        resolved = resolveRelativeSpecifier(importer, specifier).find(
+          isSourceFile,
+        )
+      }
+      if (resolved) {
+        const isPrivate = privateByPath.get(resolved)
+        if (isPrivate) reachableGroups.add(isPrivate.group)
+        enqueue(resolved)
+        continue
+      }
+      // Nothing on disk answers to this specifier, so it is either external or
+      // routed through something this walk does not model — a tsconfig path
+      // alias, or the package's own name (`swr/_internal`). Both keep the file
+      // path, so a specifier meaning a private module still spells that
+      // module's underscore-prefixed segment. Keep whatever it could have meant.
+      const named = new Set(
+        specifier
+          .split('/')
+          .filter((segment) => segment.startsWith('_'))
+          .map(baseNameWithoutExtension),
+      )
+      if (named.size === 0) continue
+      for (const { file, group } of privateByPath.values()) {
+        const mentioned = file
+          .split(/[/\\]/)
+          .some((segment) => named.has(baseNameWithoutExtension(segment)))
+        if (mentioned) reachableGroups.add(group)
+      }
+    }
+  }
+
+  const kept = new Set<string>()
+  for (const { file, group } of privateByPath.values()) {
+    if (reachableGroups.has(group)) kept.add(file)
+  }
+  return kept
+}
+
 /**
  * exportsEntries {
  *   "./index" => {
@@ -444,11 +577,31 @@ export async function collectSourceEntriesFromExportPaths(
   const suffixPattern = [...runtimeExportConventions].join(',')
   const extPattern = [...availableExtensions].join(',')
   const privatePattern = `**/_*{,/*}{,{.${suffixPattern}}}.{${extPattern}}`
-  const privateFiles = await glob(privatePattern, {
+  const allPrivateFiles = await glob(privatePattern, {
     cwd: sourceFolderPath,
     ignore: [TESTS_GLOB_PATTERN],
     expandDirectories: false,
   })
+  // Only the ones a declared export reaches: see `findReachablePrivateFiles`.
+  const reachablePrivateFiles = await findReachablePrivateFiles(
+    sourceFolderPath,
+    allPrivateFiles,
+    new Set([
+      ...bins.values(),
+      ...[...exportsEntries.values()].flatMap((sources) =>
+        Object.values(sources),
+      ),
+    ]),
+  )
+  const privateFiles = allPrivateFiles.filter((file) =>
+    reachablePrivateFiles.has(file),
+  )
+  if (process.env.DEBUG && privateFiles.length !== allPrivateFiles.length) {
+    const skipped = allPrivateFiles.filter((f) => !reachablePrivateFiles.has(f))
+    logger.log(
+      `Skipping ${skipped.length} private module(s) no export reaches: ${skipped.join(', ')}`,
+    )
+  }
   const defaultPrivateModuleFormats =
     requiredPrivateModuleFormats !== ModuleFormat.none
       ? requiredPrivateModuleFormats

--- a/src/entries.ts
+++ b/src/entries.ts
@@ -538,6 +538,10 @@ export async function findReachablePrivateFiles(
   privateFiles: string[],
   entrySources: Iterable<string>,
 ): Promise<Set<string>> {
+  // Nothing to decide, and most packages are here: no private modules means no
+  // reason to read a single source file.
+  if (privateFiles.length === 0) return new Set()
+
   /** absolute path -> the glob-relative name, and the export path it serves. */
   const privateByPath = new Map<string, { file: string; group: string }>()
   for (const file of privateFiles) {

--- a/src/entries.ts
+++ b/src/entries.ts
@@ -512,31 +512,38 @@ function resolveRelativeSpecifier(importer: string, specifier: string) {
 }
 
 /**
- * The private modules some declared export actually reaches.
+ * The private modules something in `src` actually imports.
  *
- * A private module exists so that entries built separately can share it through
- * one emitted file instead of each inlining a copy. One that no export reaches
- * shares nothing, and building it is not free: a codegen script sitting in
- * `src` next to the module it generates pulls whatever it imports —
- * a devDependency the size of the TypeScript compiler, in the case this was
- * measured against — into the package's module graph and into `dist`.
+ * A private module exists so that bundles built separately can share it through
+ * one emitted file instead of each inlining a copy. One that nothing imports
+ * shares nothing, and building it is not free: a codegen script sitting in `src`
+ * next to the module it generates pulls whatever it imports — a devDependency
+ * the size of the TypeScript compiler, in the case this was measured against —
+ * into the package's module graph and into `dist`.
  *
- * Reachability is walked over relative specifiers, which is how a module inside
- * `src` is named. The walk only ever removes a module it has positively shown to
- * be unmentioned, so everything it cannot account for is kept: a bare specifier
- * that could be a tsconfig path alias keeps every private module whose
- * underscore-prefixed segment it spells, and a file that will not parse or that
- * computes a specifier at runtime keeps all of them.
+ * Answered by asking which private modules are referenced rather than by walking
+ * the graph from the entries, so no module has to be followed to reach another.
+ * That keeps a private module imported only from unreachable code, which is the
+ * safe direction and much less work: any specifier naming a private module has
+ * to spell its underscore-prefixed segment, so a file not containing that text
+ * cannot reference it and is never parsed.
+ *
+ * It only ever removes a module it has positively shown to be unreferenced.
+ * Everything it cannot account for is kept: a specifier that resolves to nothing
+ * on disk keeps every private module whose segment it spells, since it may be a
+ * tsconfig path alias or the package's own name, and a file that will not parse
+ * or that computes a specifier at runtime keeps all of them.
  *
  * Runtime-condition variants of one module (`_util.js` and
- * `_util.react-server.js`) are reached as a group: the variants are alternative
- * sources for a single export path, and the one an importer names depends on
- * the condition being built, not on which file the specifier spells.
+ * `_util.react-server.js`) are kept as a group: the variants are alternative
+ * sources for a single export path, and the one an importer means depends on the
+ * condition being built, not on which file the specifier spells.
  */
 export async function findReachablePrivateFiles(
   sourceFolderPath: string,
   privateFiles: string[],
-  entrySources: Iterable<string>,
+  /** Every source file in `src`, relative to it. */
+  sourceFiles: string[],
 ): Promise<Set<string>> {
   // Nothing to decide, and most packages are here: no private modules means no
   // reason to read a single source file.
@@ -544,60 +551,69 @@ export async function findReachablePrivateFiles(
 
   /** absolute path -> the glob-relative name, and the export path it serves. */
   const privateByPath = new Map<string, { file: string; group: string }>()
+  /**
+   * Text a specifier naming one of these modules has to contain.
+   *
+   * Every segment, not just the underscore-prefixed one: a module inside a
+   * private directory is named by its siblings relatively, so `_internal/events`
+   * is reached by `'./events'`, which says nothing about `_internal`.
+   */
+  const privateTokens = new Set<string>()
   for (const file of privateFiles) {
     privateByPath.set(path.join(sourceFolderPath, file), {
       file,
       group: stripSpecialCondition(sourceFilenameToExportFullPath(file)),
     })
+    for (const segment of file.split(/[/\\]/)) {
+      privateTokens.add(baseNameWithoutExtension(segment))
+      // `index.react-server` is also referred to as `index`.
+      privateTokens.add(segment.split('.')[0])
+    }
   }
 
-  const reachableGroups = new Set<string>()
-  const visited = new Set<string>()
-  const queue: string[] = []
+  const referencedGroups = new Set<string>()
 
-  const enqueue = (file: string) => {
-    if (visited.has(file)) return
-    visited.add(file)
-    queue.push(file)
-  }
-  for (const source of entrySources) enqueue(source)
-
-  /** Every private module is kept once nothing can be concluded any more. */
-  let keepAll = false
-
-  while (queue.length > 0 && !keepAll) {
-    const importer = queue.pop()!
+  for (const sourceFile of sourceFiles) {
+    const importer = path.join(sourceFolderPath, sourceFile)
     let code: string
     try {
       code = await fsp.readFile(importer, 'utf8')
     } catch {
       continue
     }
+    // A file mentioning none of the names cannot import one of these modules,
+    // and one with no `import(`/`require(` cannot be hiding a computed
+    // specifier — so there is nothing in it worth parsing.
+    const mightReference = [...privateTokens].some((token) =>
+      code.includes(token),
+    )
+    const mightCompute = code.includes('import(') || code.includes('require(')
+    if (!mightReference && !mightCompute) continue
+
     const found = collectSpecifiers(code, importer)
     if (found == null || found.hasComputedSpecifier) {
       // A file that will not parse, or one importing a path it computes at
-      // runtime, could reach anything. Stop deciding rather than decide wrong.
-      keepAll = true
-      break
+      // runtime, could reference anything. Stop deciding rather than decide
+      // wrong.
+      return new Set(privateFiles)
     }
+
     for (const specifier of found.specifiers) {
-      let resolved: string | undefined
-      if (specifier.startsWith('.')) {
-        resolved = resolveRelativeSpecifier(importer, specifier).find(
-          isSourceFile,
-        )
-      }
+      const resolved = specifier.startsWith('.')
+        ? resolveRelativeSpecifier(importer, specifier).find(isSourceFile)
+        : undefined
       if (resolved) {
         const isPrivate = privateByPath.get(resolved)
-        if (isPrivate) reachableGroups.add(isPrivate.group)
-        enqueue(resolved)
+        // A private module importing itself is not a reference to it.
+        if (isPrivate && resolved !== importer) {
+          referencedGroups.add(isPrivate.group)
+        }
         continue
       }
       // Nothing on disk answers to this specifier, so it is either external or
-      // routed through something this walk does not model — a tsconfig path
-      // alias, or the package's own name (`swr/_internal`). Both keep the file
-      // path, so a specifier meaning a private module still spells that
-      // module's underscore-prefixed segment. Keep whatever it could have meant.
+      // routed through something not modelled here — a tsconfig path alias, or
+      // the package's own name (`swr/_internal`). Both keep the file path, so
+      // keep whatever it could have meant.
       const named = new Set(
         specifier
           .split('/')
@@ -609,16 +625,14 @@ export async function findReachablePrivateFiles(
         const mentioned = file
           .split(/[/\\]/)
           .some((segment) => named.has(baseNameWithoutExtension(segment)))
-        if (mentioned) reachableGroups.add(group)
+        if (mentioned) referencedGroups.add(group)
       }
     }
   }
 
-  if (keepAll) return new Set(privateFiles)
-
   const kept = new Set<string>()
   for (const { file, group } of privateByPath.values()) {
-    if (reachableGroups.has(group)) kept.add(file)
+    if (referencedGroups.has(group)) kept.add(file)
   }
   return kept
 }
@@ -690,16 +704,21 @@ export async function collectSourceEntriesFromExportPaths(
     ignore: [TESTS_GLOB_PATTERN],
     expandDirectories: false,
   })
-  // Only the ones a declared export reaches: see `findReachablePrivateFiles`.
+  // Only the ones something imports: see `findReachablePrivateFiles`. Skipped
+  // entirely when the package declares no private modules, which is the common
+  // case and the only reason to list the source files at all.
+  const sourceFiles =
+    allPrivateFiles.length > 0
+      ? await glob(`**/*.{${extPattern}}`, {
+          cwd: sourceFolderPath,
+          ignore: [TESTS_GLOB_PATTERN],
+          expandDirectories: false,
+        })
+      : []
   const reachablePrivateFiles = await findReachablePrivateFiles(
     sourceFolderPath,
     allPrivateFiles,
-    new Set([
-      ...bins.values(),
-      ...[...exportsEntries.values()].flatMap((sources) =>
-        Object.values(sources),
-      ),
-    ]),
+    sourceFiles,
   )
   const privateFiles = allPrivateFiles.filter((file) =>
     reachablePrivateFiles.has(file),

--- a/src/entries.ts
+++ b/src/entries.ts
@@ -533,7 +533,7 @@ function resolveRelativeSpecifier(importer: string, specifier: string) {
  * sources for a single export path, and the one an importer names depends on
  * the condition being built, not on which file the specifier spells.
  */
-async function findReachablePrivateFiles(
+export async function findReachablePrivateFiles(
   sourceFolderPath: string,
   privateFiles: string[],
   entrySources: Iterable<string>,

--- a/src/entries.ts
+++ b/src/entries.ts
@@ -1,8 +1,7 @@
-import { existsSync, statSync } from 'fs'
+import { existsSync } from 'fs'
 import fsp from 'fs/promises'
 import path, { posix } from 'path'
 import { glob } from 'tinyglobby'
-import { parseSync } from '@swc/core'
 import {
   getExportTypeFromFile,
   getOutputFormat,
@@ -33,6 +32,10 @@ import {
   TESTS_GLOB_PATTERN,
 } from './constants'
 import { posixRelativify } from './lib/format'
+import {
+  collectSpecifiers,
+  resolveSpecifierToSourceFile,
+} from './lib/module-specifiers'
 
 export async function collectEntriesFromParsedExports(
   cwd: string,
@@ -383,134 +386,6 @@ export async function collectSourceEntriesByExportPath(
   }
 }
 
-type CollectedSpecifiers = {
-  specifiers: string[]
-  /**
-   * An `import()` or `require()` whose argument is not a literal. Nothing can be
-   * concluded about what such a call reaches, so the caller stops concluding.
-   */
-  hasComputedSpecifier: boolean
-}
-
-/** Whatever `node` and everything under it imports. */
-function walkForSpecifiers(node: any, found: CollectedSpecifiers): void {
-  if (node == null || typeof node !== 'object') return
-  if (Array.isArray(node)) {
-    for (const child of node) walkForSpecifiers(child, found)
-    return
-  }
-
-  switch (node.type) {
-    // `import x from '...'`, `export * from '...'`, `export { x } from '...'`.
-    // A named export without a source is a local re-export and has none.
-    case 'ImportDeclaration':
-    case 'ExportAllDeclaration':
-    case 'ExportNamedDeclaration': {
-      if (node.source?.type === 'StringLiteral') {
-        found.specifiers.push(node.source.value)
-      }
-      break
-    }
-    // `import x = require('...')`
-    case 'TsImportEqualsDeclaration': {
-      const expression = node.moduleRef?.expression
-      if (expression?.type === 'StringLiteral') {
-        found.specifiers.push(expression.value)
-      }
-      break
-    }
-    case 'CallExpression': {
-      const callee = node.callee
-      const isImportCall = callee?.type === 'Import'
-      const isRequireCall =
-        callee?.type === 'Identifier' && callee.value === 'require'
-      if (isImportCall || isRequireCall) {
-        const argument = node.arguments?.[0]?.expression
-        if (argument?.type === 'StringLiteral') {
-          found.specifiers.push(argument.value)
-        } else if (argument != null) {
-          found.hasComputedSpecifier = true
-        }
-      }
-      break
-    }
-  }
-
-  for (const key in node) {
-    if (key === 'span') continue
-    walkForSpecifiers(node[key], found)
-  }
-}
-
-/**
- * What `filePath` imports, or `null` if it could not be parsed.
- *
- * Parsed rather than matched, because a specifier has to be told apart from text
- * that merely looks like one: a module that generates code has import statements
- * inside its string literals, and reading those as its own imports is how a file
- * appears to reach something it does not.
- */
-function collectSpecifiers(
-  code: string,
-  filePath: string,
-): CollectedSpecifiers | null {
-  const found: CollectedSpecifiers = {
-    specifiers: [],
-    hasComputedSpecifier: false,
-  }
-  const isTs = isTypescriptFile(filePath)
-  const isJsxExtension = /\.[jt]sx$/.test(filePath)
-  // `tsx` and `jsx` change how `<` is read, and the extension does not always
-  // settle it — a `.ts` file can hold JSX, and a generic arrow function in one
-  // parsed as JSX fails. Whichever the extension suggests is tried first.
-  const variants = [isJsxExtension, !isJsxExtension]
-  for (const jsxEnabled of variants) {
-    try {
-      const ast = parseSync(code, {
-        syntax: isTs ? 'typescript' : 'ecmascript',
-        [isTs ? 'tsx' : 'jsx']: jsxEnabled,
-      } as any)
-      walkForSpecifiers(ast.body, found)
-      return found
-    } catch {
-      continue
-    }
-  }
-  return null
-}
-
-function isSourceFile(filePath: string): boolean {
-  // A directory answers `existsSync`, and `./_internal` meaning
-  // `_internal/index.ts` is exactly the case that matters here — so the
-  // candidate has to be a file before it counts as resolved.
-  return statSync(filePath, { throwIfNoEntry: false })?.isFile() ?? false
-}
-
-/**
- * Which files `specifier`, written in `importer`, could mean.
- *
- * Relative specifiers only — a bare one cannot name a file inside `src`. The
- * candidates cover the ways a source file is written versus imported: the path
- * as-is, with each source extension appended, as a directory index, and with a
- * declared output extension swapped back to a source one (`./_utils.js` in
- * TypeScript means `_utils.ts`).
- */
-function resolveRelativeSpecifier(importer: string, specifier: string) {
-  const base = path.resolve(path.dirname(importer), specifier)
-  const candidates = [base]
-  for (const ext of availableExtensions) {
-    candidates.push(`${base}.${ext}`)
-    candidates.push(path.join(base, `index.${ext}`))
-  }
-  const withoutJsExt = base.replace(/\.(m|c)?js$/, '')
-  if (withoutJsExt !== base) {
-    for (const ext of availableExtensions) {
-      candidates.push(`${withoutJsExt}.${ext}`)
-    }
-  }
-  return candidates
-}
-
 /**
  * The private modules something in `src` actually imports.
  *
@@ -599,9 +474,7 @@ export async function findReachablePrivateFiles(
     }
 
     for (const specifier of found.specifiers) {
-      const resolved = specifier.startsWith('.')
-        ? resolveRelativeSpecifier(importer, specifier).find(isSourceFile)
-        : undefined
+      const resolved = resolveSpecifierToSourceFile(importer, specifier)
       if (resolved) {
         const isPrivate = privateByPath.get(resolved)
         // A private module importing itself is not a reference to it.

--- a/src/lib/module-specifiers.test.ts
+++ b/src/lib/module-specifiers.test.ts
@@ -1,0 +1,143 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  collectSpecifiers,
+  resolveSpecifierToSourceFile,
+} from './module-specifiers'
+
+describe('collectSpecifiers', () => {
+  /** The modules `code` names, given the extension it is written in. */
+  function named(code: string, ext = 'ts'): string[] | null {
+    const found = collectSpecifiers(code, `/pkg/src/index.${ext}`)
+    return found && found.specifiers
+  }
+
+  it('should collect every static form', () => {
+    expect(
+      named(
+        [
+          `import a from './a'`,
+          `import './side-effect'`,
+          `export * from './b'`,
+          `export { c } from './c'`,
+          `import type { T } from './t'`,
+          `export type { U } from './u'`,
+          `import x = require('./legacy')`,
+        ].join('\n'),
+      ),
+    ).toEqual(['./a', './side-effect', './b', './c', './t', './u', './legacy'])
+  })
+
+  it('should collect a dynamic import wherever it appears', () => {
+    // Nested inside a function body, which is why the whole tree is walked
+    // rather than only the top-level statements.
+    const found = collectSpecifiers(
+      `export function load() { return import('./lazy') }`,
+      '/pkg/src/index.ts',
+    )
+    expect(found?.specifiers).toEqual(['./lazy'])
+    expect(found?.hasComputedSpecifier).toBe(false)
+  })
+
+  it('should report a computed specifier rather than guess at it', () => {
+    const found = collectSpecifiers(
+      `export const load = (n: string) => import('./' + n)`,
+      '/pkg/src/index.ts',
+    )
+    expect(found?.hasComputedSpecifier).toBe(true)
+  })
+
+  it('should not collect an import written inside a string', () => {
+    // A module that generates code holds import statements in its literals.
+    expect(named("export const t = `import { x } from './target'`")).toEqual([])
+    expect(named(`// import { x } from './commented'`)).toEqual([])
+  })
+
+  it('should not be confused by TypeScript that looks like other syntax', () => {
+    // A generic arrow parsed as JSX fails, and a regex holding a quote looks
+    // like the start of a specifier.
+    expect(named(`const f = <T,>(x: T) => x\nimport { a } from './a'`)).toEqual(
+      ['./a'],
+    )
+    expect(named(`const r = /['"]/g\nimport { a } from './a'`)).toEqual(['./a'])
+    expect(named(`enum E { A }\nimport { a } from './a'`)).toEqual(['./a'])
+  })
+
+  it('should read JSX in the extensions that carry it', () => {
+    const jsx = `import { a } from './a'\nexport const C = () => <div p="x">{'</div>'}</div>`
+    expect(named(jsx, 'tsx')).toEqual(['./a'])
+    expect(named(jsx, 'jsx')).toEqual(['./a'])
+  })
+
+  it('should return null for code it cannot parse', () => {
+    // Distinct from `[]`: a caller has to tell "names nothing" from "unknown".
+    expect(
+      collectSpecifiers(`this is not ( valid ] <<<`, '/pkg/src/index.ts'),
+    ).toBeNull()
+  })
+})
+
+describe('resolveSpecifierToSourceFile', () => {
+  const created: string[] = []
+
+  afterEach(() => {
+    while (created.length)
+      rmSync(created.pop()!, { recursive: true, force: true })
+  })
+
+  function writeFiles(files: string[]): string {
+    const root = mkdtempSync(path.join(tmpdir(), 'bunchee-specifier-'))
+    created.push(root)
+    for (const file of files) {
+      const target = path.join(root, file)
+      mkdirSync(path.dirname(target), { recursive: true })
+      writeFileSync(target, '')
+    }
+    return root
+  }
+
+  /** What `specifier` written in `<root>/index.ts` resolves to, relative again. */
+  function resolve(files: string[], specifier: string): string | undefined {
+    const root = writeFiles(files)
+    const resolved = resolveSpecifierToSourceFile(
+      path.join(root, 'index.ts'),
+      specifier,
+    )
+    return resolved && path.relative(root, resolved)
+  }
+
+  it('should add a source extension', () => {
+    expect(resolve(['util.ts'], './util')).toBe('util.ts')
+    expect(resolve(['util.tsx'], './util')).toBe('util.tsx')
+  })
+
+  it('should resolve a directory to its index', () => {
+    // The directory itself exists, so anything checking only for existence
+    // would stop here and never reach the file.
+    expect(resolve(['internal/index.ts'], './internal')).toBe(
+      path.join('internal', 'index.ts'),
+    )
+  })
+
+  it('should map a declared output extension back to source', () => {
+    // TypeScript source imports a sibling by the extension it will be built to.
+    expect(resolve(['util.ts'], './util.js')).toBe('util.ts')
+    expect(resolve(['util.mts'], './util.mjs')).toBe('util.mts')
+  })
+
+  it('should resolve a file that is already spelled exactly', () => {
+    expect(resolve(['util.ts'], './util.ts')).toBe('util.ts')
+  })
+
+  it('should not resolve a bare specifier', () => {
+    // It names a package, not a file, even where a same-named file exists.
+    expect(resolve(['react.ts'], 'react')).toBeUndefined()
+    expect(resolve(['internal/index.ts'], 'pkg/internal')).toBeUndefined()
+  })
+
+  it('should not resolve what is not there', () => {
+    expect(resolve(['util.ts'], './missing')).toBeUndefined()
+  })
+})

--- a/src/lib/module-specifiers.test.ts
+++ b/src/lib/module-specifiers.test.ts
@@ -77,6 +77,17 @@ describe('collectSpecifiers', () => {
       collectSpecifiers(`this is not ( valid ] <<<`, '/pkg/src/index.ts'),
     ).toBeNull()
   })
+
+  it('should give up on a tree too deep to walk', () => {
+    // Generated code nests an expression like this once per term. Deep enough
+    // and following it would overflow the stack, so it is answered as unknown
+    // rather than as a file that names nothing.
+    const shallow = `import { a } from './a'\nconst x = ${'1+'.repeat(200)}1`
+    expect(named(shallow)).toEqual(['./a'])
+
+    const deep = `import { a } from './a'\nconst x = ${'1+'.repeat(5000)}1`
+    expect(collectSpecifiers(deep, '/pkg/src/index.ts')).toBeNull()
+  })
 })
 
 describe('resolveSpecifierToSourceFile', () => {

--- a/src/lib/module-specifiers.ts
+++ b/src/lib/module-specifiers.ts
@@ -14,11 +14,26 @@ export type CollectedSpecifiers = {
   hasComputedSpecifier: boolean
 }
 
+/**
+ * How deep this will follow a tree before giving up on it.
+ *
+ * Real source sits well under a hundred levels; this is only reached by
+ * generated code, where an expression like `0+1+2+...` nests once per term.
+ * Recursing past roughly four thousand overflows the stack, and while that
+ * throws and is handled like any other unreadable file, a limit makes giving up
+ * a decision rather than a side effect of how much stack was left.
+ */
+const MAX_DEPTH = 3000
+
+/** Thrown to unwind out of a tree deeper than `MAX_DEPTH`. */
+class TooDeep extends Error {}
+
 /** Collects into `found` whatever `node` and everything under it names. */
-function walk(node: any, found: CollectedSpecifiers): void {
+function walk(node: any, found: CollectedSpecifiers, depth: number): void {
   if (node == null || typeof node !== 'object') return
+  if (depth > MAX_DEPTH) throw new TooDeep()
   if (Array.isArray(node)) {
-    for (const child of node) walk(child, found)
+    for (const child of node) walk(child, found, depth + 1)
     return
   }
 
@@ -64,7 +79,7 @@ function walk(node: any, found: CollectedSpecifiers): void {
 
   for (const key in node) {
     if (key === 'span') continue
-    walk(node[key], found)
+    walk(node[key], found, depth + 1)
   }
 }
 
@@ -85,24 +100,28 @@ export function collectSpecifiers(
   code: string,
   filePath: string,
 ): CollectedSpecifiers | null {
-  const found: CollectedSpecifiers = {
-    specifiers: [],
-    hasComputedSpecifier: false,
-  }
   const isTs = tsExtensions.has(path.extname(filePath).slice(1))
   const isJsxExtension = /\.[jt]sx$/.test(filePath)
   // `tsx` and `jsx` change how `<` is read, and the extension does not settle
   // it — a `.ts` file can hold JSX, and a generic arrow function in one parsed
   // as JSX fails. Whichever the extension suggests is tried first.
   for (const jsxEnabled of [isJsxExtension, !isJsxExtension]) {
+    // Per attempt: the first can name some of what it finds before failing part
+    // way through, and those must not be carried into the second.
+    const found: CollectedSpecifiers = {
+      specifiers: [],
+      hasComputedSpecifier: false,
+    }
     try {
       const ast = parseSync(code, {
         syntax: isTs ? 'typescript' : 'ecmascript',
         [isTs ? 'tsx' : 'jsx']: jsxEnabled,
       } as any)
-      walk(ast.body, found)
+      walk(ast.body, found, 0)
       return found
-    } catch {
+    } catch (error) {
+      // Too deep once is too deep whichever way `<` is read.
+      if (error instanceof TooDeep) return null
       continue
     }
   }

--- a/src/lib/module-specifiers.ts
+++ b/src/lib/module-specifiers.ts
@@ -1,0 +1,156 @@
+import { statSync } from 'fs'
+import path from 'path'
+import { parseSync } from '@swc/core'
+import { availableExtensions, tsExtensions } from '../constants'
+
+export type CollectedSpecifiers = {
+  /** Every module named by a literal specifier. */
+  specifiers: string[]
+  /**
+   * An `import()` or `require()` whose argument is not a literal. What such a
+   * call names is not knowable from the source, so a caller reasoning about
+   * which modules are reached has to stop concluding.
+   */
+  hasComputedSpecifier: boolean
+}
+
+/** Collects into `found` whatever `node` and everything under it names. */
+function walk(node: any, found: CollectedSpecifiers): void {
+  if (node == null || typeof node !== 'object') return
+  if (Array.isArray(node)) {
+    for (const child of node) walk(child, found)
+    return
+  }
+
+  switch (node.type) {
+    // `import x from '...'`, `export * from '...'`, `export { x } from '...'`,
+    // and their type-only forms. A named export with no source is a local
+    // re-export and names nothing.
+    case 'ImportDeclaration':
+    case 'ExportAllDeclaration':
+    case 'ExportNamedDeclaration': {
+      if (node.source?.type === 'StringLiteral') {
+        found.specifiers.push(node.source.value)
+      }
+      break
+    }
+    // `import x = require('...')`
+    case 'TsImportEqualsDeclaration': {
+      const expression = node.moduleRef?.expression
+      if (expression?.type === 'StringLiteral') {
+        found.specifiers.push(expression.value)
+      }
+      break
+    }
+    // `import('...')` and `require('...')`, which can appear anywhere an
+    // expression can — so this is why the whole tree is walked rather than just
+    // the top-level statements the static forms are limited to.
+    case 'CallExpression': {
+      const callee = node.callee
+      const isImportCall = callee?.type === 'Import'
+      const isRequireCall =
+        callee?.type === 'Identifier' && callee.value === 'require'
+      if (isImportCall || isRequireCall) {
+        const argument = node.arguments?.[0]?.expression
+        if (argument?.type === 'StringLiteral') {
+          found.specifiers.push(argument.value)
+        } else if (argument != null) {
+          found.hasComputedSpecifier = true
+        }
+      }
+      break
+    }
+  }
+
+  for (const key in node) {
+    if (key === 'span') continue
+    walk(node[key], found)
+  }
+}
+
+/**
+ * The modules `code` names, or `null` if it could not be parsed.
+ *
+ * Parsed rather than matched, because a specifier has to be told apart from text
+ * that only looks like one: a module that generates code holds import statements
+ * inside its string literals, and reading those as its own is how a file appears
+ * to reach something it does not.
+ *
+ * A lexer that only extracts specifiers would be cheaper, but the ones available
+ * answer a file they cannot handle with an empty list rather than an error —
+ * indistinguishable from a file that imports nothing. Returning `null` on
+ * failure is the point: a caller can tell "names nothing" from "unknown".
+ */
+export function collectSpecifiers(
+  code: string,
+  filePath: string,
+): CollectedSpecifiers | null {
+  const found: CollectedSpecifiers = {
+    specifiers: [],
+    hasComputedSpecifier: false,
+  }
+  const isTs = tsExtensions.has(path.extname(filePath).slice(1))
+  const isJsxExtension = /\.[jt]sx$/.test(filePath)
+  // `tsx` and `jsx` change how `<` is read, and the extension does not settle
+  // it — a `.ts` file can hold JSX, and a generic arrow function in one parsed
+  // as JSX fails. Whichever the extension suggests is tried first.
+  for (const jsxEnabled of [isJsxExtension, !isJsxExtension]) {
+    try {
+      const ast = parseSync(code, {
+        syntax: isTs ? 'typescript' : 'ecmascript',
+        [isTs ? 'tsx' : 'jsx']: jsxEnabled,
+      } as any)
+      walk(ast.body, found)
+      return found
+    } catch {
+      continue
+    }
+  }
+  return null
+}
+
+function isFile(filePath: string): boolean {
+  // A directory answers `existsSync`, and `'./_internal'` meaning
+  // `_internal/index.ts` is exactly the case that matters — so a candidate has
+  // to be a file before it counts as resolved.
+  return statSync(filePath, { throwIfNoEntry: false })?.isFile() ?? false
+}
+
+/**
+ * The source file `specifier`, written in `importer`, resolves to.
+ *
+ * `undefined` when nothing on disk answers to it, which covers both a bare
+ * specifier — those name a package, not a file in the source folder — and a
+ * relative one routed through something not modelled here, such as a tsconfig
+ * path alias.
+ *
+ * The candidates cover the ways a source file is written versus imported: the
+ * path as-is, with each source extension appended, as a directory index, and
+ * with a declared output extension swapped back to a source one (`'./_utils.js'`
+ * in TypeScript means `_utils.ts`).
+ */
+export function resolveSpecifierToSourceFile(
+  importer: string,
+  specifier: string,
+): string | undefined {
+  if (!specifier.startsWith('.')) return undefined
+
+  const base = path.resolve(path.dirname(importer), specifier)
+  if (isFile(base)) return base
+
+  for (const ext of availableExtensions) {
+    const withExtension = `${base}.${ext}`
+    if (isFile(withExtension)) return withExtension
+    const asDirectoryIndex = path.join(base, `index.${ext}`)
+    if (isFile(asDirectoryIndex)) return asDirectoryIndex
+  }
+
+  const withoutJsExtension = base.replace(/\.(m|c)?js$/, '')
+  if (withoutJsExtension !== base) {
+    for (const ext of availableExtensions) {
+      const candidate = `${withoutJsExtension}.${ext}`
+      if (isFile(candidate)) return candidate
+    }
+  }
+  return undefined
+}

--- a/src/lib/worker-pool.ts
+++ b/src/lib/worker-pool.ts
@@ -11,6 +11,20 @@ import { logger, pauseActiveSpinner } from '../logger'
 // fits comfortably in one heap, and skipping the pool avoids worker startup.
 export const MIN_ENTRIES_FOR_WORKERS = 8
 
+/**
+ * The entry count at which a *merged* build is worth fanning out.
+ *
+ * Merging already collapses the work to a few graphs, so the only thing left to
+ * split is the declaration emit — and a worker cannot start without its own copy
+ * of rollup and of the TypeScript compiler API. Measured on `pkg-N` fixtures,
+ * that startup outweighs the split until somewhere past 256 entries: staying in
+ * this process ran 1.29x faster at 8 entries, 1.17x at 64, 1.02x at 256, and
+ * 0.95x at 512. Memory moves the other way throughout — one heap held 20-47%
+ * less than the pool did — so the threshold sits at the far end of the range,
+ * where sharding starts winning on time by enough to pay for the memory.
+ */
+export const MIN_ENTRIES_FOR_MERGED_WORKERS = 256
+
 export function availableCores(): number {
   return Math.max(1, (os.availableParallelism?.() ?? os.cpus().length) - 1)
 }

--- a/src/plugins/alias-plugin.ts
+++ b/src/plugins/alias-plugin.ts
@@ -116,38 +116,33 @@ function findTypesFileCallback({
  */
 const SIBLING_MARK = '\0bunchee-sibling:'
 
-// Alias entry key to dist bundle path
-export function aliasEntries({
-  entry: sourceFilePath,
-  exportCondition,
+/**
+ * Where each entry's source lands in `dist`, for the output being built.
+ *
+ * The choice depends on the output format, so this is also what decides whether
+ * two outputs can share one module graph: if the map is the same for both, the
+ * plugin rewrites imports identically and the graph does not depend on which
+ * output follows it.
+ */
+export function buildSourceToBundleMap({
   entries,
-  isESMPkg,
   format,
+  isESMPkg,
+  exportCondition,
   dts,
-  cwd,
-  mergedSources,
 }: {
-  entry: string
   entries: Entries
   format: OutputOptions['format']
   isESMPkg: boolean
   exportCondition: ParsedExportCondition
   dts: boolean
-  cwd: string
-  /**
-   * The sources this build owns as inputs. When set, the build is a merged one:
-   * rollup emits the references between these itself, and only entries outside
-   * the set need rewriting to a `<dist>` path.
-   */
-  mergedSources?: Set<string>
-}): Plugin {
+}): Map<string, string> {
   const currentConditionNames = new Set(
     exportCondition.targets[0]?.conditions ?? [],
   )
-
   // <imported source file path>: <relative path to source's bundle>
   const sourceToRelativeBundleMap = new Map<string, string>()
-  let specialCondition = getSpecialExportTypeFromConditionNames(
+  const specialCondition = getSpecialExportTypeFromConditionNames(
     currentConditionNames,
   )
   for (const [, exportCondition] of Object.entries(entries)) {
@@ -186,6 +181,41 @@ export function aliasEntries({
         sourceToRelativeBundleMap.set(exportCondition.source, matchedBundlePath)
     }
   }
+  return sourceToRelativeBundleMap
+}
+
+// Alias entry key to dist bundle path
+export function aliasEntries({
+  entry: sourceFilePath,
+  exportCondition,
+  entries,
+  isESMPkg,
+  format,
+  dts,
+  cwd,
+  mergedSources,
+}: {
+  entry: string
+  entries: Entries
+  format: OutputOptions['format']
+  isESMPkg: boolean
+  exportCondition: ParsedExportCondition
+  dts: boolean
+  cwd: string
+  /**
+   * The sources this build owns as inputs. When set, the build is a merged one:
+   * rollup emits the references between these itself, and only entries outside
+   * the set need rewriting to a `<dist>` path.
+   */
+  mergedSources?: Set<string>
+}): Plugin {
+  const sourceToRelativeBundleMap = buildSourceToBundleMap({
+    entries,
+    format,
+    isESMPkg,
+    exportCondition,
+    dts,
+  })
 
   if (mergedSources) {
     return {

--- a/src/plugins/alias-plugin.ts
+++ b/src/plugins/alias-plugin.ts
@@ -117,6 +117,30 @@ function findTypesFileCallback({
 const SIBLING_MARK = '\0bunchee-sibling:'
 
 /**
+ * The format the alias map is chosen by, for one output file.
+ *
+ * Not the rollup output format: declarations are always generated as ESM, so
+ * which sibling declaration an import should point at is carried by the
+ * extension instead — `.d.cts`, or `.d.ts` in a CJS package, means the CJS one.
+ */
+export function getAliasFormat({
+  dts,
+  file,
+  format,
+  isESMPkg,
+}: {
+  dts: boolean
+  file: string | undefined
+  format: OutputOptions['format']
+  isESMPkg: boolean
+}): OutputOptions['format'] {
+  if (!dts) return format
+  const isCjsTypes =
+    file?.endsWith('.d.cts') || (file?.endsWith('.d.ts') && !isESMPkg)
+  return isCjsTypes ? 'cjs' : 'esm'
+}
+
+/**
  * Where each entry's source lands in `dist`, for the output being built.
  *
  * The choice depends on the output format, so this is also what decides whether

--- a/src/rollup-job.ts
+++ b/src/rollup-job.ts
@@ -89,7 +89,9 @@ export async function createMergedRollupJobs(
   // an earlier job's output.
   if (options.clean && !isFromCli) {
     for (const config of allConfigs) {
-      await removeOutputDir(config.output, buildContext.cwd)
+      for (const output of config.output) {
+        await removeOutputDir(output, buildContext.cwd)
+      }
     }
   }
 
@@ -97,7 +99,8 @@ export async function createMergedRollupJobs(
     const shape = allConfigs
       .map(
         (config) =>
-          `${Object.keys(config.input).length} inputs -> ${config.output.format}`,
+          `${Object.keys(config.input).length} inputs -> ` +
+          config.output.map((output) => output.format).join('+'),
       )
       .join(' | ')
     logger.log(
@@ -122,7 +125,10 @@ export async function createMergedRollupJobs(
   }
 }
 
-async function runMergedBundle({ output, ...restOptions }: MergedRollupConfig) {
+async function runMergedBundle({
+  output: outputs,
+  ...restOptions
+}: MergedRollupConfig) {
   let bundle: RollupBuild
   const debug = Boolean(process.env.DEBUG)
   const started = Date.now()
@@ -135,12 +141,17 @@ async function runMergedBundle({ output, ...restOptions }: MergedRollupConfig) {
     logMergedGraph(bundle, Object.keys(restOptions.input).length, started)
   }
   try {
-    const writeStart = Date.now()
-    const result = await bundle.write(output)
-    if (debug) {
-      logger.log(`  write ${output.format}: ${Date.now() - writeStart}ms`)
+    // One graph, written once per output: the parse and transform work behind it
+    // is not repeated for the second format.
+    const results = []
+    for (const output of outputs) {
+      const writeStart = Date.now()
+      results.push(await bundle.write(output))
+      if (debug) {
+        logger.log(`  write ${output.format}: ${Date.now() - writeStart}ms`)
+      }
     }
-    return result
+    return results
   } finally {
     await bundle.close()
   }

--- a/src/rollup/input.ts
+++ b/src/rollup/input.ts
@@ -21,7 +21,7 @@ import { esmShim } from '../plugins/esm-shim'
 import { inlineCss } from '../plugins/inline-css'
 import { rawContent } from '../plugins/raw-plugin'
 import { nativeAddon } from '../plugins/native-addon-plugin'
-import { aliasEntries } from '../plugins/alias-plugin'
+import { aliasEntries, getAliasFormat } from '../plugins/alias-plugin'
 import { prependShebang } from '../plugins/prepend-shebang'
 import { swcHelpersWarningPlugin } from '../plugins/swc-helpers-warning-plugin'
 import { memoizeByKey } from '../lib/memoize'
@@ -221,13 +221,12 @@ export async function buildInputConfig(
 
   // common plugins for both dts and ts assets that need to be processed
 
-  // If it's a .d.ts file under non-ESM package or .d.cts file, use cjs types alias.
-  const aliasFormat = dts
-    ? bundleConfig.file?.endsWith('.d.cts') ||
-      (bundleConfig.file?.endsWith('.d.ts') && !isESModulePackage(pkg.type))
-      ? 'cjs'
-      : 'esm'
-    : bundleConfig.format
+  const aliasFormat = getAliasFormat({
+    dts,
+    file: bundleConfig.file,
+    format: bundleConfig.format,
+    isESMPkg: isESModulePackage(pkg.type),
+  })
 
   const aliasPlugin = aliasEntries({
     entry,

--- a/src/rollup/merged-config.ts
+++ b/src/rollup/merged-config.ts
@@ -11,7 +11,7 @@ import type {
 import type { ExportOutput } from '../exports'
 import { buildInputConfig } from './input'
 import { buildOutputConfigs } from './output'
-import { buildSourceToBundleMap } from '../plugins/alias-plugin'
+import { buildSourceToBundleMap, getAliasFormat } from '../plugins/alias-plugin'
 import { getEntryBundleOutputs } from '../build-config'
 import { isESModulePackage, normalizePath } from '../utils'
 import { getSpecialExportTypeFromConditionNames } from '../entries'
@@ -249,7 +249,14 @@ function coalesceGroups(
     )
     const map = buildSourceToBundleMap({
       entries,
-      format: representative.output.format,
+      // The format the plugin will actually be given, which for declarations is
+      // decided by the extension rather than by the rollup output format.
+      format: getAliasFormat({
+        dts,
+        file: representative.output.file,
+        format: representative.output.format,
+        isESMPkg,
+      }),
       isESMPkg,
       exportCondition: {
         ...representative.exportCondition,

--- a/src/rollup/merged-config.ts
+++ b/src/rollup/merged-config.ts
@@ -1,4 +1,5 @@
 import { dirname, relative, resolve, sep } from 'path'
+import type { OutputOptions } from 'rollup'
 import type {
   BuildContext,
   BundleConfig,
@@ -10,8 +11,9 @@ import type {
 import type { ExportOutput } from '../exports'
 import { buildInputConfig } from './input'
 import { buildOutputConfigs } from './output'
+import { buildSourceToBundleMap } from '../plugins/alias-plugin'
 import { getEntryBundleOutputs } from '../build-config'
-import { normalizePath } from '../utils'
+import { isESModulePackage, normalizePath } from '../utils'
 import { getSpecialExportTypeFromConditionNames } from '../entries'
 import { getDefinedInlineVariables } from '../env'
 import { logger } from '../logger'
@@ -25,6 +27,13 @@ type GroupItem = {
 type Group = {
   /** Debug label; also the map key that collects the group. */
   key: string
+  /**
+   * The parts of the key that describe the *input* graph rather than how it is
+   * written: the inlined env, the condition imports resolve through, and which
+   * occurrence of that shape this is. Groups agreeing here are candidates for
+   * sharing one graph.
+   */
+  graphKey: string
   items: GroupItem[]
   /** Absolute output file -> the source that claimed it. */
   claimed: Map<string, string>
@@ -132,10 +141,7 @@ export async function buildMergedConfigs(
     )
     const seen = new Map<string, number>()
     for (const output of outputs) {
-      const shape = [
-        dts ? 'dts' : 'js',
-        output.format,
-        outputExtension(output.file),
+      const graphShape = [
         JSON.stringify(env),
         // Which sibling bundle an import resolves to is decided per runtime or
         // optimize condition, so entries only share a graph with entries that
@@ -143,6 +149,12 @@ export async function buildMergedConfigs(
         getSpecialExportTypeFromConditionNames(
           new Set(output.target.conditions),
         ),
+      ]
+      const shape = [
+        dts ? 'dts' : 'js',
+        output.format,
+        outputExtension(output.file),
+        ...graphShape,
       ].join('|')
       const occurrence = seen.get(shape) ?? 0
       seen.set(shape, occurrence + 1)
@@ -157,6 +169,7 @@ export async function buildMergedConfigs(
         const key = attempt === 0 ? shape : `${shape}|#${attempt}`
         const candidate = groups.get(key) ?? {
           key,
+          graphKey: JSON.stringify([...graphShape, attempt]),
           items: [],
           claimed: new Map(),
         }
@@ -187,12 +200,94 @@ export async function buildMergedConfigs(
   }
 
   const configs: MergedRollupConfig[] = []
-  for (const group of groups.values()) {
+  for (const graph of coalesceGroups([...groups.values()], buildContext, dts)) {
     configs.push(
-      await buildMergedConfig(group, bundleConfig, buildContext, dts),
+      await buildMergedConfig(graph, bundleConfig, buildContext, dts),
     )
   }
   return configs
+}
+
+/** The input name -> source pairs a group builds, in a comparable form. */
+function inputSignature(group: Group): string {
+  return JSON.stringify(
+    group.items
+      .map((item) => [
+        toInputName(item.exportPath),
+        item.exportCondition.source,
+      ])
+      .sort(),
+  )
+}
+
+/**
+ * Groups that differ only in what they are written as, collapsed into one graph.
+ *
+ * A package that publishes both `import` and `require` describes the same
+ * entries twice, and the two only diverge once rollup starts generating: the
+ * modules parsed, transformed and tree-shaken to get there are the same work.
+ * Built as separate groups that work is done once per format.
+ *
+ * Two groups can share a graph when they take the same inputs and the alias
+ * plugin would rewrite them the same way. The second condition is what keeps
+ * this honest: which sibling bundle an import of an entry outside the graph
+ * resolves to is chosen per format, so groups whose maps disagree still get a
+ * graph each.
+ */
+function coalesceGroups(
+  groups: Group[],
+  buildContext: BuildContext,
+  dts: boolean,
+): Group[][] {
+  const { entries, pkg } = buildContext
+  const isESMPkg = isESModulePackage(pkg.type)
+
+  const aliasSignature = (group: Group): string => {
+    const [representative] = group.items
+    const owned = new Set(
+      group.items.map((item) => item.exportCondition.source),
+    )
+    const map = buildSourceToBundleMap({
+      entries,
+      format: representative.output.format,
+      isESMPkg,
+      exportCondition: {
+        ...representative.exportCondition,
+        targets: [representative.output.target],
+      },
+      dts,
+    })
+    // An input of this graph is emitted by rollup as a chunk, so its entry in
+    // the map is never read. Only the sources this graph does not own get
+    // rewritten, and only those have to agree between the two outputs.
+    return JSON.stringify(
+      [...map].filter(([source]) => !owned.has(source)).sort(),
+    )
+  }
+
+  const graphs = new Map<string, Group[]>()
+  for (const group of groups) {
+    const key = JSON.stringify([
+      group.graphKey,
+      inputSignature(group),
+      aliasSignature(group),
+    ])
+    const existing = graphs.get(key)
+    if (existing) existing.push(group)
+    else graphs.set(key, [group])
+  }
+
+  if (process.env.DEBUG) {
+    for (const members of graphs.values()) {
+      if (members.length > 1) {
+        logger.log(
+          `Sharing one graph across ${members.length} outputs: ` +
+            members.map((member) => member.key).join(' + '),
+        )
+      }
+    }
+  }
+  return [...graphs.values()]
 }
 
 /**
@@ -241,34 +336,26 @@ export function shardEntries(names: string[], count: number): string[][] {
 }
 
 async function buildMergedConfig(
-  group: Group,
+  /**
+   * The groups sharing this graph — one per output. They take the same inputs,
+   * so only where each entry lands differs between them.
+   */
+  graph: Group[],
   bundleConfig: BundleConfig,
   buildContext: BuildContext,
   dts: boolean,
 ): Promise<MergedRollupConfig> {
   const { cwd } = buildContext
-  const { items } = group
+  const [primary] = graph
 
   const input: Record<string, string> = {}
-  /** input name -> absolute output file */
-  const outputFiles = new Map<string, string>()
-  /**
-   * Same, keyed by source. Rollup sanitises an input name before it reaches
-   * `chunk.name` — a bin entry's `$binary` arrives as `_binary` — so the source
-   * behind the chunk is the reliable way back to its output path.
-   */
-  const outputFilesBySource = new Map<string, string>()
-  for (const item of items) {
-    const name = toInputName(item.exportPath)
-    const file = resolve(cwd, item.output.file)
-    input[name] = item.exportCondition.source
-    outputFiles.set(name, file)
-    outputFilesBySource.set(item.exportCondition.source, file)
+  for (const item of primary.items) {
+    input[toInputName(item.exportPath)] = item.exportCondition.source
   }
 
-  // The first entry stands in for the group when building the options shared
-  // across it: format, sourcemap, interop, chunk naming.
-  const [representative] = items
+  // The first entry of the first group stands in for the graph when building the
+  // options shared across it: format, sourcemap, interop, chunk naming.
+  const [representative] = primary.items
   const representativeCondition: ParsedExportCondition = {
     ...representative.exportCondition,
     targets: [representative.output.target],
@@ -288,20 +375,41 @@ async function buildMergedConfig(
     input,
   )
 
-  const outputOptions = await buildOutputConfigs(
-    representativeBundleConfig,
-    representativeCondition,
-    buildContext,
-    dts,
-    true,
-  )
+  const output: OutputOptions[] = []
+  for (const group of graph) {
+    const [groupRepresentative] = group.items
+    /** input name -> absolute output file */
+    const outputFiles = new Map<string, string>()
+    /**
+     * Same, keyed by source. Rollup sanitises an input name before it reaches
+     * `chunk.name` — a bin entry's `$binary` arrives as `_binary` — so the
+     * source behind the chunk is the reliable way back to its output path.
+     */
+    const outputFilesBySource = new Map<string, string>()
+    for (const item of group.items) {
+      const file = resolve(cwd, item.output.file)
+      outputFiles.set(toInputName(item.exportPath), file)
+      outputFilesBySource.set(item.exportCondition.source, file)
+    }
 
-  const dir = commonRootDir([...outputFiles.values()].map((f) => dirname(f)))
+    const groupBundleConfig: BundleConfig = {
+      ...bundleConfig,
+      file: groupRepresentative.output.file,
+      format: groupRepresentative.output.format,
+    }
+    const outputOptions = await buildOutputConfigs(
+      groupBundleConfig,
+      {
+        ...groupRepresentative.exportCondition,
+        targets: [groupRepresentative.output.target],
+      },
+      buildContext,
+      dts,
+      true,
+    )
 
-  return {
-    ...inputOptions,
-    input,
-    output: {
+    const dir = commonRootDir([...outputFiles.values()].map((f) => dirname(f)))
+    output.push({
       ...outputOptions,
       dir,
       // Each entry keeps the exact path its export condition declares, which
@@ -318,6 +426,8 @@ async function buildMergedConfig(
         }
         return normalizePath(relative(dir, file))
       },
-    },
+    })
   }
+
+  return { ...inputOptions, input, output }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,10 +118,15 @@ type BuncheeRollupConfig = CustomRollupInputOptions & {
   output: OutputOptions
 }
 
-/** One rollup build shared by many entries: a single module graph, one output. */
+/** One rollup build shared by many entries: a single module graph. */
 type MergedRollupConfig = CustomRollupInputOptions & {
   input: Record<string, string>
-  output: OutputOptions
+  /**
+   * One per file set this graph is written as. More than one when the same
+   * inputs are emitted in several formats — the graph is built once and written
+   * per output, the way a rollup config with an `output` array behaves.
+   */
+  output: OutputOptions[]
 }
 
 type CliArgs = {

--- a/test/integration/many-entries/index.test.ts
+++ b/test/integration/many-entries/index.test.ts
@@ -8,7 +8,10 @@ import {
 import { executeBunchee } from '../../testing-utils/shared'
 
 // Nine entries, above MIN_ENTRIES_FOR_WORKERS, with no directive layers: this
-// is the fixture that merges the JS into one graph and shards the types.
+// is the fixture that merges every entry into one graph per output. Being over
+// the worker threshold, it is also what catches a merged build fanning out to
+// workers it cannot profit from. The worker path itself is covered by
+// `many-entries-cli`, where a CLI entry file blocks merging.
 const dir = __dirname
 const distDir = path.join(dir, 'dist')
 
@@ -59,15 +62,22 @@ describe('integration - many-entries', () => {
     expect(contents['index.js']).not.toContain(`'a:'`)
   }, 120_000)
 
-  it('should build the JS as one graph and shard the types', async () => {
+  it('should build the JS and the types as one graph each', async () => {
     const { stdout } = await build({ DEBUG: '1' })
 
     // Nine entries with a types output each would be 18 rollup instances if
-    // every entry were built on its own.
-    expect(stdout).toMatch(/Building 9 entries in 1 shared rollup instances/)
-    expect(stdout).toMatch(
-      /Building 9 entries in \d+ worker threads \(\d+ shards of ~\d+\)/,
-    )
+    // every entry were built on its own. One graph for the JS, one for the
+    // declarations.
+    expect(stdout).toMatch(/Building 9 entries in 2 shared rollup instances/)
+  }, 120_000)
+
+  it('should not fan out to workers once the entries are merged', async () => {
+    const { stdout } = await build({ DEBUG: '1' })
+
+    // A worker cannot start without its own copy of rollup and of the
+    // TypeScript compiler API, which costs more than splitting two graphs
+    // across threads saves at any entry count measured.
+    expect(stdout).not.toContain('worker threads')
   }, 120_000)
 
   it('should emit code shared between entries as a single chunk', async () => {
@@ -88,25 +98,10 @@ describe('integration - many-entries', () => {
   it('should emit a declaration file per entry', async () => {
     const { contents } = await build()
 
-    // The types are sharded across workers, so this is what catches a shard
-    // dropping the entries it was handed.
+    // Every entry shares one declaration graph, so this is what catches an
+    // entry being dropped from it.
     for (const entry of ENTRIES) {
       expect(contents[`${entry}.d.ts`]).toContain(`declare const ${entry}`)
     }
   }, 120_000)
-
-  it('should produce the same output as an in-process build', async () => {
-    const workers = await build({ DEBUG: '1' })
-    const inProcess = await build({ DEBUG: '1', TEST_NO_WORKERS: '1' })
-
-    // Guard the comparison: it only means anything if the first build really
-    // did fan out. Runs from source and from dist resolve the worker file
-    // differently, so this has to hold for both.
-    expect(workers.stdout).toMatch(/Building 9 entries in \d+ worker threads/)
-    expect(inProcess.stdout).not.toContain('worker threads')
-
-    // Types sharded across workers against one merged graph in this process.
-    expect(inProcess.files).toEqual(workers.files)
-    expect(inProcess.contents).toEqual(workers.contents)
-  }, 240_000)
 })

--- a/test/integration/merged-shared-graph/index.test.ts
+++ b/test/integration/merged-shared-graph/index.test.ts
@@ -1,0 +1,49 @@
+import path from 'path'
+import { describe, expect, it } from 'vitest'
+import {
+  getFileContents,
+  getFileNamesFromDirectory,
+  removeDirectory,
+} from '../../testing-utils'
+import { executeBunchee } from '../../testing-utils/shared'
+
+// Two entries published as both `import` and `require`. The two formats describe
+// the same entries, so the modules behind them are parsed, transformed and
+// tree-shaken once and the graph is written twice.
+const distDir = path.join(__dirname, 'dist')
+
+async function build(env: NodeJS.ProcessEnv = {}) {
+  await removeDirectory(distDir)
+  const result = await executeBunchee(['--cwd', __dirname], { env })
+  expect(result.stderr).toBe('')
+  expect(result.code).toBe(0)
+  return {
+    stdout: result.stdout,
+    files: await getFileNamesFromDirectory(distDir),
+    contents: await getFileContents(distDir),
+  }
+}
+
+describe('integration - merged-shared-graph', () => {
+  it('should build one graph and write it as both formats', async () => {
+    const { stdout } = await build({ DEBUG: '1' })
+
+    expect(stdout).toMatch(/Sharing one graph across 2 outputs/)
+    expect(stdout).toMatch(/2 inputs -> esm\+cjs/)
+  }, 120_000)
+
+  it('should emit both formats with the shared module as a chunk', async () => {
+    const { files, contents } = await build()
+
+    // One chunk per format, rather than a copy of `shared` inlined into each of
+    // the four entry files.
+    const chunks = files.filter((file) => file.startsWith('shared-'))
+    expect(chunks).toHaveLength(2)
+
+    for (const file of ['index.mjs', 'index.js', 'other.mjs', 'other.js']) {
+      expect(files).toContain(file)
+      expect(contents[file]).toContain('shared-')
+      expect(contents[file]).not.toContain(`= 'shared'`)
+    }
+  }, 120_000)
+})

--- a/test/integration/merged-shared-graph/package.json
+++ b/test/integration/merged-shared-graph/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "merged-shared-graph",
+  "version": "0.0.0",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    },
+    "./other": {
+      "import": "./dist/other.mjs",
+      "require": "./dist/other.js"
+    }
+  }
+}

--- a/test/integration/merged-shared-graph/src/index.js
+++ b/test/integration/merged-shared-graph/src/index.js
@@ -1,0 +1,3 @@
+import { shared } from './shared'
+
+export const index = `index:${shared}`

--- a/test/integration/merged-shared-graph/src/other.js
+++ b/test/integration/merged-shared-graph/src/other.js
@@ -1,0 +1,3 @@
+import { shared } from './shared'
+
+export const other = `other:${shared}`

--- a/test/integration/merged-shared-graph/src/shared.js
+++ b/test/integration/merged-shared-graph/src/shared.js
@@ -1,0 +1,1 @@
+export const shared = 'shared'

--- a/test/integration/private-module-unreachable/index.test.ts
+++ b/test/integration/private-module-unreachable/index.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assertFilesContent,
+  createJob,
+  getFileNamesFromDirectory,
+} from '../../testing-utils'
+
+// `_`-prefixed files are built so that entries can share one emitted copy of a
+// module. `src/_codegen.js` is shared by nothing — it is a build-time script —
+// so building it would only add its imports to the module graph and its output
+// to dist.
+describe('integration private-module-unreachable', () => {
+  const { distDir } = createJob({ directory: __dirname })
+
+  it('should build only the private module an export reaches', async () => {
+    expect(await getFileNamesFromDirectory(distDir)).toEqual([
+      '_shared.js',
+      'used.js',
+    ])
+  })
+
+  it('should still link the reached private module', async () => {
+    await assertFilesContent(distDir, {
+      'used.js': `'./_shared.js'`,
+    })
+  })
+})

--- a/test/integration/private-module-unreachable/package.json
+++ b/test/integration/private-module-unreachable/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "private-module-unreachable",
+  "type": "module",
+  "exports": {
+    "./used": "./dist/used.js"
+  }
+}

--- a/test/integration/private-module-unreachable/src/_codegen.js
+++ b/test/integration/private-module-unreachable/src/_codegen.js
@@ -1,0 +1,10 @@
+// A build-time script: nothing in the package imports it, and it is only ever
+// run by hand. Its own imports must not reach the package's module graph, and
+// the import statement it emits as text is not one of its imports.
+import { readFileSync } from 'fs'
+
+export const template = `export { shared } from './_shared'`
+
+export function generate(from) {
+  return readFileSync(from, 'utf8') + template
+}

--- a/test/integration/private-module-unreachable/src/_shared.js
+++ b/test/integration/private-module-unreachable/src/_shared.js
@@ -1,0 +1,1 @@
+export const shared = 'shared'

--- a/test/integration/private-module-unreachable/src/used.js
+++ b/test/integration/private-module-unreachable/src/used.js
@@ -1,0 +1,3 @@
+export { shared } from './_shared'
+
+export const used = 'used'


### PR DESCRIPTION
## The problem

Three things made builds do more work than they needed to, none specific to one package.

**1. Private modules nothing imports were still built.** Any `_`-prefixed file under `src` becomes a build entry. The convention lets separately-built entries share a module through one emitted file — but a module nothing imports shares nothing, and it isn't free: it's a rollup input, so its imports enter the module graph and its output lands in `dist`.

This bites hardest on build-time scripts, which tend to sit next to whatever they generate, get named with a leading underscore, and import tooling. Only `dependencies` and `peerDependencies` are external, so a `devDependency` reached that way gets bundled. In one case such a script imported the TypeScript compiler: 8.9MB entered the graph, got wrapped by `@rollup/plugin-commonjs`, and defeated tree-shaking well enough that `includeUnknownTest` alone cost 1.6s — all of it twice, once per format. It shipped in `dist` too.

**2. The same graph was built once per output format.** A package publishing both `import` and `require` describes the same entries twice. They only diverge once rollup starts generating; the parse, transform and tree-shake work to get there is identical, and was being repeated.

**3. Merged builds fanned out to workers that couldn't pay for themselves.** Merging leaves only the declaration emit to split, and a worker must first load its own copy of rollup and of the TypeScript API. Below `typeShardCount`'s minimum it was pure overhead — one shard, one worker, doing what the main process would have done anyway.

## The fix

**Check reachability before deciding entries.** Walk from the declared exports, parsing each file with swc, and keep only the private modules something actually reaches. `_` then means what it is usually read as: emitted when something shares it.

The walk only drops what it can prove unmentioned; anything ambiguous is kept — a bare specifier that might be a path alias or self-reference (`pkg/_internal`), a file that won't parse, a specifier computed at runtime. The worst case is a missed optimization, never a dropped module. Parsing rather than matching matters because a codegen script has import statements inside its string literals.

**One graph per module set, written once per output.** Groups taking the same inputs share a graph, guarded by requiring the alias plugin to rewrite them identically — so nothing coalesces unless it is provably equivalent.

**Stay in-process until sharding pays.** Across `pkg-N` fixtures from 8 to 512 entries, one process ran 1.33x faster at 8, 1.15x at 64, 1.00x at 256 and 0.95x at 512, and held 20-47% less peak memory throughout. Workers are kept above 256 entries, and the per-entry path still always fans out.

## Effect

Warm medians on two real packages:

| shape | before | after |
| --- | --- | --- |
| 57 exports, dual format, one unreachable private module | 10.44s / 3445MB | **0.98s / 468MB** |
| 12 entries, dual format, `react-server` conditions | 2.11s / 1099MB | **1.91s / 1006MB** |

The second is byte-identical. The first differs only by the four `_build.*` files it no longer builds or ships.

## Notes

- **Behaviour change:** an unimported `_` file is no longer emitted.
- **Biggest remaining cost, not addressed here:** a dual-format package builds the same TypeScript program twice, for `.d.mts` and `.d.ts`. `rollup-plugin-dts` creates its programs in the `options()` hook, so memoizing the plugin instance doesn't help. Skipping the duplicate measures 1.91s -> 1.05s. Capturing it means letting rollup chunk a union of both input sets, which can move `.d.ts` chunk boundaries.