### PR TITLE
perf: reuse TypeScript program for declaration subsets

### DIFF
--- a/src/rollup-job.ts
+++ b/src/rollup-job.ts
@@ -113,6 +113,12 @@ export async function createMergedRollupJobs(
   const typesConfigs = generateTypes
     ? await buildMergedConfigs(options, buildContext, { dts: true, isFromCli })
     : []
+  // A declaration graph's Program also contains its transitive dependencies.
+  // Build the broadest graph first so later private/special-extension graphs
+  // can reuse that Program when their inputs are already part of it.
+  typesConfigs.sort(
+    (left, right) => inputCount(right.input) - inputCount(left.input),
+  )
   const allConfigs = assetsConfigs.concat(typesConfigs)
   endProfile('bundle.config', configStarted, {
     graphs: allConfigs.length,

--- a/src/rollup/input.ts
+++ b/src/rollup/input.ts
@@ -25,7 +25,6 @@ import { nativeAddon } from '../plugins/native-addon-plugin'
 import { aliasEntries, getAliasFormat } from '../plugins/alias-plugin'
 import { prependShebang } from '../plugins/prepend-shebang'
 import { swcHelpersWarningPlugin } from '../plugins/swc-helpers-warning-plugin'
-import { memoizeByKey } from '../lib/memoize'
 import {
   convertCompilerOptions,
   isTsConfigAutoDiscoverable,
@@ -116,6 +115,8 @@ async function createDtsPlugin(
   }
 
   const optionsHook = dtsPlugin.options
+  let programInputs: Set<string> | undefined
+  let pluginOptionOverrides: Record<string, unknown> | undefined
 
   return {
     ...dtsPlugin,
@@ -129,22 +130,47 @@ async function createDtsPlugin(
             : input
               ? Object.values(input)
               : []
+      const previousProgramInputs = programInputs
+      const canReuseProgram =
+        previousProgramInputs !== undefined &&
+        pluginOptionOverrides !== undefined &&
+        inputFiles.every((file) => previousProgramInputs.has(file))
       const started = startProfile()
       try {
+        if (canReuseProgram) {
+          // rollup-plugin-dts normally replaces its Programs in every options
+          // hook. A later graph whose inputs are all roots of the current
+          // Program can safely retain it; replay only the Rollup option changes
+          // the plugin made during its first initialization.
+          return {
+            ...inputOptions,
+            ...pluginOptionOverrides,
+          }
+        }
+
         // rollup-plugin-dts creates its TypeScript Programs synchronously in
         // this hook. Keep the label tied to that observable lifecycle rather
         // than attempting to patch the TypeScript compiler itself.
-        return optionsHook.call(this, inputOptions)
+        const result = optionsHook.call(this, inputOptions)
+        if (result && typeof result === 'object') {
+          pluginOptionOverrides = Object.fromEntries(
+            Object.entries(result).filter(
+              ([key, value]) =>
+                value !== (inputOptions as Record<string, unknown>)[key],
+            ),
+          )
+          programInputs = new Set(inputFiles)
+        }
+        return result
       } finally {
         endProfile('dts.program', started, {
           inputs: inputFiles.length,
+          reused: canReuseProgram,
         })
       }
     },
   } satisfies Plugin
 }
-
-const memoizeDtsPluginByKey = memoizeByKey(createDtsPlugin)
 
 export async function buildInputConfig(
   entry: string,
@@ -286,21 +312,19 @@ export async function buildInputConfig(
   ]
 
   if (useTypeScript) {
-    // Each process should be unique
-    // Each package build should be unique
-    // Composing above factors into a unique cache key to retrieve the memoized dts plugin with tsconfigs
-    const autoDiscoverable = isTsConfigAutoDiscoverable(cwd, tsConfigPath, [
-      ...new Set(Object.values(entries).map((e) => dirname(e.source))),
-    ])
-    const uniqueProcessId =
-      'dts-plugin:' + process.pid + tsConfigPath + autoDiscoverable
-    const dtsPlugin = await memoizeDtsPluginByKey(uniqueProcessId)(
+    // Keep one plugin—and therefore one TypeScript Program cache—for this
+    // package build. Scoping it to BuildContext prevents repeated in-process
+    // builds and separate watchers from observing stale compiler state.
+    pluginContext.dtsPlugin ??= createDtsPlugin(
       tsCompilerOptions,
       tsConfigPath,
       bundleConfig.dts && bundleConfig.dts.respectExternal,
       cwd,
-      autoDiscoverable,
+      isTsConfigAutoDiscoverable(cwd, tsConfigPath, [
+        ...new Set(Object.values(entries).map((e) => dirname(e.source))),
+      ]),
     )
+    const dtsPlugin = await pluginContext.dtsPlugin
     typesPlugins.push(dtsPlugin)
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import type { OutputTarget } from './exports'
 import type { JscTarget } from '@swc/types'
-import type { InputOptions, OutputOptions } from 'rollup'
+import type { InputOptions, OutputOptions, Plugin } from 'rollup'
 import type { OutputState } from './plugins/output-state-plugin'
 import type { TypescriptOptions } from './typescript'
 
@@ -175,6 +175,11 @@ type BuildContext = {
   pluginContext: {
     outputState: OutputState
     moduleDirectiveLayerMap: Map<string, Set<[string, string]>>
+    /**
+     * One declaration plugin per package build. The plugin owns the TypeScript
+     * Programs that compatible declaration graphs reuse.
+     */
+    dtsPlugin?: Promise<Plugin>
   }
 }
 

--- a/test/integration/dts-program-reuse/index.test.ts
+++ b/test/integration/dts-program-reuse/index.test.ts
@@ -1,0 +1,49 @@
+import path from 'path'
+import { describe, expect, it } from 'vitest'
+import {
+  getFileContents,
+  getFileNamesFromDirectory,
+  removeDirectory,
+} from '../../testing-utils'
+import { executeBunchee } from '../../testing-utils/shared'
+
+const dir = __dirname
+const distDir = path.join(dir, 'dist')
+const PROFILE_PREFIX = 'BUNCHEE_PROFILE '
+
+describe('integration - dts-program-reuse', () => {
+  it('reuses a broad declaration Program for a private entry graph', async () => {
+    await removeDirectory(distDir)
+    const result = await executeBunchee(['--cwd', dir], {
+      env: { PROFILE: '1' },
+    })
+
+    expect(result.stderr).toBe('')
+    expect(result.code).toBe(0)
+
+    const files = await getFileNamesFromDirectory(distDir)
+    const contents = await getFileContents(distDir)
+    expect(files).toEqual([
+      '_shared.d.ts',
+      '_shared.js',
+      '_shared.mjs',
+      'index.d.ts',
+      'index.js',
+      'index.mjs',
+    ])
+    expect(contents['_shared.d.ts']).toContain(`type Shared = {`)
+
+    const programEvents = result.stdout
+      .split('\n')
+      .filter((line) => line.startsWith(PROFILE_PREFIX))
+      .map((line) => JSON.parse(line.slice(PROFILE_PREFIX.length)))
+      .filter((event) => event.phase === 'dts.program')
+
+    expect(programEvents).toHaveLength(2)
+    expect(programEvents.map((event) => event.details.inputs)).toEqual([2, 1])
+    expect(programEvents.map((event) => event.details.reused)).toEqual([
+      false,
+      true,
+    ])
+  }, 120_000)
+})

--- a/test/integration/dts-program-reuse/package.json
+++ b/test/integration/dts-program-reuse/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "dts-program-reuse",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  }
+}

--- a/test/integration/dts-program-reuse/src/_shared.ts
+++ b/test/integration/dts-program-reuse/src/_shared.ts
@@ -1,0 +1,2 @@
+export const shared = 'shared'
+export type Shared = { shared: true }

--- a/test/integration/dts-program-reuse/src/index.ts
+++ b/test/integration/dts-program-reuse/src/index.ts
@@ -1,0 +1,5 @@
+import { shared } from './_shared'
+import type { Shared } from './_shared'
+
+export const value = shared
+export type Public = Shared & { public: true }


### PR DESCRIPTION
## Summary

- keep the declaration plugin and its TypeScript Program scoped to one package build
- build the broadest declaration graph first
- skip rollup-plugin-dts Program recreation when every later input is already a root of the current Program
- fall back to normal Program creation for non-subset graphs
- add an integration fixture covering a broad graph followed by a private subset graph

Stacked on #758 so the optimization can use its profiling signal while keeping the benchmark changes independently reviewable. No dependency patch is required.

## Results

On the Foxts reproduction, the second declaration Program setup dropped from roughly 324 ms to 0.002 ms and its complete declaration graph took roughly 1.1 ms. All 172 generated files retained the same aggregate hash.

## Validation

- tsc --noEmit
- full suite: 245 passed, 1 skipped
- built-distribution reuse and profiling tests
- focused checks with TypeScript 5.9, 6.0, and 7.0