### PR TITLE
perf: add build profiling benchmarks

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,44 @@
+# Bunchee benchmarks
+
+The benchmark harness generates temporary TypeScript packages and invokes
+`dist/bin/cli.js` directly. It does not use `npx`, access the network, or include
+package-manager startup in Bunchee's measurements.
+
+```sh
+# Build Bunchee, then benchmark 1, 8, and 57-entry packages.
+pnpm benchmark
+
+# A quick smoke run.
+pnpm benchmark -- --entries 1 --iterations 1 --warmup 0
+
+# Include the larger worker-threshold fixture.
+pnpm benchmark -- --entries 57,256 --iterations 10
+
+# Preserve a JSON report without the preceding build command's output.
+pnpm build
+node ./scripts/benchmark.js --entries 57,256 --iterations 10 --json > benchmark.json
+```
+
+By default, each scenario keeps its output between runs so the measurement
+focuses on build work. Pass `--clean` to include removal of the previous output.
+Every scenario validates the expected files and records a SHA-256 digest of the
+complete output.
+
+The report includes median and p95 wall time, CPU time, maximum resident memory,
+JS and declaration graph time, TypeScript Program setup, and output writes.
+Program setup is part of declaration graph time, not an additional duration.
+Timings are informational and should not be used as hard CI assertions.
+
+## Profiling a real package
+
+Set `PROFILE=1` when invoking a locally installed Bunchee:
+
+```sh
+PROFILE=1 pnpm exec bunchee
+```
+
+Bunchee writes newline-delimited records to stdout. Each record begins with
+`BUNCHEE_PROFILE ` followed by JSON. The format is intended for development
+tooling and is versioned by its `schemaVersion`; it is not part of Bunchee's
+public API. Profiling performs no clock reads or JSON serialization when the
+environment variable is disabled.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "ts-bunchee": "pnpm run-ts ./src/bin/index.ts",
     "build-dir": "pnpm ts-bunchee --cwd",
     "build": "pnpm run-ts ./src/bin/index.ts --runtime node",
+    "benchmark": "pnpm build && node ./scripts/benchmark.js",
     "format": "oxfmt",
     "prepare": "husky"
   },

