### PR TITLE
fix: align runtime option names

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,7 +571,7 @@ await bundle(path.resolve('./src/index.ts'), {
   external: [], // string[]
   format: 'esm', // 'esm' | 'cjs'
   target: 'es2022', // ES syntax target
-  runtime: 'nodejs', // 'browser' | 'nodejs'
+  runtime: 'node', // 'browser' | 'node'
   cwd: process.cwd(), // string
   clean: true, // boolean
   tsconfig: 'tsconfig.json', // string

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -42,7 +42,7 @@ Options:
   --no-external          do not bundle external dependencies
   --no-clean             do not clean dist folder before building, default: false
   --target <target>      js features target: swc target es versions. default: es2022
-  --runtime <runtime>    build runtime (nodejs, browser). default: browser
+  --runtime <runtime>    build runtime (node, browser). default: browser
   --env <env>            inlined process env variables, separate by comma. default: NODE_ENV
   --cwd <cwd>            specify current working directory
   --sourcemap            enable sourcemap generation
@@ -110,8 +110,9 @@ async function parseCliArgs(argv: string[]) {
     })
     .option('runtime', {
       type: 'string',
+      choices: ['browser', 'node'] as const,
       default: 'browser',
-      description: 'build runtime (nodejs, browser)',
+      description: 'build runtime (node, browser)',
     })
     .option('target', {
       type: 'string',
@@ -192,7 +193,7 @@ async function parseCliArgs(argv: string[]) {
     dts: args['dts'] === false ? false : undefined,
     dtsBundle: args['dts-bundle'],
     help: args['help'],
-    runtime: args['runtime'],
+    runtime: args['runtime'] as CliArgs['runtime'],
     target: args['target'] as CliArgs['target'],
     // no-external is a boolean flag, turning external to `false`
     external:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export type { BundleConfig } from './types'
+export type { BundleConfig, Runtime } from './types'
 export { default as bundle } from './bundle'
 // Piscina worker handler, loaded by name from dist/index.js. Not public API.
 export { buildEntryInWorker } from './worker'

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,8 @@ import type { TypescriptOptions } from './typescript'
 
 type PackageType = 'commonjs' | 'module'
 
+type Runtime = 'browser' | 'node'
+
 type ExportType =
   | 'import'
   | 'module'
@@ -43,7 +45,7 @@ type BundleConfig = {
   external?: string[] | null
   env?: string[]
   dts?: { respectExternal?: boolean } | false
-  runtime?: string
+  runtime?: Runtime
   pkg?: PackageMetadata
   clean?: boolean
   tsconfig?: string
@@ -144,7 +146,7 @@ type CliArgs = {
   external?: string | null
   dts?: false
   dtsBundle?: boolean
-  runtime?: string
+  runtime?: Runtime
   clean?: boolean
   tsconfig?: string
   onSuccess?: string
@@ -212,4 +214,5 @@ export type {
   bundleEntryOptions,
   BrowserslistConfig,
   CustomRollupInputOptions,
+  Runtime,
 }

--- a/src/typing.test.ts
+++ b/src/typing.test.ts
@@ -13,7 +13,7 @@ describe('types', () => {
       external: [],
       format: 'esm',
       target: 'es2015',
-      runtime: 'nodejs',
+      runtime: 'node',
     }
 
     return () => bundle('./tmp/index.ts', options)


### PR DESCRIPTION
## Summary

- make `node` the documented Node.js runtime name across the CLI, docs, and public types
- restrict runtime values to `browser` and `node`, correcting the previously documented but unsupported `nodejs` value
- preserve the existing behavior when the programmatic `runtime` option is omitted

## Tests

- `pnpm test src/typing.test.ts`
- `pnpm typecheck`
- `pnpm build`