### PR TITLE
Fix false output warnings before builds

### DIFF
--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -3,7 +3,10 @@ import path from 'path'
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
 import { performance } from 'perf_hooks'
-import { lint as lintPackage } from '../lint'
+import {
+  lint as lintPackage,
+  lintBeforeBuild as lintPackageBeforeBuild,
+} from '../lint'
 import { exit, hasPackageJson } from '../utils'
 import { logger, setActiveSpinner } from '../logger'
 import { bundle } from '../../src/index'
@@ -266,7 +269,9 @@ async function run(args: CliArgs) {
   // lint package by default
   const lintStarted = startProfile()
   try {
-    await lint(cwd)
+    // Generated files may be absent or stale before the build. The explicit
+    // `lint` command still checks outputs after a build has completed.
+    await lintPackageBeforeBuild(cwd)
   } finally {
     endProfile('cli.lint', lintStarted)
   }

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -74,7 +74,7 @@ function validateFilesField(packageJson: PackageMetadata) {
   return state
 }
 
-export async function lint(cwd: string) {
+async function lintPackage(cwd: string, checkOutputs: boolean) {
   // Not package.json detected, skip package linting
   if (!hasPackageJson(cwd)) {
     return
@@ -196,7 +196,9 @@ export async function lint(cwd: string) {
   // are missing on disk, and workspace: ranges that would publish unrewritten.
   const extraIssues: LintIssue[] = [
     ...conditionOrderRule({ pkg, cwd, parsedExports, pkgPath }),
-    ...outputsExistRule({ pkg, cwd, parsedExports, pkgPath }),
+    ...(checkOutputs
+      ? outputsExistRule({ pkg, cwd, parsedExports, pkgPath })
+      : []),
     ...workspaceProtocolRule({ pkg, cwd, parsedExports, pkgPath }),
   ]
 
@@ -294,4 +296,12 @@ export async function lint(cwd: string) {
   }
 
   return warningsCount
+}
+
+export function lint(cwd: string) {
+  return lintPackage(cwd, true)
+}
+
+export function lintBeforeBuild(cwd: string) {
+  return lintPackage(cwd, false)
 }

--- a/test/integration/bin/multi-path/index.test.ts
+++ b/test/integration/bin/multi-path/index.test.ts
@@ -1,4 +1,6 @@
-import { describe, it } from 'vitest'
+import fs from 'fs/promises'
+import path from 'path'
+import { beforeAll, describe, expect, it } from 'vitest'
 import {
   assertFilesContent,
   createJob,
@@ -11,10 +13,17 @@ describe('integration bin/multi-path', () => {
     it('skip test on windows', () => {})
     return
   }
-  const { distDir } = createJob({
+  beforeAll(async () => {
+    // A partially populated dist directory used to make the automatic
+    // pre-build lint report outputs that this build was about to generate.
+    await fs.mkdir(path.join(__dirname, 'dist'), { recursive: true })
+  })
+
+  const { distDir, job } = createJob({
     directory: __dirname,
   })
   it('should work with bin as multi path', async () => {
+    expect(job.stderr).not.toContain('Declared output does not exist on disk')
     await assertFilesContent(distDir, {
       'bin/a.js': '#!/usr/bin/env node',
       'bin/b.js': '#!/usr/bin/env node',


### PR DESCRIPTION
## Summary

- skip output existence checks during automatic pre-build linting
- preserve output checks for the explicit `bunchee lint` command
- cover builds that start with a partially populated `dist` directory

Fixes #764

## Tests

- `pnpm exec vitest run test/integration/lint test/integration/bin/multi-path/index.test.ts`
- `pnpm typecheck`
- `git diff --check`