--- a/scripts/benchmark.js
+++ b/scripts/benchmark.js
@@ -1,0 +1,406 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'child_process'
+import { createHash } from 'crypto'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'fs'
+import { createRequire } from 'module'
+import { tmpdir } from 'os'
+import path from 'path'
+import { performance } from 'perf_hooks'
+
+const PROFILE_PREFIX = 'BUNCHEE_PROFILE '
+const repositoryDir = path.resolve(import.meta.dirname, '..')
+const cliPath = path.join(repositoryDir, 'dist/bin/cli.js')
+const require = createRequire(import.meta.url)
+
+function printHelp() {
+  console.log(`Usage: pnpm benchmark -- [options]
+
+Options:
+  --entries <counts>     Comma-separated entry counts. Default: 1,8,57
+  --iterations <count>  Measured runs per scenario. Default: 5
+  --warmup <count>      Unmeasured runs per scenario. Default: 1
+  --mode <modes>        Comma-separated full,no-dts. Default: full,no-dts
+  --clean               Clean dist before every build. Default: false
+  --json                Print the complete report as JSON
+  --keep                Keep generated fixtures and print their location
+  -h, --help            Show this message
+
+The benchmark invokes dist/bin/cli.js directly. It never uses npx and does not
+download packages. Run pnpm build first when invoking this script directly.`)
+}
+
+function parsePositiveInteger(value, option, { allowZero = false } = {}) {
+  const parsed = Number(value)
+  const minimum = allowZero ? 0 : 1
+  if (!Number.isInteger(parsed) || parsed < minimum) {
+    throw new Error(`${option} must be an integer >= ${minimum}`)
+  }
+  return parsed
+}
+
+function parseList(value, option) {
+  const values = value.split(',').filter(Boolean)
+  if (values.length === 0) throw new Error(`${option} cannot be empty`)
+  return values
+}
+
+function parseArgs(argv) {
+  const options = {
+    entries: [1, 8, 57],
+    iterations: 5,
+    warmup: 1,
+    modes: ['full', 'no-dts'],
+    clean: false,
+    json: false,
+    keep: false,
+  }
+
+  for (let index = 0; index < argv.length; index++) {
+    const argument = argv[index]
+    const next = () => {
+      const value = argv[++index]
+      if (!value) throw new Error(`${argument} requires a value`)
+      return value
+    }
+
+    switch (argument) {
+      // pnpm forwards its conventional option separator to package scripts.
+      case '--':
+        break
+      case '--entries':
+        options.entries = parseList(next(), argument).map((value) =>
+          parsePositiveInteger(value, argument),
+        )
+        break
+      case '--iterations':
+        options.iterations = parsePositiveInteger(next(), argument)
+        break
+      case '--warmup':
+        options.warmup = parsePositiveInteger(next(), argument, {
+          allowZero: true,
+        })
+        break
+      case '--mode':
+        options.modes = parseList(next(), argument)
+        break
+      case '--clean':
+        options.clean = true
+        break
+      case '--json':
+        options.json = true
+        break
+      case '--keep':
+        options.keep = true
+        break
+      case '-h':
+      case '--help':
+        printHelp()
+        process.exit(0)
+      default:
+        throw new Error(`Unknown option: ${argument}`)
+    }
+  }
+
+  for (const mode of options.modes) {
+    if (mode !== 'full' && mode !== 'no-dts') {
+      throw new Error(`Unknown mode "${mode}". Use full or no-dts`)
+    }
+  }
+  return options
+}
+
+function writeJson(file, value) {
+  writeFileSync(file, JSON.stringify(value, null, 2) + '\n')
+}
+
+function createFixture(root, entryCount, mode) {
+  const fixtureDir = path.join(root, `${entryCount}-${mode}`)
+  const sourceDir = path.join(fixtureDir, 'src')
+  mkdirSync(sourceDir, { recursive: true })
+
+  const exports = {}
+  for (let index = 0; index < entryCount; index++) {
+    const name = `entry-${String(index).padStart(3, '0')}`
+    exports[`./${name}`] = {
+      types: `./dist/${name}/index.d.ts`,
+      import: `./dist/${name}/index.mjs`,
+      require: `./dist/${name}/index.js`,
+    }
+    writeFileSync(
+      path.join(sourceDir, `${name}.ts`),
+      [
+        `import { sharedValue } from './_shared'`,
+        `import type { Shared } from './_shared'`,
+        ``,
+        `export const value${index} = sharedValue + ${index}`,
+        `export type Entry${index} = Shared & { index: ${index} }`,
+        ``,
+      ].join('\n'),
+    )
+  }
+
+  writeFileSync(
+    path.join(sourceDir, '_shared.ts'),
+    [
+      `export const sharedValue = 1`,
+      `export type Shared = { shared: true }`,
+      ``,
+    ].join('\n'),
+  )
+  writeJson(path.join(fixtureDir, 'package.json'), {
+    name: `bunchee-benchmark-${entryCount}`,
+    private: true,
+    exports,
+  })
+  writeJson(path.join(fixtureDir, 'tsconfig.json'), {
+    compilerOptions: {
+      target: 'ES2022',
+      module: 'ESNext',
+      moduleResolution: 'bundler',
+      strict: true,
+      skipLibCheck: true,
+    },
+    include: ['src'],
+  })
+
+  // TypeScript is a peer dependency. Link the repository's selected version so
+  // generated fixtures stay offline and exercise the same compiler as Bunchee.
+  const typescriptDir = path.dirname(require.resolve('typescript/package.json'))
+  const fixtureNodeModules = path.join(fixtureDir, 'node_modules')
+  mkdirSync(fixtureNodeModules)
+  symlinkSync(
+    typescriptDir,
+    path.join(fixtureNodeModules, 'typescript'),
+    process.platform === 'win32' ? 'junction' : 'dir',
+  )
+
+  return fixtureDir
+}
+
+function parseProfileEvents(output) {
+  return output
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith(PROFILE_PREFIX))
+    .map((line) => JSON.parse(line.slice(PROFILE_PREFIX.length)))
+}
+
+function runBuild(fixtureDir, mode, clean) {
+  const args = [
+    cliPath,
+    '--cwd',
+    fixtureDir,
+    '--runtime',
+    'node',
+    ...(clean ? [] : ['--no-clean']),
+    ...(mode === 'no-dts' ? ['--no-dts'] : []),
+  ]
+  const started = performance.now()
+  const result = spawnSync(process.execPath, args, {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PROFILE: '1',
+      CI: '1',
+      NO_COLOR: '1',
+    },
+    maxBuffer: 16 * 1024 * 1024,
+  })
+  const wallMs = performance.now() - started
+
+  if (result.error) throw result.error
+  if (result.status !== 0) {
+    throw new Error(
+      `Bunchee exited with ${result.status}\n${result.stdout}\n${result.stderr}`,
+    )
+  }
+
+  const events = parseProfileEvents(result.stdout + '\n' + result.stderr)
+  if (!events.some((event) => event.phase === 'cli.total')) {
+    throw new Error('Bunchee did not emit a cli.total profile event')
+  }
+  return { wallMs, events }
+}
+
+function getFiles(directory, base = directory) {
+  if (!existsSync(directory)) return []
+  const files = []
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const file = path.join(directory, entry.name)
+    if (entry.isDirectory()) files.push(...getFiles(file, base))
+    else files.push(path.relative(base, file).replaceAll(path.sep, '/'))
+  }
+  return files.sort()
+}
+
+function validateAndHashOutput(fixtureDir, entryCount, mode) {
+  const distDir = path.join(fixtureDir, 'dist')
+  const files = getFiles(distDir)
+  const required = ['_shared.js', '_shared.mjs']
+  if (mode === 'full') required.push('_shared.d.ts', '_shared.d.mts')
+
+  for (let index = 0; index < entryCount; index++) {
+    const name = `entry-${String(index).padStart(3, '0')}`
+    required.push(`${name}/index.js`, `${name}/index.mjs`)
+    if (mode === 'full') required.push(`${name}/index.d.ts`)
+  }
+
+  const missing = required.filter((file) => !files.includes(file))
+  if (missing.length > 0) {
+    throw new Error(`Benchmark output is missing: ${missing.join(', ')}`)
+  }
+
+  const hash = createHash('sha256')
+  for (const file of files) {
+    hash.update(file)
+    hash.update('\0')
+    hash.update(readFileSync(path.join(distDir, file)))
+    hash.update('\0')
+  }
+  return { files: files.length, sha256: hash.digest('hex') }
+}
+
+function percentile(values, fraction) {
+  const sorted = [...values].sort((a, b) => a - b)
+  return sorted[Math.max(0, Math.ceil(sorted.length * fraction) - 1)]
+}
+
+function phaseDuration(run, phase, kind) {
+  return run.events
+    .filter(
+      (event) =>
+        event.phase === phase &&
+        (kind === undefined || event.details?.kind === kind),
+    )
+    .reduce((total, event) => total + event.durationMs, 0)
+}
+
+function finalEvent(run) {
+  return run.events.findLast((event) => event.phase === 'cli.total')
+}
+
+function summarize(entryCount, mode, runs, output) {
+  const values = (selector) => runs.map(selector)
+  const wall = values((run) => run.wallMs)
+  const cli = values((run) => phaseDuration(run, 'cli.total'))
+  const cpu = values((run) => {
+    const details = finalEvent(run)?.details
+    return (details?.userCpuMs ?? 0) + (details?.systemCpuMs ?? 0)
+  })
+  const maxRss = values((run) => finalEvent(run)?.details?.maxRssBytes ?? 0)
+  const jsGraph = values((run) => phaseDuration(run, 'rollup.graph', 'js'))
+  const dtsGraph = values((run) => phaseDuration(run, 'rollup.graph', 'dts'))
+  const dtsProgram = values((run) => phaseDuration(run, 'dts.program'))
+  const writes = values((run) => phaseDuration(run, 'rollup.write'))
+
+  return {
+    entries: entryCount,
+    mode,
+    samples: runs.length,
+    wallMs: {
+      p50: percentile(wall, 0.5),
+      p95: percentile(wall, 0.95),
+      min: Math.min(...wall),
+      max: Math.max(...wall),
+    },
+    cliMs: { p50: percentile(cli, 0.5) },
+    cpuMs: { p50: percentile(cpu, 0.5) },
+    maxRssBytes: Math.max(...maxRss),
+    phasesMs: {
+      jsGraphP50: percentile(jsGraph, 0.5),
+      dtsGraphP50: percentile(dtsGraph, 0.5),
+      dtsProgramP50: percentile(dtsProgram, 0.5),
+      writeP50: percentile(writes, 0.5),
+    },
+    output,
+  }
+}
+
+function round(value) {
+  return Number(value.toFixed(1))
+}
+
+function printTable(report) {
+  const rows = report.scenarios.map((scenario) => ({
+    entries: scenario.entries,
+    mode: scenario.mode,
+    'wall p50': round(scenario.wallMs.p50),
+    'wall p95': round(scenario.wallMs.p95),
+    'cpu p50': round(scenario.cpuMs.p50),
+    'JS graph': round(scenario.phasesMs.jsGraphP50),
+    'DTS graph': round(scenario.phasesMs.dtsGraphP50),
+    'DTS setup': round(scenario.phasesMs.dtsProgramP50),
+    writes: round(scenario.phasesMs.writeP50),
+    'max RSS MB': round(scenario.maxRssBytes / 1024 / 1024),
+  }))
+  console.table(rows)
+  console.log(
+    `Times are milliseconds; ${report.iterations} measured run(s) after ` +
+      `${report.warmup} warmup run(s). clean=${report.clean}`,
+  )
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2))
+  if (!existsSync(cliPath)) {
+    throw new Error(
+      `${cliPath} does not exist. Run pnpm build before this script.`,
+    )
+  }
+
+  const fixtureRoot = mkdtempSync(path.join(tmpdir(), 'bunchee-benchmark-'))
+  const scenarios = []
+  try {
+    for (const entryCount of options.entries) {
+      for (const mode of options.modes) {
+        const fixtureDir = createFixture(fixtureRoot, entryCount, mode)
+        for (let index = 0; index < options.warmup; index++) {
+          runBuild(fixtureDir, mode, options.clean)
+        }
+
+        const runs = []
+        for (let index = 0; index < options.iterations; index++) {
+          runs.push(runBuild(fixtureDir, mode, options.clean))
+        }
+        const output = validateAndHashOutput(fixtureDir, entryCount, mode)
+        scenarios.push(summarize(entryCount, mode, runs, output))
+      }
+    }
+
+    const report = {
+      schemaVersion: 1,
+      generatedAt: new Date().toISOString(),
+      node: process.version,
+      platform: `${process.platform}-${process.arch}`,
+      cli: path.relative(repositoryDir, cliPath),
+      iterations: options.iterations,
+      warmup: options.warmup,
+      clean: options.clean,
+      scenarios,
+    }
+    if (options.json) console.log(JSON.stringify(report, null, 2))
+    else printTable(report)
+  } finally {
+    if (options.keep) {
+      console.log(`Kept benchmark fixtures at ${fixtureRoot}`)
+    } else {
+      rmSync(fixtureRoot, { recursive: true, force: true })
+    }
+  }
+}
+
+try {
+  main()
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+}

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -13,6 +13,7 @@ import { logOutputState } from '../plugins/output-state-plugin'
 import { normalizeError } from '../lib/normalize-error'
 import { createSpinner } from 'nanospinner'
 import { createRequire } from 'module'
