### PR TITLE
fix: make package lint actionable

### DIFF
--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -56,12 +56,15 @@ function help() {
   logger.log(helpMessage)
 }
 
-async function lint(cwd: string) {
+async function lint(cwd: string, failOnIssues = false) {
   // Not package.json detected, skip package linting
   if (!hasPackageJson(cwd)) {
     return
   }
-  await lintPackage(cwd)
+  const issues = await lintPackage(cwd)
+  if (failOnIssues && issues) {
+    process.exitCode = 1
+  }
 }
 
 async function parseCliArgs(argv: string[]) {
@@ -165,7 +168,7 @@ async function parseCliArgs(argv: string[]) {
       'lint package.json',
       () => {}, // skip builder arg
       (argv) => {
-        return lint(argv.cwd || process.cwd())
+        return lint(argv.cwd || process.cwd(), true)
       },
     )
     .version(version)

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -201,6 +201,7 @@ export async function lint(cwd: string) {
   ]
 
   const warningsCount =
+    Number(!name) +
     exportsState.badTypesExport.length +
     fieldState.missingFiles.length +
     exportsState.badCjsRequireExport.paths.length +
@@ -291,4 +292,6 @@ export async function lint(cwd: string) {
   for (const issue of extraIssues) {
     logger.warn(issue.message)
   }
+
+  return warningsCount
 }

--- a/src/lint/rules.ts
+++ b/src/lint/rules.ts
@@ -19,23 +19,29 @@ export type LintRule = (context: LintContext) => LintIssue[]
 function checkConditionOrder(
   exportKey: string,
   value: Record<string, any>,
-  seen: Set<string>,
+  conditionPath: string[] = [],
 ): string[] {
   const problems: string[] = []
   const keys = Object.keys(value)
-  const orderKey = keys.join(',')
-  if (seen.has(orderKey)) {
-    return problems
-  }
-  seen.add(orderKey)
+  const location = conditionPath.length
+    ? `export "${exportKey}" condition "${conditionPath.join('.')}"`
+    : `export "${exportKey}"`
 
   const typesIndex = keys.indexOf('types')
   const defaultIndex = keys.indexOf('default')
   if (typesIndex > 0) {
-    problems.push(`export "${exportKey}": "types" condition should come first`)
+    problems.push(`${location}: "types" condition should come first`)
   }
   if (defaultIndex !== -1 && defaultIndex !== keys.length - 1) {
-    problems.push(`export "${exportKey}": "default" condition should come last`)
+    problems.push(`${location}: "default" condition should come last`)
+  }
+
+  for (const [condition, child] of Object.entries(value)) {
+    if (child && typeof child === 'object') {
+      problems.push(
+        ...checkConditionOrder(exportKey, child, [...conditionPath, condition]),
+      )
+    }
   }
   return problems
 }
@@ -52,13 +58,12 @@ export const conditionOrderRule: LintRule = ({ pkg }) => {
     return issues
   }
 
-  const seen = new Set<string>()
   for (const exportKey of Object.keys(exportsField)) {
     const value = exportsField[exportKey]
     if (!value || typeof value !== 'object') {
       continue
     }
-    for (const problem of checkConditionOrder(exportKey, value, seen)) {
+    for (const problem of checkConditionOrder(exportKey, value)) {
       issues.push({ message: problem })
     }
   }

--- a/test/integration/lint/condition-order/index.test.ts
+++ b/test/integration/lint/condition-order/index.test.ts
@@ -8,8 +8,10 @@ describe('integration lint condition-order', () => {
   })
 
   it('should warn that types should come first and default last', () => {
-    const { stderr } = job
+    const { code, stderr } = job
+    expect(code).toBe(1)
     expect(stderr).toContain('"types" condition should come first')
     expect(stderr).toContain('"default" condition should come last')
+    expect(stderr).toContain('condition "import"')
   })
 })

--- a/test/integration/lint/condition-order/package.json
+++ b/test/integration/lint/condition-order/package.json
@@ -5,6 +5,12 @@
     ".": {
       "default": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./nested": {
+      "import": {
+        "default": "./dist/nested.js",
+        "types": "./dist/nested.d.ts"
+      }
     }
   }
 }

--- a/test/integration/lint/valid/index.test.ts
+++ b/test/integration/lint/valid/index.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { createJob } from '../../../testing-utils'
+
+describe('integration lint valid package', () => {
+  const { job } = createJob({
+    directory: __dirname,
+    args: ['lint'],
+  })
+
+  it('exits successfully', () => {
+    expect(job.code).toBe(0)
+    expect(job.stderr).not.toContain('issues found')
+  })
+})

--- a/test/integration/lint/valid/package.json
+++ b/test/integration/lint/valid/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "valid-package",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  }
+}

--- a/test/integration/lint/valid/src/index.ts
+++ b/test/integration/lint/valid/src/index.ts
@@ -1,0 +1,1 @@
+export const value = true


### PR DESCRIPTION
## Summary

- recursively validate `types` and `default` ordering in nested export conditions
- include a missing package name in the reported issue count
- make explicit `bunchee lint` invocations exit non-zero when issues are found while keeping automatic build-time lint warning-only

## Tests

- `pnpm test test/integration/lint`
- `pnpm typecheck`
- `pnpm build`
- `POST_BUILD=1 pnpm test test/integration/lint`