### PR TITLE
test: smoke test the packed release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,9 @@ jobs:
           pnpm test
           pnpm test:post
 
+      - name: Test packed package
+        run: pnpm test:package
+
   install_and_test_compat:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: [ubuntu-latest]
@@ -136,6 +139,9 @@ jobs:
         run: |
           pnpm test
           pnpm test:post
+
+      - name: Test packed package
+        run: pnpm test:package
 
   release:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ By using the standard `exports` configuration as the single source of truth, **b
 
 ## Quick Start
 
+> Migrating from bunchee 6? See the [bunchee 7 migration guide](./docs/MIGRATION.md).
+
 ### Installation
 
 ```sh

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,0 +1,57 @@
+# Migrating to bunchee 7
+
+## Requirements
+
+bunchee 7 requires Node.js 22.12 or newer. Its default JavaScript target is
+now ES2022; pass `--target` or configure `compilerOptions.target` when an older
+output target is required.
+
+TypeScript 5 and 6 continue to work as before. TypeScript 7 no longer exposes
+the JavaScript compiler API bunchee uses to emit declarations, so TypeScript 7
+projects must also install its official compatibility package:
+
+```sh
+npm install --save-dev @typescript/typescript6
+```
+
+## ESM defaults
+
+The `bunchee` package itself is now ESM. Replace CommonJS loading of its Node.js
+API with an ESM import:
+
+```diff
+-const { bundle } = require('bunchee')
++import { bundle } from 'bunchee'
+```
+
+`bunchee prepare` now generates an ESM-only package by default. Pass `--cjs`
+when generating both ESM and CommonJS exports:
+
+```sh
+bunchee prepare --cjs
+```
+
+The old `--prepare` build flag has been removed; use the `bunchee prepare`
+command explicitly.
+
+## Package metadata
+
+Newly prepared packages no longer receive a legacy `module` field. Prefer the
+standard `exports` field, with `main` and `types` only when compatibility with
+older resolvers is needed.
+
+The non-standard `typings` fallback is no longer recognized. Rename it to
+`types` or add a `types` export condition:
+
+```diff
+-"typings": "./dist/index.d.ts"
++"types": "./dist/index.d.ts"
+```
+
+## Output chunks
+
+bunchee 7 builds entries through a shared module graph. This avoids rebuilding
+common modules, improves declaration performance, and keeps directive layers
+such as `use client`, `use server`, and `use cache` separate. Packages that
+inspect generated chunk names should treat those names as build artifacts and
+update any snapshots after migrating.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "vitest run",
     "test:update": "TEST_UPDATE_SNAPSHOT=1 pnpm test",
     "test:post": "cross-env POST_BUILD=1 pnpm test test/compile.test.ts test/integration.test.ts",
+    "test:package": "node ./scripts/test-packed-package.js",
     "site": "next dev docs",
     "docs:build": "pnpm --dir docs install && next build docs",
     "clean": "rm -rf ./dist",

--- a/scripts/test-packed-package.js
+++ b/scripts/test-packed-package.js
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict'
+import { execFile as execFileCallback } from 'node:child_process'
+import {
+  mkdtemp,
+  mkdir,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+import { pathToFileURL } from 'node:url'
+
+const execFile = promisify(execFileCallback)
+const root = path.resolve(import.meta.dirname, '..')
+const tempDir = await mkdtemp(path.join(tmpdir(), 'bunchee-package-smoke-'))
+
+async function run(command, args, options = {}) {
+  return execFile(command, args, {
+    ...options,
+    maxBuffer: 10 * 1024 * 1024,
+  })
+}
+
+try {
+  const packDir = path.join(tempDir, 'packed')
+  await mkdir(packDir)
+
+  const { stdout: packOutput } = await run(
+    'npm',
+    ['pack', '--json', '--ignore-scripts', '--pack-destination', packDir],
+    {
+      cwd: root,
+      env: {
+        ...process.env,
+        npm_config_cache: path.join(tempDir, 'npm-cache'),
+      },
+    },
+  )
+  const [packResult] = JSON.parse(packOutput)
+  const packedFiles = new Set(packResult.files.map((file) => file.path))
+  for (const expected of [
+    'README.md',
+    'package.json',
+    'dist/index.js',
+    'dist/index.d.ts',
+    'dist/bin/cli.js',
+  ]) {
+    assert(packedFiles.has(expected), `tarball is missing ${expected}`)
+  }
+
+  const tarball = path.join(packDir, packResult.filename)
+  await run('tar', ['-xzf', tarball, '-C', tempDir])
+
+  // Let the unpacked package resolve the dependencies installed for this
+  // checkout without downloading a second dependency tree.
+  await symlink(
+    path.join(root, 'node_modules'),
+    path.join(tempDir, 'node_modules'),
+    process.platform === 'win32' ? 'junction' : 'dir',
+  )
+
+  const unpackedPackage = path.join(tempDir, 'package')
+  const packedApi = await import(
+    pathToFileURL(path.join(unpackedPackage, 'dist/index.js')).href
+  )
+  assert.equal(typeof packedApi.bundle, 'function')
+
+  const consumerDir = path.join(tempDir, 'consumer')
+  await mkdir(path.join(consumerDir, 'src', 'bin'), { recursive: true })
+  await writeFile(
+    path.join(consumerDir, 'package.json'),
+    JSON.stringify(
+      {
+        name: 'bunchee-package-smoke-consumer',
+        type: 'module',
+        exports: {
+          '.': {
+            import: {
+              types: './dist/index.d.ts',
+              default: './dist/index.js',
+            },
+            require: {
+              types: './dist/index.d.cts',
+              default: './dist/index.cjs',
+            },
+          },
+        },
+        bin: './dist/bin/cli.js',
+      },
+      null,
+      2,
+    ),
+  )
+  await writeFile(
+    path.join(consumerDir, 'tsconfig.json'),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          module: 'NodeNext',
+          moduleResolution: 'NodeNext',
+          strict: true,
+          target: 'ES2022',
+        },
+      },
+      null,
+      2,
+    ),
+  )
+  await writeFile(
+    path.join(consumerDir, 'src/index.ts'),
+    'export const answer = 42\n',
+  )
+  await writeFile(
+    path.join(consumerDir, 'src/bin/index.ts'),
+    "console.log('packed-bunchee-bin')\n",
+  )
+
+  const packedCli = path.join(unpackedPackage, 'dist/bin/cli.js')
+  await run(process.execPath, [packedCli, '--runtime', 'node'], {
+    cwd: consumerDir,
+  })
+
+  const esm = await import(
+    pathToFileURL(path.join(consumerDir, 'dist/index.js')).href
+  )
+  assert.equal(esm.answer, 42)
+
+  const cjsCheck = await run(
+    process.execPath,
+    [
+      '-e',
+      `const value = require(${JSON.stringify(path.join(consumerDir, 'dist/index.cjs'))}); if (value.answer !== 42) process.exit(1)`,
+    ],
+    { cwd: consumerDir },
+  )
+  assert.equal(cjsCheck.stderr, '')
+
+  for (const declaration of ['dist/index.d.ts', 'dist/index.d.cts']) {
+    assert.match(
+      await readFile(path.join(consumerDir, declaration), 'utf8'),
+      /answer = 42/,
+    )
+  }
+
+  await writeFile(
+    path.join(consumerDir, 'consume.ts'),
+    "import { answer } from 'bunchee-package-smoke-consumer'\nconst value: 42 = answer\n",
+  )
+  await writeFile(
+    path.join(consumerDir, 'consume.cts'),
+    "import packageValue = require('bunchee-package-smoke-consumer')\nconst value: 42 = packageValue.answer\n",
+  )
+  await writeFile(
+    path.join(consumerDir, 'tsconfig.consume.json'),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          module: 'NodeNext',
+          moduleResolution: 'NodeNext',
+          noEmit: true,
+          strict: true,
+          target: 'ES2022',
+          types: [],
+        },
+        include: ['consume.ts', 'consume.cts'],
+      },
+      null,
+      2,
+    ),
+  )
+  await run(
+    path.join(root, 'node_modules', '.bin', 'tsc'),
+    ['-p', 'tsconfig.consume.json'],
+    { cwd: consumerDir },
+  )
+
+  const consumerBin = path.join(consumerDir, 'dist/bin/cli.js')
+  assert.match(await readFile(consumerBin, 'utf8'), /^#!\/usr\/bin\/env node/)
+  const { stdout: binOutput } = await run(process.execPath, [consumerBin], {
+    cwd: consumerDir,
+  })
+  assert.equal(binOutput.trim(), 'packed-bunchee-bin')
+
+  console.log(`Packed package smoke test passed: ${packResult.filename}`)
+} finally {
+  await rm(tempDir, { recursive: true, force: true })
+}


### PR DESCRIPTION
## Summary

- add a `test:package` smoke test that packs and unpacks the actual release tarball
- load the packed Node.js API, then use its CLI to build a consumer with ESM, CJS, declaration, and binary outputs
- execute both module formats and the binary, and resolve both declaration formats with TypeScript
- run the smoke test in the normal Linux CI lane and every tagged compatibility lane
- add and link a bunchee 6 to 7 migration guide

## Tests

- `pnpm build`
- `pnpm test:package`
- `pnpm typecheck`
- GitHub CI