+import { endProfile, startProcessProfile, startProfile } from '../lib/profile'
 
 // Read rather than imported: a JSON module in ESM has no named exports, and a
 // default import would inline the whole manifest into the bin. The path holds
@@ -259,7 +260,12 @@ async function run(args: CliArgs) {
   const cliEntry = source ? path.resolve(cwd, source) : ''
 
   // lint package by default
-  await lint(cwd)
+  const lintStarted = startProfile()
+  try {
+    await lint(cwd)
+  } finally {
+    endProfile('cli.lint', lintStarted)
+  }
 
   const spinnerInstance = process.stdout.isTTY
     ? createSpinner('Building...\n\n', {
@@ -376,20 +382,36 @@ async function run(args: CliArgs) {
 }
 
 async function main() {
-  let params, error
+  const mainStarted = startProcessProfile()
+  let status = 'success'
   try {
-    params = await parseCliArgs(process.argv)
-  } catch (err) {
-    error = err
+    let params, error
+    try {
+      params = await parseCliArgs(process.argv)
+    } catch (err) {
+      error = err
+    }
+    if (error || !params) {
+      // if (!error) help()
+      return exit(error as Error)
+    }
+    if ('cmd' in params) {
+      return
+    }
+    await run(params)
+  } catch (error) {
+    status = 'error'
+    throw error
+  } finally {
+    const usage =
+      mainStarted === undefined ? undefined : process.resourceUsage()
+    endProfile('cli.total', mainStarted, {
+      status,
+      userCpuMs: usage && usage.userCPUTime / 1000,
+      systemCpuMs: usage && usage.systemCPUTime / 1000,
+      maxRssBytes: usage && usage.maxRSS * 1024,
+    })
   }
-  if (error || !params) {
-    // if (!error) help()
-    return exit(error as Error)
-  }
-  if ('cmd' in params) {
-    return
-  }
-  await run(params)
 }
 
 function logWatcherBuildTime(result: RollupWatcher[], spinner: Spinner) {

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -42,6 +42,7 @@ import {
 } from './rollup/merged-config'
 import { spawn } from 'child_process'
 import { logger } from './logger'
+import { endProfile, startProfile } from './lib/profile'
 
 function assignDefault(
   options: BundleConfig,
@@ -67,21 +68,30 @@ async function bundle(
   cliEntryPath: string,
   { cwd: _cwd, onSuccess, ...options }: BundleConfig = {},
 ): Promise<void> {
+  const bundleStarted = startProfile()
   const cwd = resolve(process.cwd(), _cwd || '')
   assignDefault(options, 'format', 'esm')
   assignDefault(options, 'minify', false)
   assignDefault(options, 'target', 'es2022')
 
+  const packageStarted = startProfile()
   const pkg = await getPackageMeta(cwd)
   const parsedExportsInfo = await parseExports(pkg, cwd)
+  endProfile('bundle.package', packageStarted, {
+    exports: parsedExportsInfo.size,
+  })
   const isMultiEntries = hasMultiEntryExport(parsedExportsInfo)
   const hasBin = Boolean(pkg.bin)
   // Original input file path, client path might change later
   const inputFile = cliEntryPath
   const isFromCli = Boolean(cliEntryPath)
 
+  const tsconfigStarted = startProfile()
   const tsConfigPath = resolveTsConfigPath(cwd, options.tsconfig)
   let tsConfig = resolveTsConfig(cwd, tsConfigPath)
+  endProfile('bundle.tsconfig', tsconfigStarted, {
+    found: Boolean(tsConfig?.tsConfigPath),
+  })
   let hasTsConfig = Boolean(tsConfig?.tsConfigPath)
 
   const defaultTsOptions: TypescriptOptions = {
@@ -146,12 +156,16 @@ async function bundle(
     }
   }
 
+  const entriesStarted = startProfile()
   const entries = await collectEntriesFromParsedExports(
     cwd,
     parsedExportsInfo,
     pkg,
     inputFile,
   )
+  endProfile('bundle.entries', entriesStarted, {
+    entries: Object.keys(entries).length,
+  })
 
   // Collect and log missing entries for defined exports
   const missingEntries = [...parsedExportsInfo.keys()].filter(
@@ -214,7 +228,12 @@ async function bundle(
   // `_entryFilter` is not a reason to skip merging: a worker gets a shard of
   // entries and builds them as one graph, with the entries it does not own
   // resolved as externals against their own output paths.
+  const mergeStarted = startProfile()
   const useMerged = await canMergeEntries(entries, options, isFromCli)
+  endProfile('bundle.merge-plan', mergeStarted, {
+    entries: entryNames.length,
+    merged: useMerged,
+  })
 
   // With many entries, every entry's rollup build shares one heap and peak
   // memory scales with entry count, which OOMs on packages with many exports.
@@ -317,7 +336,20 @@ async function bundle(
         await onSuccess()
       }
     }
+    endProfile('bundle.total', bundleStarted, {
+      entries: entryNames.length,
+      generateTypes,
+      jobs: assetJobs.length,
+      merged: useMerged,
+      status: 'success',
+    })
   } catch (error) {
+    endProfile('bundle.total', bundleStarted, {
+      entries: entryNames.length,
+      generateTypes,
+      merged: useMerged,
+      status: 'error',
+    })
     options._callbacks?.onBuildError?.(error)
     return Promise.reject(error)
   }

--- a/src/lib/profile.test.ts
+++ b/src/lib/profile.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { createProfileEvent, PROFILE_PREFIX } from './profile'
+
+describe('build profiling', () => {
+  it('creates a stable JSON-serializable event', () => {
+    const event = createProfileEvent('rollup.graph', 12.34567, {
+      kind: 'dts',
+      inputs: 57,
+      omitted: undefined,
+    })
+
+    expect(PROFILE_PREFIX).toBe('BUNCHEE_PROFILE ')
+    expect(event).toEqual({
+      schemaVersion: 1,
+      phase: 'rollup.graph',
+      durationMs: 12.346,
+      pid: process.pid,
+      details: {
+        kind: 'dts',
+        inputs: 57,
+      },
+    })
+    expect(() => JSON.stringify(event)).not.toThrow()
+  })
+})

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -1,0 +1,79 @@
+import { performance } from 'perf_hooks'
+
+export const PROFILE_PREFIX = 'BUNCHEE_PROFILE '
+
+type ProfileDetail = string | number | boolean | null
+export type ProfileDetails = Record<string, ProfileDetail | undefined>
+
+export type ProfileEvent = {
+  schemaVersion: 1
+  phase: string
+  durationMs: number
+  pid: number
+  details?: Record<string, ProfileDetail>
+}
+
+export function isProfileEnabled(): boolean {
+  return process.env.PROFILE === '1'
+}
+
+/**
+ * Capture a phase start without paying for a clock read when profiling is off.
+ */
+export function startProfile(): number | undefined {
+  return isProfileEnabled() ? performance.now() : undefined
+}
+
+/**
+ * Start a timer at the beginning of the Node.js process lifetime.
+ *
+ * Used by the CLI total so module loading is represented in the profile, while
+ * individual build phases use `startProfile`.
+ */
+export function startProcessProfile(): number | undefined {
+  return isProfileEnabled() ? 0 : undefined
+}
+
+export function createProfileEvent(
+  phase: string,
+  durationMs: number,
+  details?: ProfileDetails,
+): ProfileEvent {
+  const filteredDetails = details
+    ? Object.fromEntries(
+        Object.entries(details).filter(
+          (entry): entry is [string, ProfileDetail] => {
+            return entry[1] !== undefined
+          },
+        ),
+      )
+    : undefined
+
+  return {
+    schemaVersion: 1,
+    phase,
+    durationMs: Number(durationMs.toFixed(3)),
+    pid: process.pid,
+    ...(filteredDetails && Object.keys(filteredDetails).length > 0
+      ? { details: filteredDetails }
+      : {}),
+  }
+}
+
+/**
+ * Emit one machine-readable JSON line. The prefix lets callers share stdout
+ * with Bunchee's normal output and select profile records without parsing it.
+ */
+export function endProfile(
+  phase: string,
+  startedAt: number | undefined,
+  details?: ProfileDetails,
+): void {
+  if (startedAt === undefined) return
+  const event = createProfileEvent(
+    phase,
+    performance.now() - startedAt,
+    details,
+  )
+  process.stdout.write(PROFILE_PREFIX + JSON.stringify(event) + '\n')
+}

--- a/src/rollup-job.ts
+++ b/src/rollup-job.ts
@@ -21,12 +21,34 @@ import {
 import { removeOutputDir } from './utils'
 import { normalizeError } from './lib/normalize-error'
 import { logger } from './logger'
+import { endProfile, startProfile } from './lib/profile'
+
+function inputCount(input: string | Record<string, string>): number {
+  return typeof input === 'string' ? 1 : Object.keys(input).length
+}
+
+function graphKind(plugins: MergedRollupConfig['plugins']): 'dts' | 'js' {
+  const pluginValue = plugins as unknown
+  const pluginList: unknown[] = Array.isArray(pluginValue)
+    ? pluginValue.flat(Infinity)
+    : [pluginValue]
+  return pluginList.some(
+    (plugin) =>
+      plugin != null &&
+      typeof plugin === 'object' &&
+      'name' in plugin &&
+      plugin.name === 'dts',
+  )
+    ? 'dts'
+    : 'js'
+}
 
 export async function createAssetRollupJobs(
   options: BundleConfig,
   buildContext: BuildContext,
   bundleJobOptions: BundleJobOptions,
 ) {
+  const configStarted = startProfile()
   const { isFromCli, generateTypes } = bundleJobOptions
   const assetsConfigs = options._typesOnly
     ? []
@@ -41,14 +63,22 @@ export async function createAssetRollupJobs(
       })
     : []
   const allConfigs = assetsConfigs.concat(typesConfigs)
+  endProfile('bundle.config', configStarted, {
+    graphs: allConfigs.length,
+    merged: false,
+  })
 
   // When it's production build (non watch mode), we need to remove the output directory
   if (!options.watch) {
+    const cleanStarted = startProfile()
     for (const config of allConfigs) {
       if (options.clean && !isFromCli) {
         await removeOutputDir(config.output, buildContext.cwd)
       }
     }
+    endProfile('bundle.clean', cleanStarted, {
+      enabled: Boolean(options.clean && !isFromCli),
+    })
   }
 
   const rollupJobs = allConfigs.map((rollupConfig) =>
@@ -72,6 +102,7 @@ export async function createMergedRollupJobs(
   buildContext: BuildContext,
   bundleJobOptions: BundleJobOptions,
 ) {
+  const configStarted = startProfile()
   const { isFromCli, generateTypes } = bundleJobOptions
   const assetsConfigs = options._typesOnly
     ? []
@@ -83,16 +114,22 @@ export async function createMergedRollupJobs(
     ? await buildMergedConfigs(options, buildContext, { dts: true, isFromCli })
     : []
   const allConfigs = assetsConfigs.concat(typesConfigs)
+  endProfile('bundle.config', configStarted, {
+    graphs: allConfigs.length,
+    merged: true,
+  })
 
   // Clean every output directory before anything is written: the JS and types
   // groups usually share one dist directory, so cleaning per job would delete
   // an earlier job's output.
   if (options.clean && !isFromCli) {
+    const cleanStarted = startProfile()
     for (const config of allConfigs) {
       for (const output of config.output) {
         await removeOutputDir(output, buildContext.cwd)
       }
     }
+    endProfile('bundle.clean', cleanStarted, { enabled: true })
   }
 
   if (process.env.DEBUG) {
@@ -132,11 +169,26 @@ async function runMergedBundle({
   let bundle: RollupBuild
   const debug = Boolean(process.env.DEBUG)
   const started = Date.now()
+  const graphStarted = startProfile()
+  const kind =
+    graphStarted === undefined ? undefined : graphKind(restOptions.plugins)
+  const inputs =
+    graphStarted === undefined ? undefined : inputCount(restOptions.input)
   try {
     bundle = await rollup({ ...restOptions, cache: false })
   } catch (error) {
+    endProfile('rollup.graph', graphStarted, {
+      inputs,
+      kind,
+      status: 'error',
+    })
     return catchErrorHandler(error)
   }
+  endProfile('rollup.graph', graphStarted, {
+    inputs,
+    kind,
+    status: 'success',
+  })
   if (debug) {
     logMergedGraph(bundle, Object.keys(restOptions.input).length, started)
   }
@@ -146,7 +198,15 @@ async function runMergedBundle({
     const results = []
     for (const output of outputs) {
       const writeStart = Date.now()
-      results.push(await bundle.write(output))
+      const writeProfileStarted = startProfile()
+      try {
+        results.push(await bundle.write(output))
+      } finally {
+        endProfile('rollup.write', writeProfileStarted, {
+          format: output.format,
+          kind,
+        })
+      }
       if (debug) {
         logger.log(`  write ${output.format}: ${Date.now() - writeStart}ms`)
       }
@@ -201,15 +261,38 @@ async function bundleOrWatch(
 
 async function runBundle({ output, ...restOptions }: BuncheeRollupConfig) {
   let bundle: RollupBuild
+  const graphStarted = startProfile()
+  const kind =
+    graphStarted === undefined ? undefined : graphKind(restOptions.plugins)
+  const inputs =
+    graphStarted === undefined ? undefined : inputCount(restOptions.input)
   try {
     // One-shot builds never reuse the cache; disabling it stops rollup from
     // retaining every module's AST on the bundle for the rest of the build.
     bundle = await rollup({ ...restOptions, cache: false })
   } catch (error) {
+    endProfile('rollup.graph', graphStarted, {
+      inputs,
+      kind,
+      status: 'error',
+    })
     return catchErrorHandler(error)
   }
+  endProfile('rollup.graph', graphStarted, {
+    inputs,
+    kind,
+    status: 'success',
+  })
   try {
-    return await bundle.write(output)
+    const writeStarted = startProfile()
+    try {
+      return await bundle.write(output)
+    } finally {
+      endProfile('rollup.write', writeStarted, {
+        format: output.format,
+        kind,
+      })
+    }
   } finally {
     // Release module graph and plugin resources once the assets are written,
     // instead of holding every entry's graph until the whole build finishes.

--- a/src/rollup/input.ts
+++ b/src/rollup/input.ts
@@ -1,4 +1,4 @@
-import { Plugin } from 'rollup'
+import type { InputOptions, Plugin } from 'rollup'
 import { type Options as SwcOptions } from '@swc/core'
 import {
   BuildContext,
@@ -30,6 +30,7 @@ import {
   convertCompilerOptions,
   isTsConfigAutoDiscoverable,
 } from '../typescript'
+import { endProfile, startProfile } from '../lib/profile'
 import {
   availableESExtensionsRegex,
   disabledWarnings,
@@ -110,7 +111,37 @@ async function createDtsPlugin(
     respectExternal,
   })
 
-  return dtsPlugin
+  if (typeof dtsPlugin.options !== 'function') {
+    return dtsPlugin
+  }
+
+  const optionsHook = dtsPlugin.options
+
+  return {
+    ...dtsPlugin,
+    options(this: any, inputOptions: InputOptions) {
+      const input = inputOptions.input
+      const inputFiles =
+        typeof input === 'string'
+          ? [input]
+          : Array.isArray(input)
+            ? input
+            : input
+              ? Object.values(input)
+              : []
+      const started = startProfile()
+      try {
+        // rollup-plugin-dts creates its TypeScript Programs synchronously in
+        // this hook. Keep the label tied to that observable lifecycle rather
+        // than attempting to patch the TypeScript compiler itself.
+        return optionsHook.call(this, inputOptions)
+      } finally {
+        endProfile('dts.program', started, {
+          inputs: inputFiles.length,
+        })
+      }
+    },
+  } satisfies Plugin
 }
 
 const memoizeDtsPluginByKey = memoizeByKey(createDtsPlugin)

--- a/test/integration/many-entries/index.test.ts
+++ b/test/integration/many-entries/index.test.ts
@@ -28,6 +28,7 @@ async function build(env: NodeJS.ProcessEnv = {}) {
 }
 
 const ENTRIES = ['index', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']
+const PROFILE_PREFIX = 'BUNCHEE_PROFILE '
 
 describe('integration - many-entries', () => {
   it('should build every entry', async () => {
@@ -78,6 +79,34 @@ describe('integration - many-entries', () => {
     // TypeScript compiler API, which costs more than splitting two graphs
     // across threads saves at any entry count measured.
     expect(stdout).not.toContain('worker threads')
+  }, 120_000)
+
+  it('should emit structured build profiling when requested', async () => {
+    const { stdout } = await build({ PROFILE: '1' })
+    const events = stdout
+      .split('\n')
+      .filter((line) => line.startsWith(PROFILE_PREFIX))
+      .map((line) => JSON.parse(line.slice(PROFILE_PREFIX.length)))
+
+    expect(events.length).toBeGreaterThan(0)
+    expect(events.every((event) => event.schemaVersion === 1)).toBe(true)
+    expect(events.some((event) => event.phase === 'cli.total')).toBe(true)
+    expect(events.some((event) => event.phase === 'bundle.total')).toBe(true)
+    expect(
+      events.some(
+        (event) =>
+          event.phase === 'rollup.graph' && event.details?.kind === 'js',
+      ),
+    ).toBe(true)
+    expect(
+      events.some(
+        (event) =>
+          event.phase === 'rollup.graph' && event.details?.kind === 'dts',
+      ),
+    ).toBe(true)
+    expect(
+      events.filter((event) => event.phase === 'dts.program'),
+    ).toHaveLength(1)
   }, 120_000)
 
   it('should emit code shared between entries as a single chunk', async () => {


### PR DESCRIPTION
## Summary

- add opt-in structured build profiling behind PROFILE=1
- report CLI, bundle, Rollup graph, declaration Program, write, CPU, and memory measurements
- add an offline benchmark harness for generated 1, 8, and 57-entry TypeScript packages
- validate benchmark outputs with complete SHA-256 digests

Profiling avoids clock reads and JSON serialization when disabled. Records retain the BUNCHEE_PROFILE prefix so they can be separated from normal CLI output.

## Validation

- pnpm typecheck equivalent: tsc --noEmit
- focused profiling and many-entry integration tests
- benchmark smoke run with one entry and one iteration
- full suite on the stacked result: 245 passed, 1 skipped