### PR TITLE
ci: run compatibility matrix only for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   install_and_test_win:
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: windows-latest
     timeout-minutes: 5
     strategy:
@@ -46,6 +47,43 @@ jobs:
           pnpm test:post || exit /b 1
 
   install_and_test:
+    if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    name: Linux - Node 24 - TS 7.0.2
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v6.0.8
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6.3.0
+        with:
+          node-version: 24
+          cache: 'pnpm'
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Setup TypeScript and React types
+        run: pnpm add --save-dev typescript@7.0.2 @types/react@19.2.14 @types/react-dom@19.2.3 --prefer-offline
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Build
+        run: pnpm build
+
+      - name: Test
+        run: |
+          pnpm test
+          pnpm test:post
+
+  install_and_test_compat:
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: [ubuntu-latest]
     timeout-minutes: 5
     strategy:
@@ -101,7 +139,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: [install_and_test]
+    needs: [install_and_test_compat, install_and_test_win]
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- run one latest lane, Node 24 with TypeScript 7.0.2, for pull requests and normal main pushes
- run the existing four-lane Linux Node/TypeScript compatibility matrix only for version tags
- run the Windows lane only for version tags
- require both the compatibility matrix and Windows job to pass before publishing

The latest lane keeps the existing Linux - Node 24 - TS 7.0.2 check name.

## Validation

- parsed the workflow YAML and asserted each event gate, matrix size, and release dependency
- oxfmt --check .github/workflows/ci.yml
- git diff --check