### PR TITLE
ci: fix release drafter v7 config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -3,18 +3,20 @@ tag-template: 'v$RESOLVED_VERSION'
 
 categories:
   - title: Features
-    exclusive: true
-    semver-increment: minor
-    when:
-      label: feature
+    labels:
+      - feature
   - title: Improvements
-    exclusive: true
-    when:
-      labels:
-        - enhance
-        - bug
-        - dx
+    labels:
+      - enhance
+      - bug
+      - dx
   - title: Misc
+
+version-resolver:
+  minor:
+    labels:
+      - feature
+  default: patch
 
 autolabeler:
   - label: feature


### PR DESCRIPTION
Fix the Release Drafter configuration for the schema supported by `release-drafter@v7.3.0`.

- move category label filters from `when` to top-level `labels`
- preserve feature minor bumps via `version-resolver`
- leave `Misc` as the sole unlabeled fallback category

This fixes the failure in workflow run #31265933967: `Multiple categories detected with no labels`.